### PR TITLE
[#62] 댓글 및 피드 조회 api의 response에 유저 orgId 추가

### DIFF
--- a/server/src/comment/v1/comment-v1.service.ts
+++ b/server/src/comment/v1/comment-v1.service.ts
@@ -81,6 +81,7 @@ export class CommentV1Service {
           isLiked,
           user: {
             id: comment.user.id,
+            orgId: comment.user.orgId,
             name: comment.user.name,
             profileImage: comment.user.profileImage,
           },

--- a/server/src/comment/v1/dto/get-comments/comment-v1-get-comments-response.dto.ts
+++ b/server/src/comment/v1/dto/get-comments/comment-v1-get-comments-response.dto.ts
@@ -20,6 +20,11 @@ class CommentV1GetCommentsResponseCommentUserDto {
   @IsNumber()
   id: number;
 
+  /** 작성자 playground 고유 ID */
+  @IsNotEmpty()
+  @IsNumber()
+  orgId: number;
+
   /** 작성자 명 */
   @IsNotEmpty()
   @IsString()

--- a/server/src/post/v1/dto/get-meeting-post/post-v1-get-post-response.dto.ts
+++ b/server/src/post/v1/dto/get-meeting-post/post-v1-get-post-response.dto.ts
@@ -33,6 +33,11 @@ class PostV1GetPostResponseUserDto {
   @IsNumber()
   id: number;
 
+  /** 작성자 playground 고유 ID */
+  @IsNotEmpty()
+  @IsNumber()
+  orgId: number;
+
   /** 작성자 명 */
   @IsNotEmpty()
   @IsString()

--- a/server/src/post/v1/dto/get-meeting-posts/post-v1-get-posts-response-post.dto.ts
+++ b/server/src/post/v1/dto/get-meeting-posts/post-v1-get-posts-response-post.dto.ts
@@ -20,6 +20,11 @@ class PostV1GetPostsResponsePostUserDto {
   @IsNumber()
   id: number;
 
+  /** 작성자 playground 고유 ID */
+  @IsNotEmpty()
+  @IsNumber()
+  orgId: number;
+
   /** 작성자 명 */
   @IsNotEmpty()
   @IsString()

--- a/server/src/post/v1/post-v1.service.ts
+++ b/server/src/post/v1/post-v1.service.ts
@@ -91,6 +91,7 @@ export class PostV1Service {
           images: post.images,
           user: {
             id: post.user.id,
+            orgId: post.user.orgId,
             name: post.user.name,
             profileImage: post.user.profileImage,
           },
@@ -144,6 +145,7 @@ export class PostV1Service {
       images: post.images,
       user: {
         id: post.user.id,
+        orgId: post.user.orgId,
         name: post.user.name,
         profileImage: post.user.profileImage,
       },


### PR DESCRIPTION
## 작업 내용
- post와 comment 조회 api의 response에서, 유저 orgId를 추가해서 내려주도록 수정했습니다.

## 관련 이슈
closed #62 