### PR TITLE
[#95] add : 모임의 정보중 모임 소개 데이터 필드 추가

### DIFF
--- a/server/src/post/v1/dto/get-meeting-post/post-v1-get-post-response.dto.ts
+++ b/server/src/post/v1/dto/get-meeting-post/post-v1-get-post-response.dto.ts
@@ -73,6 +73,11 @@ class PostV1GetPostResponseMeetingDto {
   @IsNotEmpty()
   @IsString()
   category: string;
+
+  /** 모임 소개 */
+  @IsNotEmpty()
+  @IsString()
+  desc: string;
 }
 
 export class PostV1GetPostResponseDto {

--- a/server/src/post/v1/post-v1.service.ts
+++ b/server/src/post/v1/post-v1.service.ts
@@ -174,6 +174,7 @@ export class PostV1Service {
         title: post.meeting.title,
         imageURL: post.meeting.imageURL,
         category: post.meeting.category,
+        desc: post.meeting.desc,
       },
       viewCount: post.viewCount,
       likeCount: post.likeCount,


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
-  GET /post/v1/{postID} 엔드포인트 응답 결과로 모임의 desc 필드를 추가해서 내려주도록 구현했습니다.
- 다른 meeting을 내려주는 response dto 를 확인해보니 모임 소개 필드를 desc로 내려주고 있어서 여기서도 필드명은 통일했습니다 !

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
<img width="1043" alt="image" src="https://github.com/sopt-makers/sopt-crew-backend/assets/68415644/7249b5e0-dccc-49ee-a630-7a06128ade8b">


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- closed #95 
