### PR TITLE
모임 지원자 Export 하는 csv 파일에 참여자의 파트 정보 컬럼 추가

### DIFF
--- a/server/src/meeting/v1/meeting-v1.service.ts
+++ b/server/src/meeting/v1/meeting-v1.service.ts
@@ -67,6 +67,10 @@ export class MeetingV1Service {
       const recentActiveGeneration = activities
         ?.map((activity) => activity.generation)
         .sort((a, b) => b - a)[0];
+      const recentActivePart = activities
+        ?.slice()
+        .sort((a, b) => b.generation - a.generation)
+        .map((activity) => activity.part)[0];
       const formattedAppliedDate = dayjs(appliedDate).format(
         'YYYY-MM-DD HH:mm:ss',
       );
@@ -74,6 +78,7 @@ export class MeetingV1Service {
       return {
         name,
         recentActiveGeneration,
+        recentActivePart,
         phone,
         content,
         appliedDate: formattedAppliedDate,
@@ -82,6 +87,7 @@ export class MeetingV1Service {
     const csvColumns = [
       { value: 'name', label: '이름' },
       { value: 'recentActiveGeneration', label: '활동기수' },
+      { value: 'recentActivePart', label: '활동파트' },
       { value: 'phone', label: '전화번호' },
       { value: 'appliedDate', label: '신청시간' },
       { value: 'content', label: '신청내용' },

--- a/server/src/meeting/v1/meeting-v1.service.ts
+++ b/server/src/meeting/v1/meeting-v1.service.ts
@@ -64,13 +64,13 @@ export class MeetingV1Service {
     const csvData = applyList[0].map((apply) => {
       const { user, appliedDate, content } = apply;
       const { name, activities, phone } = user;
-      const recentActiveGeneration = activities
-        ?.map((activity) => activity.generation)
-        .sort((a, b) => b - a)[0];
-      const recentActivePart = activities
+
+      const recentActive = activities
         ?.slice()
-        .sort((a, b) => b.generation - a.generation)
-        .map((activity) => activity.part)[0];
+        .sort((a, b) => b.generation - a.generation)[0];
+      const recentActiveGeneration = recentActive.generation;
+      const recentActivePart = recentActive.part;
+
       const formattedAppliedDate = dayjs(appliedDate).format(
         'YYYY-MM-DD HH:mm:ss',
       );


### PR DESCRIPTION
# 관련 이슈
closed #80 

# 작업
- 모임 지원자 리스트를 Export 하는 csv 파일에 참여자의 파트 정보 컬럼을 추가합니다.
    <img width="468" alt="image" src="https://github.com/sopt-makers/sopt-crew-backend/assets/68415644/9708fd4c-7866-4802-81f9-0a3722352e1b">
