### PR TITLE
[#96] fix: 모임 이미지 필드명 통일

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/UserV2GetAllMeetingByUserMeetingDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/UserV2GetAllMeetingByUserMeetingDto.java
@@ -10,6 +10,6 @@ public class UserV2GetAllMeetingByUserMeetingDto {
   private int id;
   private String title;
   private String contents;
-  private String thumbnail;
+  private String imageUrl;
   private String category;
 }


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 내가 속한 모임 리스트 조회 API의 reponse에서 모임 이미지 필드명을 기존 api와 맞춰 imageUrl로 수정했습니다.

<img width="1079" alt="image" src="https://github.com/sopt-makers/sopt-crew-backend/assets/68415644/2552ed51-56fa-407e-900d-d274af9a9aad">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- closed #96 
