### PR TITLE
[#122] feat: 플레이그라운드 마이페이지 내 모임 영역 데이터 조회 api

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/common/config/SecurityConfig.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/config/SecurityConfig.java
@@ -23,75 +23,78 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @EnableWebSecurity
 public class SecurityConfig {
 
-    private final JwtTokenProvider jwtTokenProvider;
-    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+  private final JwtTokenProvider jwtTokenProvider;
+  private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
-    private static final String[] SWAGGER_URL = {
-            "/swagger-resources/**",
-            "/favicon.ico",
-            "/api-docs/**",
-            "/swagger-ui/**",
-            "/swagger-ui.html",
-            "/swagger-ui/index.html",
-            "/docs/swagger-ui/index.html",
-            "/swagger-ui/swagger-ui.css",
-    };
+  private static final String[] SWAGGER_URL = {
+      "/swagger-resources/**",
+      "/favicon.ico",
+      "/api-docs/**",
+      "/swagger-ui/**",
+      "/swagger-ui.html",
+      "/swagger-ui/index.html",
+      "/docs/swagger-ui/index.html",
+      "/swagger-ui/swagger-ui.css",
+  };
 
-    private static final String[] AUTH_WHITELIST = {
-            "/health"
-    };
+  private static final String[] AUTH_WHITELIST = {
+      "/health",
+      "meeting/v2/org-user/**"
+  };
 
-    @Bean
-    @Profile("dev")
-    SecurityFilterChain devSecurityFilterChain(HttpSecurity http) throws Exception {
-        http.csrf((csrfConfig) -> csrfConfig.disable())
-                .cors(Customizer.withDefaults())
-                .sessionManagement(
-                        (sessionManagement) -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(
-                        authorize -> authorize.requestMatchers(AUTH_WHITELIST).permitAll()
-                                .requestMatchers(SWAGGER_URL).permitAll()
-                                .anyRequest().authenticated())
-                .addFilterBefore(
-                        new JwtAuthenticationFilter(this.jwtTokenProvider, this.jwtAuthenticationEntryPoint),
-                        UsernamePasswordAuthenticationFilter.class)
-                .exceptionHandling(exceptionHandling -> exceptionHandling
-                        .authenticationEntryPoint(this.jwtAuthenticationEntryPoint));
-        return http.build();
-    }
+  @Bean
+  @Profile("dev")
+  SecurityFilterChain devSecurityFilterChain(HttpSecurity http) throws Exception {
+    http.csrf((csrfConfig) -> csrfConfig.disable())
+        .cors(Customizer.withDefaults())
+        .sessionManagement(
+            (sessionManagement) -> sessionManagement.sessionCreationPolicy(
+                SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(
+            authorize -> authorize.requestMatchers(AUTH_WHITELIST).permitAll()
+                .requestMatchers(SWAGGER_URL).permitAll()
+                .anyRequest().authenticated())
+        .addFilterBefore(
+            new JwtAuthenticationFilter(this.jwtTokenProvider, this.jwtAuthenticationEntryPoint),
+            UsernamePasswordAuthenticationFilter.class)
+        .exceptionHandling(exceptionHandling -> exceptionHandling
+            .authenticationEntryPoint(this.jwtAuthenticationEntryPoint));
+    return http.build();
+  }
 
-    @Bean
-    @Profile("prod")
-    SecurityFilterChain prodSecurityFilterChain(HttpSecurity http) throws Exception {
-        http.csrf((csrfConfig) -> csrfConfig.disable())
-                .cors(Customizer.withDefaults())
-                .sessionManagement(
-                        (sessionManagement) -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(
-                        authorize -> authorize.requestMatchers(AUTH_WHITELIST).permitAll()
-                                .requestMatchers(SWAGGER_URL).permitAll()
-                                .anyRequest().authenticated())
-                .addFilterBefore(
-                        new JwtAuthenticationFilter(this.jwtTokenProvider, this.jwtAuthenticationEntryPoint),
-                        UsernamePasswordAuthenticationFilter.class)
-                .exceptionHandling(exceptionHandling -> exceptionHandling
-                        .authenticationEntryPoint(this.jwtAuthenticationEntryPoint));
-        return http.build();
-    }
+  @Bean
+  @Profile("prod")
+  SecurityFilterChain prodSecurityFilterChain(HttpSecurity http) throws Exception {
+    http.csrf((csrfConfig) -> csrfConfig.disable())
+        .cors(Customizer.withDefaults())
+        .sessionManagement(
+            (sessionManagement) -> sessionManagement.sessionCreationPolicy(
+                SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(
+            authorize -> authorize.requestMatchers(AUTH_WHITELIST).permitAll()
+                .requestMatchers(SWAGGER_URL).permitAll()
+                .anyRequest().authenticated())
+        .addFilterBefore(
+            new JwtAuthenticationFilter(this.jwtTokenProvider, this.jwtAuthenticationEntryPoint),
+            UsernamePasswordAuthenticationFilter.class)
+        .exceptionHandling(exceptionHandling -> exceptionHandling
+            .authenticationEntryPoint(this.jwtAuthenticationEntryPoint));
+    return http.build();
+  }
 
-    @Bean
-    CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(
-                Arrays.asList("https://playground.sopt.org/", "http://localhost:3000/",
-                        "https://sopt-internal-dev.pages.dev/"));
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PATCH", "DELETE", "OPTIONS"));
-        configuration.addAllowedHeader("*");
-        configuration.setAllowCredentials(false);
+  @Bean
+  CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.setAllowedOrigins(
+        Arrays.asList("https://playground.sopt.org/", "http://localhost:3000/",
+            "https://sopt-internal-dev.pages.dev/"));
+    configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PATCH", "DELETE", "OPTIONS"));
+    configuration.addAllowedHeader("*");
+    configuration.setAllowCredentials(false);
 
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
-    }
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
+  }
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/common/pagination/dto/PageMetaDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/pagination/dto/PageMetaDto.java
@@ -1,0 +1,35 @@
+package org.sopt.makers.crew.main.common.pagination.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class PageMetaDto {
+
+  @Schema(description = "페이지 위치")
+  private int page;
+
+  @Schema(description = "가져올 데이터 개수")
+  private int take;
+
+  @Schema(description = "응답 데이터 개수")
+  private int itemCount;
+
+  @Schema(description = "총 페이지 수")
+  private int pageCount;
+
+  @Schema(description = "이전 페이지가 있는지 유무")
+  private boolean hasPreviousPage;
+
+  @Schema(description = "다음 페이지가 있는지 유무")
+  private boolean hasNextPage;
+
+  public PageMetaDto(PageOptionsDto pageOptionsDto, int itemCount) {
+    this.page = pageOptionsDto.getPage();
+    this.take = pageOptionsDto.getTake();
+    this.itemCount = itemCount;
+    this.pageCount = (int) Math.ceil((double) this.itemCount / this.take);
+    this.hasPreviousPage = this.page > 1;
+    this.hasNextPage = this.page < this.pageCount;
+  }
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/common/pagination/dto/PageOptionsDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/pagination/dto/PageOptionsDto.java
@@ -1,0 +1,24 @@
+package org.sopt.makers.crew.main.common.pagination.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+
+@Getter
+public class PageOptionsDto {
+
+  @Schema(description = "각 페이지", defaultValue = "1", example = "1")
+  @Min(1)
+  private Integer page;
+
+  @Schema(description = "가져올 데이터 개수", defaultValue = "12", example = "12")
+  @Min(1)
+  @Max(50)
+  private Integer take;
+
+  public PageOptionsDto(Integer page, Integer take) {
+    this.page = page == null ? 1 : page;
+    this.take = take == null ? 12 : take;
+  }
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserRepository.java
@@ -1,12 +1,20 @@
 package org.sopt.makers.crew.main.entity.user;
 
+import java.util.Optional;
 import org.sopt.makers.crew.main.common.exception.UnAuthorizedException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Integer> {
 
+  Optional<User> findByOrgId(Integer orgId);
+
   default User findByIdOrThrow(Integer userId) {
     return findById(userId)
+        .orElseThrow(() -> new UnAuthorizedException());
+  }
+
+  default User findByOrgIdOrThrow(Integer orgUserId) {
+    return findByOrgId(orgUserId)
         .orElseThrow(() -> new UnAuthorizedException());
   }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -1,0 +1,46 @@
+package org.sopt.makers.crew.main.meeting.v2;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
+import org.sopt.makers.crew.main.meeting.v2.service.MeetingV2Service;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/meeting/v2")
+@RequiredArgsConstructor
+@Tag(name = "모임")
+public class MeetingV2Controller {
+
+  private final MeetingV2Service meetingV2Service;
+
+  @Operation(summary = "플레이그라운드 마이페이지 내 모임 정보 조회")
+  @GetMapping("/org-user")
+  @ResponseStatus(HttpStatus.OK)
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "204", description = "참여했던 모임이 없습니다.", content = @Content),
+  })
+  @Parameters({
+      @Parameter(name = "page", description = "페이지, default = 1", example = "1"),
+      @Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50"),
+      @Parameter(name = "orgUserId", description = "플레이그라운드 유저 id", example = "0")
+  })
+  public ResponseEntity<MeetingV2GetAllMeetingByOrgUserDto> getAllMeetingByOrgUser(
+      @ModelAttribute @Parameter(hidden = true) MeetingV2GetAllMeetingByOrgUserQueryDto queryDto) {
+    return ResponseEntity.ok(meetingV2Service.getAllMeetingByOrgUser(queryDto));
+  }
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/query/MeetingV2GetAllMeetingByOrgUserQueryDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/query/MeetingV2GetAllMeetingByOrgUserQueryDto.java
@@ -1,0 +1,17 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.query;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
+
+@Getter
+public class MeetingV2GetAllMeetingByOrgUserQueryDto extends PageOptionsDto {
+
+  @NotNull
+  private Integer orgUserId;
+
+  public MeetingV2GetAllMeetingByOrgUserQueryDto(Integer orgUserId, Integer page, Integer take) {
+    super(page, take);
+    this.orgUserId = orgUserId;
+  }
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetAllMeetingByOrgUserDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetAllMeetingByOrgUserDto.java
@@ -1,0 +1,15 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.sopt.makers.crew.main.common.pagination.dto.PageMetaDto;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class MeetingV2GetAllMeetingByOrgUserDto {
+
+  private List<MeetingV2GetAllMeetingByOrgUserMeetingDto> meetings;
+
+  private PageMetaDto meta;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetAllMeetingByOrgUserMeetingDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetAllMeetingByOrgUserMeetingDto.java
@@ -1,0 +1,19 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class MeetingV2GetAllMeetingByOrgUserMeetingDto {
+
+  private Integer id;
+  private Boolean isMeetingLeader;
+  private String title;
+  private String imageUrl;
+  private String category;
+  private LocalDateTime mStartDate;
+  private LocalDateTime mEndDate;
+  private Boolean isActiveMeeting;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -1,0 +1,11 @@
+package org.sopt.makers.crew.main.meeting.v2.service;
+
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
+
+public interface MeetingV2Service {
+
+  MeetingV2GetAllMeetingByOrgUserDto getAllMeetingByOrgUser(
+      MeetingV2GetAllMeetingByOrgUserQueryDto queryDto);
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -1,0 +1,76 @@
+package org.sopt.makers.crew.main.meeting.v2.service;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.sopt.makers.crew.main.common.pagination.dto.PageMetaDto;
+import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
+import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.UserRepository;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserMeetingDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MeetingV2ServiceImpl implements MeetingV2Service {
+
+  private final UserRepository userRepository;
+  private final ApplyRepository applyRepository;
+
+  @Override
+  public MeetingV2GetAllMeetingByOrgUserDto getAllMeetingByOrgUser(
+      MeetingV2GetAllMeetingByOrgUserQueryDto queryDto) {
+    int page = queryDto.getPage();
+    int take = queryDto.getTake();
+
+    User user = userRepository.findByOrgIdOrThrow(queryDto.getOrgUserId());
+
+    List<MeetingV2GetAllMeetingByOrgUserMeetingDto> userJoinedList = Stream.concat(
+            user.getMeetings().stream(),
+            applyRepository.findAllByUserIdAndStatus(user.getId(), EnApplyStatus.APPROVE)
+                .stream()
+                .map(apply -> apply.getMeeting())
+        )
+        .map(meeting -> MeetingV2GetAllMeetingByOrgUserMeetingDto.of(
+            meeting.getId(),
+            checkMeetingLeader(meeting, user.getId()),
+            meeting.getTitle(),
+            meeting.getImageURL().get(0).getUrl(),
+            meeting.getCategory().getValue(),
+            meeting.getMStartDate(),
+            meeting.getMEndDate(),
+            checkActivityStatus(meeting)
+        ))
+        .sorted(Comparator.comparing(MeetingV2GetAllMeetingByOrgUserMeetingDto::getId).reversed())
+        .collect(Collectors.toList());
+
+    List<MeetingV2GetAllMeetingByOrgUserMeetingDto> pagedUserJoinedList = userJoinedList.stream()
+        .skip((long) (page - 1) * take) // 스킵할 아이템 수 계산
+        .limit(take) // 페이지당 아이템 수 제한
+        .collect(Collectors.toList());
+    PageOptionsDto pageOptionsDto = new PageOptionsDto(page, take);
+    PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, userJoinedList.size());
+    return MeetingV2GetAllMeetingByOrgUserDto.of(pagedUserJoinedList, pageMetaDto);
+  }
+
+  private Boolean checkMeetingLeader(Meeting meeting, Integer userId) {
+    return meeting.getUserId().equals(userId);
+  }
+
+  private Boolean checkActivityStatus(Meeting meeting) {
+    LocalDateTime now = LocalDateTime.now();
+    LocalDateTime mStartDate = meeting.getMStartDate();
+    LocalDateTime mEndDate = meeting.getMEndDate();
+    return now.isEqual(mStartDate) || (now.isAfter(mStartDate) && now.isBefore(mEndDate));
+  }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- pagination 관련 파일 추가해서 api 개발 진행했습니다.

- 플레이그라운드 마이페이지 내 모임 영역에 필요한 데이터 컬럼만 뽑아서 내려줄 수 있도록 구현했습니다.
  -  id : 모임 id
  -  isMeetingLeader : 해당 모임의 개설자인지
  -  title : 모임 타이틀
  -  imageUrl : 모임 썸네일 Url
  -  category : 모임 카테고리
  -  mStartDate : 모임 활동 시작 날짜
  -  mEndDate : 모임 활동 종료 날짜
  -  isActiveMeeting: 활동중인 모임인지 여부
  
<img width="1043" alt="image" src="https://github.com/sopt-makers/sopt-crew-backend/assets/68415644/6a9a0f45-e3eb-4403-8f69-31cf8483c3c5">

- 영우님과 코드 포맷팅이 다르게 설정되어있었나봅니다 ㅠㅠ 어떤걸로 세팅해두셨는지 알려주시면 제가 바꿔볼게요..!

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
pagination 관해서 한 가지 의견을 여쭤보고 싶은게 있는데요...! 

지금 이 api의 서비스 로직의 경우, 내가 참여한 모임 리스트를 조회하다 보니 `내가 개설한 모임`과 `내가 지원하고 참여한 모임` 두 개를 합쳐서 내려줘야하는데요. 

apply 테이블과 조인을 해서 meeting 데이터를 가져온 것과 meeting 테이블에서 userId를 통해 가져온 데이터를 합쳐서 내려줄려면 DB 조회 쿼리 로직이 두 개로 나눠져야한다고 판단했습니다. 

그러다보니 DB 계층에서 페이지네이션이 되는게 아니라 서비스 계층에서 페이지네이션을 구현할 수 밖에 없다고 생각해서 일단 그렇게 구현해놓기는 했습니다.

혹시 제가 생각 못했던 방법이 있거나, 잘못 생각한 부분이 있는지 영우님 의견 들어보고 싶습니다 :)

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- closed #122 
