### PR TITLE
[#57] 조회 api의 response에서 null 대신 빈 배열로 처리

### DIFF
--- a/server/src/comment/v1/comment-v1.controller.ts
+++ b/server/src/comment/v1/comment-v1.controller.ts
@@ -56,7 +56,7 @@ export class CommentV1Controller {
   async getComments(
     @Query() query: CommentV1GetCommentsQueryDto,
     @GetUser() user: User,
-  ): Promise<CommentV1GetCommentsResponseDto | null> {
+  ): Promise<CommentV1GetCommentsResponseDto> {
     return this.commentV1Service.getComments({ query, user });
   }
 

--- a/server/src/comment/v1/comment-v1.service.ts
+++ b/server/src/comment/v1/comment-v1.service.ts
@@ -45,7 +45,7 @@ export class CommentV1Service {
   }: {
     query: CommentV1GetCommentsQueryDto;
     user: User;
-  }): Promise<CommentV1GetCommentsResponseDto | null> {
+  }): Promise<CommentV1GetCommentsResponseDto> {
     const [comments, commentAmount] = await this.commentRepository.findAndCount(
       {
         where: {
@@ -57,10 +57,6 @@ export class CommentV1Service {
         take: query.take,
       },
     );
-
-    if (commentAmount === 0) {
-      return null;
-    }
 
     const pageOptions: PageOptionsDto = {
       page: query.page,

--- a/server/src/meeting/v0/meeting-v0.controller.ts
+++ b/server/src/meeting/v0/meeting-v0.controller.ts
@@ -38,6 +38,7 @@ import { MeetingV0GetApplyListByMeetingResponseDto } from './dto/get-apply-list-
 import { MeetingV0GetAllMeetingsResponseDto } from './dto/get-all-meetings/meeting-v0-get-all-meetings-response.dto';
 import { GetUser } from 'src/common/decorator/get-user.decorator';
 import { ApiOkResponseCommon } from 'src/common/decorator/api-ok-response-common.decorator';
+import { Apply } from 'src/entity/apply/apply.entity';
 
 @ApiTags('모임')
 @Controller('meeting')
@@ -56,7 +57,7 @@ export class MeetingV0Controller {
     @Param('id', ParseIntPipe) id: number,
     @Body() updateStatusApplyDto: MeetingV0UpdateStatusApplyDto,
     @GetUser() user: User,
-  ): Promise<null> {
+  ): Promise<void> {
     return this.meetingV0Service.updateApplyStatusByMeeting(
       id,
       user,
@@ -107,7 +108,7 @@ export class MeetingV0Controller {
   async applyMeeting(
     @Body() applyMeetingDto: MeetingV0ApplyMeetingDto,
     @GetUser() user: User,
-  ): Promise<null> {
+  ): Promise<void> {
     return this.meetingV0Service.applyMeeting(applyMeetingDto, user);
   }
 

--- a/server/src/meeting/v0/meeting-v0.service.ts
+++ b/server/src/meeting/v0/meeting-v0.service.ts
@@ -90,7 +90,7 @@ export class MeetingV0Service {
 
     apply.status = status;
     await apply.save();
-    return null;
+    return;
   }
 
   async getApplyListByMeeting(
@@ -349,7 +349,7 @@ export class MeetingV0Service {
       }
 
       await this.applyRepository.createApply(applyMeetingDto, meeting, user);
-      return null;
+      return;
     }
 
     // 지원 이력이 있을 경우 지원 삭제
@@ -357,7 +357,6 @@ export class MeetingV0Service {
     const targetApply = meeting.appliedInfo[applyIndex];
     meeting.appliedInfo.splice(applyIndex, 1);
     await this.applyRepository.deleteApply(targetApply.id);
-    return null;
   }
 
   /**

--- a/server/src/meeting/v1/meeting-v1.controller.ts
+++ b/server/src/meeting/v1/meeting-v1.controller.ts
@@ -113,7 +113,6 @@ export class MeetingV1Controller {
       '"이미지 파일이 없습니다." or "한 개 이상의 파트를 입력해주세요" or "조건에 맞는 모임이 없습니다."',
     schema: { $ref: getSchemaPath(BaseExceptionDto) },
   })
-  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))
   @Put('/:id')

--- a/server/src/meeting/v1/meeting-v1.service.ts
+++ b/server/src/meeting/v1/meeting-v1.service.ts
@@ -176,7 +176,7 @@ export class MeetingV1Service {
    * @param id meeting id
    * @param body MeetingV1UpdateMeetingBodyDto
    * @param user 유저정보
-   * @returns null
+   * @returns void
    */
   async updateMeetingById(
     id: number,
@@ -219,7 +219,7 @@ export class MeetingV1Service {
     );
 
     if (result.affected === 1) {
-      return null;
+      return;
     } else {
       throw new HttpException(
         { message: '조건에 맞는 모임이 없습니다' },

--- a/server/src/post/v1/post-v1.service.ts
+++ b/server/src/post/v1/post-v1.service.ts
@@ -52,7 +52,7 @@ export class PostV1Service {
   }: {
     query: PostV1GetPostsQueryDto;
     user: User;
-  }): Promise<PostV1GetPostsResponseDto | null> {
+  }): Promise<PostV1GetPostsResponseDto> {
     const [posts, postAmount] = await this.postRepository.findAndCount({
       where: { meetingId: query.meetingId },
       relations: ['meeting', 'user', 'comments', 'comments.user', 'likes'],
@@ -60,10 +60,6 @@ export class PostV1Service {
       skip: query.skip,
       take: query.take,
     });
-
-    if (postAmount === 0) {
-      return null;
-    }
 
     const pageOptions: PageOptionsDto = {
       page: query.page,


### PR DESCRIPTION
## 작업 내용
- 조회 api의 response에서 null 대신 빈 배열로 처리하도록 수정하였습니다.

## 관련 이슈
#57 