### PR TITLE
[#32] 사용자의 활동이 비었을 때의 예외처리 추가

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -46,7 +46,7 @@
       "devDependencies": {
         "@nestjs/cli": "^9.0.0",
         "@nestjs/schematics": "^9.0.0",
-        "@nestjs/testing": "^9.4.0",
+        "@nestjs/testing": "^9.0.0",
         "@types/express": "^4.17.13",
         "@types/jest": "28.1.4",
         "@types/json2csv": "^5.0.3",
@@ -3173,11 +3173,10 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-9.1.4.tgz",
-      "integrity": "sha512-S6KpGeKotPYh126hhRqYLhvg9lxSbAmGfEbK8m09crIK7CYP05t32KtT6n12xl5/iva1G4Ch87Z/3rYP76etUg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-9.0.0.tgz",
+      "integrity": "sha512-Ib25JrYQf5ICro19FBytoMpMQicanC4HG3goPBSqsolu+AhVzSU0OhDwmmiDy3aHgmheFnNEEdUH+Gh5Rm2cNw==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
@@ -3185,7 +3184,7 @@
         "object-hash": "3.0.0",
         "path-to-regexp": "3.2.0",
         "tslib": "2.4.0",
-        "uuid": "9.0.0"
+        "uuid": "8.3.2"
       },
       "funding": {
         "type": "opencollective",
@@ -3209,6 +3208,14 @@
         "@nestjs/websockets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/core/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@nestjs/elasticsearch": {
@@ -3275,10 +3282,9 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-9.1.4.tgz",
-      "integrity": "sha512-SLJWDa6V54QrUvzKI4Eyt7gyrjV7F9FY1uHFihshjmQfpf0ebCGacR9jzNwf01aHl0BJX3DUn/KYteBjz6DJXw==",
-      "license": "MIT",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-9.0.0.tgz",
+      "integrity": "sha512-5W5KeYHKKQe4/H7DcPViIObC9nO74P8wnLZUpk4HCUUuFZIzPpUu9v+RAg7c/jGrbdyjfg3VKODCUKFo6PBfmg==",
       "dependencies": {
         "body-parser": "1.20.0",
         "cors": "2.8.5",
@@ -3559,12 +3565,12 @@
       }
     },
     "node_modules/@nestjs/testing": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-9.4.0.tgz",
-      "integrity": "sha512-xZWp363P4otcebg++gSjUcdCfTK0RorORzyFq3aLaSAQOlq8kxfFDRIKzEATR4aOUfqTMMsAA8lhnMJWf35N6A==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-9.0.0.tgz",
+      "integrity": "sha512-lBBzZvJWaYutYC1wOEKf4KOis/wxudBX0pVLZxzHmtbkeC2EQgQCbyKA88m1R9QeYTt9CmVMg4eyb+WeOADZiQ==",
       "dev": true,
       "dependencies": {
-        "tslib": "2.5.0"
+        "tslib": "2.4.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3584,12 +3590,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@nestjs/testing/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-      "dev": true
     },
     "node_modules/@nestjs/typeorm": {
       "version": "9.0.1",
@@ -4490,7 +4490,6 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -4691,8 +4690,7 @@
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -4982,7 +4980,6 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
       "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
-      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.4",
@@ -5006,7 +5003,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -5014,8 +5010,21 @@
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/bowser": {
       "version": "2.11.0",
@@ -5167,7 +5176,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -5623,7 +5631,6 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -5632,10 +5639,9 @@
       }
     },
     "node_modules/content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-      "license": "MIT",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -5651,7 +5657,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -5659,8 +5664,7 @@
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "license": "MIT"
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "node_modules/cookiejar": {
       "version": "2.1.3",
@@ -5852,7 +5856,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -5861,7 +5864,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -5964,8 +5966,7 @@
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.283",
@@ -5997,7 +5998,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -6112,8 +6112,7 @@
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -6450,7 +6449,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -6518,7 +6516,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
       "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
-      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -6560,7 +6557,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -6568,14 +6564,26 @@
     "node_modules/express/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/express/node_modules/path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
-      "license": "MIT"
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/external-editor": {
       "version": "3.1.0",
@@ -6734,7 +6742,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
       "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
-      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -6752,7 +6759,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -6760,8 +6766,7 @@
     "node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/find-up": {
       "version": "4.1.0",
@@ -6875,7 +6880,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -6884,7 +6888,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -7247,7 +7250,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -7458,7 +7460,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
@@ -8933,8 +8934,7 @@
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-      "license": "MIT"
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -9124,7 +9124,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -9223,7 +9222,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
@@ -9270,7 +9268,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -9490,7 +9487,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -9877,7 +9873,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -9911,10 +9906,10 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
-      "license": "BSD-3-Clause",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dev": true,
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -9968,7 +9963,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -9977,7 +9971,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
       "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -10315,7 +10308,6 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
       "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
-      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -10339,7 +10331,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -10347,14 +10338,12 @@
     "node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/send/node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -10376,7 +10365,6 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
       "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
-      "license": "MIT",
       "dependencies": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -10390,8 +10378,7 @@
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
@@ -10554,7 +10541,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -10715,22 +10701,6 @@
       },
       "engines": {
         "node": ">=6.4.0 <13 || >=14"
-      }
-    },
-    "node_modules/superagent/node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/supertest": {
@@ -11039,7 +11009,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.6"
       }
@@ -11564,7 +11533,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",
     "@nestjs/schematics": "^9.0.0",
-    "@nestjs/testing": "^9.4.0",
+    "@nestjs/testing": "^9.0.0",
     "@types/express": "^4.17.13",
     "@types/jest": "28.1.4",
     "@types/json2csv": "^5.0.3",

--- a/server/src/entity/user/user.entity.ts
+++ b/server/src/entity/user/user.entity.ts
@@ -28,7 +28,7 @@ export class User extends BaseEntity {
 
   /** 활동 목록 */
   @Column({ type: 'jsonb', nullable: true, default: null })
-  activities: UserActivity[];
+  activities: UserActivity[] | null;
 
   /** 프로필 이미지 */
   @Column({

--- a/server/src/meeting/v0/meeting-v0.service.ts
+++ b/server/src/meeting/v0/meeting-v0.service.ts
@@ -310,7 +310,7 @@ export class MeetingV0Service {
         );
       }
 
-      if (user.activities === null) {
+      if (user.activities === null || user.activities.length === 0) {
         throw new BadRequestException('기수/파트를 설정해주세요');
       }
 

--- a/server/src/user/v1/dto/user-v1-get-user-own-profile/user-v1-get-user-own-profile-response.dto.ts
+++ b/server/src/user/v1/dto/user-v1-get-user-own-profile/user-v1-get-user-own-profile-response.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Allow, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import {
+  Allow,
+  IsBoolean,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+} from 'class-validator';
 
 export class UserV1GetUserOwnProfileResponseDto {
   @ApiProperty({
@@ -33,4 +39,11 @@ export class UserV1GetUserOwnProfileResponseDto {
   @Allow(null)
   @IsString()
   profileImage: string | null;
+
+  @ApiProperty({
+    description: '유저 활동 가지고 있는지 여부, 유저 활동이 없으면 false',
+  })
+  @IsNotEmpty()
+  @IsBoolean()
+  hasActivities: boolean;
 }

--- a/server/src/user/v1/user-v1.service.ts
+++ b/server/src/user/v1/user-v1.service.ts
@@ -5,11 +5,15 @@ import { UserV1GetUserOwnProfileResponseDto } from './dto/user-v1-get-user-own-p
 @Injectable()
 export class UserV1Service {
   getUserOwnProfile(user: User): UserV1GetUserOwnProfileResponseDto {
+    const hasActivities =
+      user.activities !== null && user.activities.length > 0;
+
     return {
       id: user.id,
       name: user.name,
       orgId: user.orgId,
       profileImage: user.profileImage,
+      hasActivities,
     };
   }
 }

--- a/server/test/unit/meeting/v0/meeting-v0.service.test.ts
+++ b/server/test/unit/meeting/v0/meeting-v0.service.test.ts
@@ -1,0 +1,94 @@
+import { BadRequestException } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { MulterModule } from '@nestjs/platform-express';
+import { Test } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from 'src/auth/auth.module';
+import { JwtStrategy } from 'src/auth/v0/jwt.strategy';
+import { TransformInterceptor } from 'src/common/interceptor/transform.interceptor';
+import { multerOptionsFactory } from 'src/common/utils/multer-options.factory';
+import { TypeOrmExModule } from 'src/db/typeorm-ex.module';
+import { ApplyRepository } from 'src/entity/apply/apply.repository';
+import { ApplyStatus } from 'src/entity/apply/enum/apply-status.enum';
+import { MeetingRepository } from 'src/entity/meeting/meeting.repository';
+import { User } from 'src/entity/user/user.entity';
+import { UserRepository } from 'src/entity/user/user.repository';
+import { MeetingV0ApplyMeetingDto } from 'src/meeting/v0/dto/meeting-v0-apply-meeting.dto';
+import { MeetingV0Controller } from 'src/meeting/v0/meeting-v0.controller';
+import { MeetingV0Service } from 'src/meeting/v0/meeting-v0.service';
+
+describe('MeetingV0Service', () => {
+  let service: MeetingV0Service;
+  let meetingRepository: MeetingRepository;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          envFilePath:
+            process.env.NODE_ENV === 'dev' ? '.dev.env' : '.prod.env',
+        }),
+        TypeOrmModule.forRootAsync({
+          useFactory: (config: ConfigService) => ({
+            type: 'postgres',
+            host: config.get('DB_HOST'),
+            port: parseInt(config.get('DB_PORT')),
+            username: config.get('DB_USERNAME'),
+            password: config.get('DB_PASSWORD'),
+            database: config.get('DB_NAME'),
+            entities: [__dirname + '/**/*.entity.{js,ts}'],
+            schema: config.get('DB_SCHEMA'),
+            synchronize: process.env.NODE_ENV === 'dev' ? true : false,
+          }),
+          inject: [ConfigService],
+        }),
+        MulterModule.registerAsync({
+          imports: [ConfigModule],
+          useFactory: multerOptionsFactory,
+          inject: [ConfigService],
+        }),
+        TypeOrmExModule.forCustomRepository([
+          MeetingRepository,
+          ApplyRepository,
+          UserRepository,
+        ]),
+        AuthModule,
+      ],
+      controllers: [MeetingV0Controller],
+      providers: [
+        MeetingV0Service,
+        JwtStrategy,
+        {
+          provide: APP_INTERCEPTOR,
+          useClass: TransformInterceptor,
+        },
+      ],
+    }).compile();
+
+    service = module.get<MeetingV0Service>(MeetingV0Service);
+    meetingRepository = module.get<MeetingRepository>(MeetingRepository);
+  });
+
+  describe('applyMeeting', () => {
+    it('유저의 활동정보가 빈배열일 때 "기수/파트를 설정해주세요" 예외를 던진다.', async () => {
+      const applyMeetingDto = {
+        id: 1,
+      } as unknown as MeetingV0ApplyMeetingDto;
+      const user = {
+        id: 2,
+        activities: [],
+      } as unknown as User;
+      jest.spyOn(meetingRepository, 'getMeeting').mockResolvedValue({
+        appliedInfo: [{ user: { id: 1 }, status: ApplyStatus.APPROVE }],
+      } as any);
+
+      const result = service.applyMeeting(applyMeetingDto, user);
+
+      await expect(result).rejects.toThrowError(
+        new BadRequestException('기수/파트를 설정해주세요'),
+      );
+    });
+  });
+});

