### PR TITLE
[#47] feat: 미팅 조회시 생성 기수별로 가능하도록 수정

### DIFF
--- a/server/src/entity/meeting/meeting.entity.ts
+++ b/server/src/entity/meeting/meeting.entity.ts
@@ -104,6 +104,13 @@ export class Meeting extends BaseEntity {
   canJoinOnlyActiveGeneration: boolean;
 
   /**
+   * 모임 기수
+   * @description 생성 시점의 기수
+   */
+  @Column()
+  createdGeneration: number;
+
+  /**
    * 대상 활동 기수
    * null인 경우 모든 기수 허용
    * */

--- a/server/src/entity/meeting/meeting.repository.ts
+++ b/server/src/entity/meeting/meeting.repository.ts
@@ -109,7 +109,7 @@ export class MeetingRepository extends Repository<Meeting> {
         );
       } else {
         meetingQuery.andWhere(
-          `meeting.joinableParts = ARRAY[:joinableParts]::${enumNameInDatabase}`,
+          `meeting.joinableParts @> ARRAY[:joinableParts]::${enumNameInDatabase}`,
           {
             joinableParts,
           },

--- a/server/src/meeting/v0/dto/get-all-meetings/meeting-v0-get-all-meetings-query.dto.ts
+++ b/server/src/meeting/v0/dto/get-all-meetings/meeting-v0-get-all-meetings-query.dto.ts
@@ -1,9 +1,16 @@
-import { IsString, IsOptional, IsNotEmpty, IsEnum } from 'class-validator';
+import {
+  IsString,
+  IsOptional,
+  IsNotEmpty,
+  IsEnum,
+  IsNumber,
+} from 'class-validator';
 
 import { ApiProperty } from '@nestjs/swagger';
 import { PageOptionsDto } from 'src/common/pagination/dto/page-options.dto';
 import { MeetingJoinablePart } from '../../../../entity/meeting/enum/meeting-joinable-part.enum';
 import { IsBoolean } from 'src/common/decorator/is-boolean.decorator';
+import { Transform } from 'class-transformer';
 
 export class MeetingV0GetAllMeetingsQueryDto extends PageOptionsDto {
   @ApiProperty({
@@ -51,4 +58,16 @@ export class MeetingV0GetAllMeetingsQueryDto extends PageOptionsDto {
   @IsOptional()
   @IsString()
   readonly query?: string;
+
+  @ApiProperty({
+    example: '32,33',
+    description: '모임 기수',
+    type: 'string',
+    required: false,
+  })
+  @IsOptional()
+  @Transform(({ value }) => value.split(',').map(Number))
+  @IsNotEmpty({ each: true })
+  @IsNumber({}, { each: true })
+  readonly createdGenerations?: number[];
 }

--- a/server/src/meeting/v0/dto/meeting-v0-get-meeting-by-id-response.dto.ts
+++ b/server/src/meeting/v0/dto/meeting-v0-get-meeting-by-id-response.dto.ts
@@ -72,6 +72,8 @@ export class MeetingV0GetMeetingByIdResponseDto {
 
   approvedApplyCount: number;
 
+  createdGeneration: number;
+
   joinableParts: MeetingJoinablePart[];
   // 칼럼이 아닌 response할 때 meeting 객체에 넣어줄 값
   status?: MeetingV0MeetingStatus; // 모임 상태

--- a/server/src/meeting/v0/meeting-v0.service.ts
+++ b/server/src/meeting/v0/meeting-v0.service.ts
@@ -214,6 +214,7 @@ export class MeetingV0Service {
       page,
       isOnlyActiveGeneration,
       joinableParts,
+      createdGenerations,
     } = getMeetingDto;
 
     const categoryArr: MeetingCategory[] = category
@@ -225,13 +226,14 @@ export class MeetingV0Service {
       : [];
 
     const [meetingResponse, itemCount] =
-      await this.meetingRepository.getMeetingsAndCount(
+      await this.meetingRepository.getMeetingsAndCount({
         getMeetingDto,
         categoryArr,
         statusArr,
-        isOnlyActiveGeneration,
+        canJoinOnlyActiveGeneration: isOnlyActiveGeneration,
         joinableParts,
-      );
+        createdGenerations,
+      });
 
     const meetingPromises = meetingResponse.map(async (meeting) => {
       const { status } = await getMeetingStatus(meeting);

--- a/server/src/meeting/v1/meeting-v1.service.ts
+++ b/server/src/meeting/v1/meeting-v1.service.ts
@@ -159,6 +159,7 @@ export class MeetingV1Service {
       {
         ...meeting,
         targetActiveGeneration,
+        createdGeneration: ACTIVE_GENERATION,
         canJoinOnlyActiveGeneration,
         endDate,
       },


### PR DESCRIPTION
## 작업 내용
- meeting entity에 `createdGeneration`필드 추가
- v0 미팅 조회 API에 생성 기수를 기준으로 조회 가능하도록 수정
- v1 미팅 생성시 현재 기수를 기준으로 `createdGeneration`필드가 채워지도록 변경
## 관련 이슈
#47