### PR TITLE
[#64] 피드 댓글 작성자 프로필 이미지 및 개수 전체 개수를 내려주도록 수정

### DIFF
--- a/server/src/post/v1/post-v1.service.ts
+++ b/server/src/post/v1/post-v1.service.ts
@@ -78,8 +78,7 @@ export class PostV1Service {
           .filter((item, index, self) => {
             return self.findIndex((t) => t.user.id === item.user.id) === index;
           })
-          .map((comment) => comment.user.profileImage)
-          .slice(0, 3);
+          .map((comment) => comment.user.profileImage);
 
         const isLiked = post.likes.some((like) => like.userId === user.id);
 


### PR DESCRIPTION
# 관련이슈
closed #64 
# 작업 내용
- 3개 제한이었던 프로필 사진 수를 제한 해제 시킴