--- a/server/test/unit/user/v1/user-v1.service.test.ts
+++ b/server/test/unit/user/v1/user-v1.service.test.ts
@@ -15,7 +15,7 @@ describe('UserV1Service', () => {
         name: 1,
         orgId: 1,
         profileImage: 1,
-        activities: null,
+        activities: [{ test: 'test' }],
         phone: null,
       } as unknown as User;
 
@@ -26,7 +26,26 @@ describe('UserV1Service', () => {
         name: mockInput.name,
         orgId: mockInput.orgId,
         profileImage: mockInput.profileImage,
+        hasActivities: true,
       });
     });
+
+    it.each([[[]], [null]])(
+      '유저 정보의 activities가 %s로 들어오면 hasActivities가 false로 나와야한다.',
+      (activities) => {
+        const mockInput = {
+          id: 1,
+          name: 1,
+          orgId: 1,
+          profileImage: 1,
+          activities,
+          phone: null,
+        } as unknown as User;
+
+        const result = service.getUserOwnProfile(mockInput);
+
+        expect(result.hasActivities).toEqual(false);
+      },
+    );
   });
 });


### PR DESCRIPTION
# 관련 이슈
#32 
# 작업 내용
- test 라이브러리 버전 불일치 문제 수정
- 변경 사항에 대해서만 테스트 코드 작성(TDD)
- 유저 정보 조회시 활동이 없을 경우 hasActivities를 플래그로 내려준다.
- 누락된 User 엔티티의 activities 타입에 null 추가