### PR TITLE
[#43] docs: 성공 응답모델 문서에 CommonResponseDto 적용

### DIFF
--- a/server/src/comment/v1/comment-v1.controller.ts
+++ b/server/src/comment/v1/comment-v1.controller.ts
@@ -28,6 +28,7 @@ import { CommentV1ReportCommentParamDto } from './dto/report-comment/comment-v1-
 import { CommentV1ReportCommentResponseDto } from './dto/report-comment/comment-v1-report-comment-response.dto';
 import { CommentV1SwitchCommentLikeParamDto } from 'src/comment/v1/dto/switch-comment-like/comment-v1-switch-comment-like-param.dto';
 import { CommentV1SwitchCommentLikeResponseDto } from './dto/switch-comment-like/comment-v1-switch-comment-like-response.dto';
+import { ApiOkResponseCommon } from 'src/common/decorator/api-ok-response-common.decorator';
 
 @ApiTags('댓글/대댓글')
 @Controller('comment/v1')
@@ -37,6 +38,7 @@ export class CommentV1Controller {
   @ApiOperation({
     summary: '모임 게시글 댓글 리스트 조회',
   })
+  @ApiOkResponseCommon(CommentV1GetCommentsResponseDto)
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
     description: '"모임이 없습니다." or "권한이 없습니다."',
@@ -55,6 +57,7 @@ export class CommentV1Controller {
   @ApiOperation({
     summary: '댓글 좋아요 토글',
   })
+  @ApiOkResponseCommon(CommentV1SwitchCommentLikeResponseDto)
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))
   @Post('/:commentId/like')
@@ -68,6 +71,7 @@ export class CommentV1Controller {
   @ApiOperation({
     summary: '댓글 신고',
   })
+  @ApiOkResponseCommon(CommentV1ReportCommentResponseDto)
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
     description: '',
@@ -86,6 +90,7 @@ export class CommentV1Controller {
   @ApiOperation({
     summary: '모임 게시글 댓글 작성',
   })
+  @ApiOkResponseCommon(CommentV1CreateCommentResponseDto)
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
     description: '',

--- a/server/src/common/decorator/api-ok-response-common.decorator.ts
+++ b/server/src/common/decorator/api-ok-response-common.decorator.ts
@@ -1,0 +1,27 @@
+import { Type, applyDecorators } from '@nestjs/common';
+import { ApiExtraModels, ApiOkResponse, getSchemaPath } from '@nestjs/swagger';
+import { CommonResponseDto } from '../dto/common-response.dto';
+
+/**
+ * Swagger Ok Response에 공통 응답 DTO를 추가하는 Decorator
+ * @param dataDto 응답 데이터 DTO
+ */
+export const ApiOkResponseCommon = <DataDto extends Type<unknown>>(
+  dataDto: DataDto,
+) =>
+  applyDecorators(
+    ApiExtraModels(CommonResponseDto, dataDto),
+    ApiOkResponse({
+      description: '성공',
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(CommonResponseDto) },
+          {
+            properties: {
+              data: { $ref: getSchemaPath(dataDto) },
+            },
+          },
+        ],
+      },
+    }),
+  );

--- a/server/src/common/dto/common-response.dto.ts
+++ b/server/src/common/dto/common-response.dto.ts
@@ -1,0 +1,14 @@
+import { HttpStatus } from '@nestjs/common';
+import { ApiProperty } from '@nestjs/swagger';
+
+/** 기본 응답 Wrapper */
+export class CommonResponseDto<T> {
+  @ApiProperty({
+    enum: HttpStatus,
+    example: HttpStatus.OK,
+  })
+  statusCode: HttpStatus;
+
+  @ApiProperty()
+  data: T;
+}

--- a/server/src/common/interceptor/transform.interceptor.ts
+++ b/server/src/common/interceptor/transform.interceptor.ts
@@ -6,20 +6,16 @@ import {
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-
-interface Response<T> {
-  statusCode: number;
-  data: T;
-}
+import { CommonResponseDto } from '../dto/common-response.dto';
 
 @Injectable()
 export class TransformInterceptor<T>
-  implements NestInterceptor<T, Response<T>>
+  implements NestInterceptor<T, CommonResponseDto<T>>
 {
   intercept(
     context: ExecutionContext,
     next: CallHandler,
-  ): Observable<Response<T>> {
+  ): Observable<CommonResponseDto<T>> {
     return next.handle().pipe(
       map((data) => ({
         statusCode: context.switchToHttp().getResponse().statusCode,

--- a/server/src/common/utils/swagger.ts
+++ b/server/src/common/utils/swagger.ts
@@ -1,6 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { BaseExceptionDto } from '../dto/base-exception.dto';
+import { CommonResponseDto } from '../dto/common-response.dto';
 
 /**
  * Swagger 세팅
@@ -16,7 +17,7 @@ export function setupSwagger(app: INestApplication): void {
     .build();
 
   const document = SwaggerModule.createDocument(app, options, {
-    extraModels: [BaseExceptionDto],
+    extraModels: [BaseExceptionDto, CommonResponseDto],
   });
   SwaggerModule.setup('api-docs', app, document, {
     swaggerOptions: {

--- a/server/src/meeting/v0/meeting-v0.controller.ts
+++ b/server/src/meeting/v0/meeting-v0.controller.ts
@@ -37,7 +37,7 @@ import { MeetingV0GetMeetingByIdResponseDto } from './dto/meeting-v0-get-meeting
 import { MeetingV0GetApplyListByMeetingResponseDto } from './dto/get-apply-list-by-meeting/meeting-v0-get-apply-list-by-meeting-response.dto';
 import { MeetingV0GetAllMeetingsResponseDto } from './dto/get-all-meetings/meeting-v0-get-all-meetings-response.dto';
 import { GetUser } from 'src/common/decorator/get-user.decorator';
-import { Meeting } from '../../entity/meeting/meeting.entity';
+import { ApiOkResponseCommon } from 'src/common/decorator/api-ok-response-common.decorator';
 
 @ApiTags('모임')
 @Controller('meeting')
@@ -56,7 +56,7 @@ export class MeetingV0Controller {
     @Param('id', ParseIntPipe) id: number,
     @Body() updateStatusApplyDto: MeetingV0UpdateStatusApplyDto,
     @GetUser() user: User,
-  ) {
+  ): Promise<null> {
     return this.meetingV0Service.updateApplyStatusByMeeting(
       id,
       user,
@@ -69,6 +69,7 @@ export class MeetingV0Controller {
     description:
       '모임 지원자/참여자 조회 (모임장이면 지원자, 아니면 참여자 조회)',
   })
+  @ApiOkResponseCommon(MeetingV0GetApplyListByMeetingResponseDto)
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
     description: '모임이 없습니다',
@@ -106,7 +107,7 @@ export class MeetingV0Controller {
   async applyMeeting(
     @Body() applyMeetingDto: MeetingV0ApplyMeetingDto,
     @GetUser() user: User,
-  ) {
+  ): Promise<null> {
     return this.meetingV0Service.applyMeeting(applyMeetingDto, user);
   }
 
@@ -114,11 +115,7 @@ export class MeetingV0Controller {
     summary: '모임 상세 조회',
     description: '모임 상세 조회',
   })
-  @ApiResponse({
-    status: HttpStatus.OK,
-    description: '노출할 정보가 있는 경우',
-    schema: { $ref: getSchemaPath(Meeting) },
-  })
+  @ApiOkResponseCommon(MeetingV0GetMeetingByIdResponseDto)
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
     description: '모임이 없습니다',
@@ -139,6 +136,7 @@ export class MeetingV0Controller {
     summary: '모임 전체 조회/검색/필터링',
     description: '모임 전체 조회/검색/필터링',
   })
+  @ApiOkResponseCommon(MeetingV0GetAllMeetingsResponseDto)
   @Get('/')
   async getAllMeeting(
     @Query() getMeetingDto: MeetingV0GetAllMeetingsQueryDto,

--- a/server/src/meeting/v1/meeting-v1.controller.ts
+++ b/server/src/meeting/v1/meeting-v1.controller.ts
@@ -31,6 +31,7 @@ import { MeetingV1CreateMeetingResponseDto } from './dto/create-meeting/meeting-
 import { MeetingV1CreateMeetingBodyDto } from './dto/create-meeting/meeting-v1-create-meeting-body.dto';
 import { MeetingV1GetApplyListByMeetingCsvFileUrlQueryDto } from './dto/get-apply-list-by-meeting-csv-file-url/meeting-v1-get-apply-list-by-meeting-csv-file-url-query.dto';
 import { MeetingV1GetApplyListByMeetingCsvFileUrlResponseDto } from './dto/get-apply-list-by-meeting-csv-file-url/meeting-v1-get-apply-list-by-meeting-csv-file-url-response.dto';
+import { ApiOkResponseCommon } from 'src/common/decorator/api-ok-response-common.decorator';
 
 @ApiTags('모임')
 @Controller('meeting/v1')
@@ -41,6 +42,7 @@ export class MeetingV1Controller {
     summary: '모임 지원자 목록 csv 파일 다운로드',
     description: '모임장일때만 지원자 목록 csv 파일 다운로드 가능',
   })
+  @ApiOkResponseCommon(MeetingV1GetApplyListByMeetingCsvFileUrlResponseDto)
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
     description: '"모임이 없습니다." or "권한이 없습니다."',
@@ -65,6 +67,7 @@ export class MeetingV1Controller {
   @ApiOperation({
     summary: 'Meeting 썸네일 업로드용 Pre-Signed URL 발급',
   })
+  @ApiOkResponseCommon(MeetingV1GetPresignedUrlResponseDto)
   @ApiResponse({
     status: HttpStatus.INTERNAL_SERVER_ERROR,
     description: '발급 실패',
@@ -83,6 +86,7 @@ export class MeetingV1Controller {
     summary: '모임 생성',
     description: '모임 생성',
   })
+  @ApiOkResponseCommon(MeetingV1CreateMeetingResponseDto)
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
     description:

--- a/server/src/notice/v1/notice-v1.controller.ts
+++ b/server/src/notice/v1/notice-v1.controller.ts
@@ -5,6 +5,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { NoticeV1GetNoticesQueryDto } from './dto/notice-v1-get-notices-query.dto';
 import { NoticeV1CreateNoticeBodyDto } from './dto/notice-v1-create-notice-body.dto';
 import { NoticeV1GetNoticesResponseDto } from './dto/notice-v1-get-notices-response.dto';
+import { ApiOkResponseCommon } from 'src/common/decorator/api-ok-response-common.decorator';
 
 @ApiTags('공지사항')
 @Controller('notice/v1')
@@ -12,6 +13,7 @@ export class NoticeV1Controller {
   constructor(private readonly noticeV1Service: NoticeV1Service) {}
 
   @ApiOperation({ summary: '공지사항 조회' })
+  @ApiOkResponseCommon(NoticeV1GetNoticesResponseDto)
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))
   @Get()

--- a/server/src/post/v1/post-v1.controller.ts
+++ b/server/src/post/v1/post-v1.controller.ts
@@ -32,6 +32,7 @@ import { PostV1ReportPostParamDto } from './dto/report-post/post-v1-report-post-
 import { PostV1ReportPostResponseDto } from './dto/report-post/post-v1-report-post-response.dto';
 import { PostV1SwitchPostLikeParamDto } from './dto/switch-post-like/post-v1-switch-post-like-param.dto';
 import { PostV1SwitchPostLikeResponseDto } from './dto/switch-post-like/post-v1-switch-post-like-response.dto';
+import { ApiOkResponseCommon } from 'src/common/decorator/api-ok-response-common.decorator';
 
 @ApiTags('게시글')
 @Controller('post/v1')
@@ -41,6 +42,7 @@ export class PostV1Controller {
   @ApiOperation({
     summary: '모임 게시글 개수 조회',
   })
+  @ApiOkResponseCommon(PostV1GetPostCountResponseDto)
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
     description: '"모임이 없습니다." or "권한이 없습니다."',
@@ -56,6 +58,7 @@ export class PostV1Controller {
   @ApiOperation({
     summary: '모임 게시글 목록 조회',
   })
+  @ApiOkResponseCommon(PostV1GetPostsResponseDto)
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
     description: '"모임이 없습니다." or "권한이 없습니다."',
@@ -74,6 +77,7 @@ export class PostV1Controller {
   @ApiOperation({
     summary: '모임 게시글 조회',
   })
+  @ApiOkResponseCommon(PostV1GetPostResponseDto)
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
     description: '"모임이 없습니다." or "권한이 없습니다."',
@@ -92,6 +96,7 @@ export class PostV1Controller {
   @ApiOperation({
     summary: '모임 게시글 작성',
   })
+  @ApiOkResponseCommon(PostV1CreatePostResponseDto)
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
     description: '모임이 없습니다.',
@@ -110,6 +115,7 @@ export class PostV1Controller {
   @ApiOperation({
     summary: '게시글 좋아요 토글',
   })
+  @ApiOkResponseCommon(PostV1SwitchPostLikeResponseDto)
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))
   @Post('/:postId/like')
@@ -123,6 +129,7 @@ export class PostV1Controller {
   @ApiOperation({
     summary: '모임 게시글 신고',
   })
+  @ApiOkResponseCommon(PostV1ReportPostResponseDto)
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
     description: '"모임이 없습니다." or "권한이 없습니다."',

--- a/server/src/user/v0/dto/get-apply-by-user/user-v0-get-apply-by-user-apply-meeting.dto.ts
+++ b/server/src/user/v0/dto/get-apply-by-user/user-v0-get-apply-by-user-apply-meeting.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty, OmitType } from '@nestjs/swagger';
+import { Meeting } from 'src/entity/meeting/meeting.entity';
+import { MeetingV0MeetingStatus } from 'src/meeting/v0/enum/meeting-v0-meeting-status.enum';
+
+export class UserV0GetApplyByUserApplyMeetingDto extends OmitType(Meeting, [
+  'hasId',
+  'save',
+  'remove',
+  'softRemove',
+  'recover',
+  'reload',
+] as const) {
+  @ApiProperty({ enum: MeetingV0MeetingStatus })
+  status: MeetingV0MeetingStatus;
+}

--- a/server/src/user/v0/dto/get-apply-by-user/user-v0-get-apply-by-user-apply.dto.ts
+++ b/server/src/user/v0/dto/get-apply-by-user/user-v0-get-apply-by-user-apply.dto.ts
@@ -1,0 +1,15 @@
+import { OmitType } from '@nestjs/swagger';
+import { UserV0GetApplyByUserApplyMeetingDto } from './user-v0-get-apply-by-user-apply-meeting.dto';
+import { Apply } from 'src/entity/apply/apply.entity';
+
+export class UserV0GetApplyByUserApplyDto extends OmitType(Apply, [
+  'hasId',
+  'save',
+  'remove',
+  'softRemove',
+  'recover',
+  'reload',
+  'meeting',
+] as const) {
+  meeting: UserV0GetApplyByUserApplyMeetingDto;
+}

--- a/server/src/user/v0/dto/get-apply-by-user/user-v0-get-apply-by-user.dto.ts
+++ b/server/src/user/v0/dto/get-apply-by-user/user-v0-get-apply-by-user.dto.ts
@@ -1,0 +1,7 @@
+import { UserV0GetApplyByUserApplyDto } from './user-v0-get-apply-by-user-apply.dto';
+
+export class UserV0GetApplyByUserDto {
+  apply: UserV0GetApplyByUserApplyDto[];
+
+  count: number;
+}

--- a/server/src/user/v0/dto/get-meeting-by-user/user-v0-get-meeting-by-user-meeting.dto.ts
+++ b/server/src/user/v0/dto/get-meeting-by-user/user-v0-get-meeting-by-user-meeting.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty, OmitType } from '@nestjs/swagger';
+import { Meeting } from 'src/entity/meeting/meeting.entity';
+import { MeetingV0MeetingStatus } from 'src/meeting/v0/enum/meeting-v0-meeting-status.enum';
+
+export class UserV0GetMeetingByUserMeetingDto extends OmitType(Meeting, [
+  'hasId',
+  'save',
+  'remove',
+  'softRemove',
+  'recover',
+  'reload',
+] as const) {
+  @ApiProperty({ enum: MeetingV0MeetingStatus })
+  status: MeetingV0MeetingStatus;
+}

--- a/server/src/user/v0/dto/get-meeting-by-user/user-v0-get-meeting-by-user.dto.ts
+++ b/server/src/user/v0/dto/get-meeting-by-user/user-v0-get-meeting-by-user.dto.ts
@@ -1,0 +1,7 @@
+import { UserV0GetMeetingByUserMeetingDto } from './user-v0-get-meeting-by-user-meeting.dto';
+
+export class UserV0GetMeetingByUserDto {
+  meetings: UserV0GetMeetingByUserMeetingDto[];
+
+  count: number;
+}

--- a/server/src/user/v0/user-v0.controller.ts
+++ b/server/src/user/v0/user-v0.controller.ts
@@ -15,6 +15,9 @@ import {
 import { AuthGuard } from '@nestjs/passport';
 import { User } from '../../entity/user/user.entity';
 import { GetUser } from 'src/common/decorator/get-user.decorator';
+import { ApiOkResponseCommon } from 'src/common/decorator/api-ok-response-common.decorator';
+import { UserV0GetApplyByUserDto } from './dto/get-apply-by-user/user-v0-get-apply-by-user.dto';
+import { UserV0GetMeetingByUserDto } from './dto/get-meeting-by-user/user-v0-get-meeting-by-user.dto';
 
 @ApiTags('사용자')
 @Controller('users')
@@ -25,10 +28,13 @@ export class UserV0Controller {
     summary: '내가 만든 모임 조회',
     description: '내가 만든 모임 조회',
   })
+  @ApiOkResponseCommon(UserV0GetMeetingByUserDto)
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))
   @Get('/meeting')
-  async getMeetingByUser(@GetUser() user: User) {
+  async getMeetingByUser(
+    @GetUser() user: User,
+  ): Promise<UserV0GetMeetingByUserDto> {
     return this.usersV0Service.getMeetingByUser(user);
   }
 
@@ -36,10 +42,13 @@ export class UserV0Controller {
     summary: '내가 신청한 모임 조회',
     description: '내가 신청한 모임 조회',
   })
+  @ApiOkResponseCommon(UserV0GetApplyByUserDto)
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))
   @Get('/apply')
-  async getApplyByUser(@GetUser() user: User) {
+  async getApplyByUser(
+    @GetUser() user: User,
+  ): Promise<UserV0GetApplyByUserDto> {
     return this.usersV0Service.getApplyByUser(user);
   }
 
@@ -47,6 +56,7 @@ export class UserV0Controller {
     summary: '유저 상세 조회',
     description: '유저 상세 조회',
   })
+  @ApiOkResponseCommon(User)
   @ApiParam({ name: 'id', required: true, description: '유저 id' })
   @Get('/:id')
   async getUserById(@Param('id', ParseIntPipe) id: number) {

--- a/server/src/user/v0/user-v0.service.ts
+++ b/server/src/user/v0/user-v0.service.ts
@@ -5,6 +5,8 @@ import { UserRepository } from '../../entity/user/user.repository';
 import { getMeetingStatus } from 'src/common/utils/get-meeting-status.function';
 import { ApplyRepository } from 'src/entity/apply/apply.repository';
 import { MeetingRepository } from 'src/entity/meeting/meeting.repository';
+import { UserV0GetApplyByUserDto } from './dto/get-apply-by-user/user-v0-get-apply-by-user.dto';
+import { UserV0GetMeetingByUserDto } from './dto/get-meeting-by-user/user-v0-get-meeting-by-user.dto';
 
 @Injectable()
 export class UserV0Service {
@@ -20,7 +22,7 @@ export class UserV0Service {
   ) {}
 
   // 내가 생성한 모임 조회
-  async getMeetingByUser(user: User) {
+  async getMeetingByUser(user: User): Promise<UserV0GetMeetingByUserDto> {
     const [meetings, itemCount] =
       await this.meetingRepository.getMeetingAndCount(user);
 
@@ -38,7 +40,7 @@ export class UserV0Service {
   }
 
   // 내가 지원한 내역 조회
-  async getApplyByUser(user: User) {
+  async getApplyByUser(user: User): Promise<UserV0GetApplyByUserDto> {
     const [applies, itemCount] = await this.applyRepository.getApplyAndCount(
       user,
     );

--- a/server/src/user/v1/user-v1.controller.ts
+++ b/server/src/user/v1/user-v1.controller.ts
@@ -5,6 +5,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { User } from '../../entity/user/user.entity';
 import { GetUser } from 'src/common/decorator/get-user.decorator';
 import { UserV1GetUserOwnProfileResponseDto } from './dto/user-v1-get-user-own-profile/user-v1-get-user-own-profile-response.dto';
+import { ApiOkResponseCommon } from 'src/common/decorator/api-ok-response-common.decorator';
 
 @ApiTags('사용자')
 @Controller('users/v1')
@@ -15,6 +16,7 @@ export class UserV1Controller {
     summary: '유저 본인 프로필 조회',
     description: '유저 본인 프로필 조회',
   })
+  @ApiOkResponseCommon(UserV1GetUserOwnProfileResponseDto)
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))
   @Get('/profile/me')


### PR DESCRIPTION
# 관련 이슈
#43 
# 작업 내용
- 성공 응답모델 문서에 CommonResponseDto를 래핑해서 노출되도록 수정
- ApiOkResponseCommon 데코레이터를 이용해 문서에 적용
- 일부 응답 Dto가 없었던 API의 응답 Dto 정의