### PR TITLE
[#125] feat: 모임 홈 개선 - 모임 둘러보기 API 개발

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -26,6 +26,7 @@ import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
 import org.sopt.makers.crew.main.entity.apply.Apply;
 import org.sopt.makers.crew.main.entity.meeting.converter.MeetingCategoryConverter;
+import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
@@ -99,7 +100,7 @@ public class Meeting {
    * 모집 인원
    */
   @Column(name = "capacity", nullable = false)
-  private int capacity;
+  private Integer capacity;
 
   /**
    * 모임 소개
@@ -147,19 +148,19 @@ public class Meeting {
    * 멘토 필요 여부
    */
   @Column(name = "isMentorNeeded", nullable = false)
-  private boolean isMentorNeeded;
+  private Boolean isMentorNeeded;
 
   /**
    * 활동 기수만 참여 가능한지 여부
    */
   @Column(name = "canJoinOnlyActiveGeneration", nullable = false)
-  private boolean canJoinOnlyActiveGeneration;
+  private Boolean canJoinOnlyActiveGeneration;
 
   /**
    * 모임 기수
    */
   @Column(name = "createdGeneration", nullable = false)
-  private int createdGeneration;
+  private Integer createdGeneration;
 
   /**
    * 대상 활동 기수
@@ -170,17 +171,10 @@ public class Meeting {
   /**
    * 모임 참여 가능한 파트
    */
-  @Type(
-      value = EnumArrayType.class,
-      parameters = @Parameter(
-          name = AbstractArrayType.SQL_ARRAY_TYPE,
-          value = "meeting_joinableparts_enum"
-      )
-  )
-  @Column(
-      name = "joinableParts",
-      columnDefinition = "meeting_joinableparts_enum[]"
-  )
+  @Type(value = EnumArrayType.class,
+      parameters = @Parameter(name = AbstractArrayType.SQL_ARRAY_TYPE,
+          value = "meeting_joinableparts_enum"))
+  @Column(name = "joinableParts", columnDefinition = "meeting_joinableparts_enum[]")
   private MeetingJoinablePart[] joinableParts;
 
   /**
@@ -190,13 +184,11 @@ public class Meeting {
   private List<Post> posts;
 
   @Builder
-  public Meeting(User user, int userId, String title, MeetingCategory category,
-      List<ImageUrlVO> imageURL, LocalDateTime startDate, LocalDateTime endDate, int capacity,
-      String desc,
-      String processDesc, LocalDateTime mStartDate, LocalDateTime mEndDate, String leaderDesc,
-      String targetDesc,
-      String note, boolean isMentorNeeded, boolean canJoinOnlyActiveGeneration,
-      int createdGeneration,
+  public Meeting(User user, Integer userId, String title, MeetingCategory category,
+      List<ImageUrlVO> imageURL, LocalDateTime startDate, LocalDateTime endDate, Integer capacity,
+      String desc, String processDesc, LocalDateTime mStartDate, LocalDateTime mEndDate,
+      String leaderDesc, String targetDesc, String note, Boolean isMentorNeeded,
+      Boolean canJoinOnlyActiveGeneration, Integer createdGeneration,
       Integer targetActiveGeneration, MeetingJoinablePart[] joinableParts) {
     this.user = user;
     this.userId = userId;
@@ -226,5 +218,21 @@ public class Meeting {
 
   public void addPost(Post post) {
     posts.add(post);
+  }
+
+  /**
+   * 모임 모집상태 확인
+   * 
+   * @return 모임 모집상태
+   */
+  public Integer getMeetingStatus() {
+    LocalDateTime now = LocalDateTime.now();
+    if (now.isBefore(startDate)) {
+      return EnMeetingStatus.BEFORE_START.getValue();
+    } else if (now.isBefore(endDate)) {
+      return EnMeetingStatus.APPLY_ABLE.getValue();
+    } else {
+      return EnMeetingStatus.RECRUITMENT_COMPLETE.getValue();
+    }
   }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/enums/EnMeetingStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/enums/EnMeetingStatus.java
@@ -1,0 +1,32 @@
+package org.sopt.makers.crew.main.entity.meeting.enums;
+
+import java.util.Arrays;
+import org.sopt.makers.crew.main.common.exception.BadRequestException;
+
+/** 모임 상태 */
+public enum EnMeetingStatus {
+  /** 시작 전 */
+  BEFORE_START(0),
+
+  /** 지원 가능 */
+  APPLY_ABLE(1),
+
+  /** 모집 완료 */
+  RECRUITMENT_COMPLETE(2);
+
+  private final int value;
+
+  EnMeetingStatus(int value) {
+    this.value = value;
+  }
+
+  public static EnMeetingStatus ofValue(int dbData) {
+    return Arrays.stream(EnMeetingStatus.values()).filter(v -> v.getValue() == (dbData)).findFirst()
+        .orElseThrow(() -> new BadRequestException(
+            String.format("EnMeetingStatus 클래스에 value = [%s] 값을 가진 enum 객체가 없습니다.", dbData)));
+  }
+
+  public int getValue() {
+    return value;
+  }
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/enums/MeetingCategory.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/enums/MeetingCategory.java
@@ -2,29 +2,29 @@ package org.sopt.makers.crew.main.entity.meeting.enums;
 
 import java.util.Arrays;
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
-import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
 
 public enum MeetingCategory {
-    STUDY("스터디"),
-    LECTURE("강연"),
-    LIGHTNING("번개"),
-    EVENT("행사");
+  STUDY("스터디"),
 
-    private final String value;
+  LECTURE("강연"),
 
-    MeetingCategory(String value) {
-        this.value = value;
-    }
+  LIGHTNING("번개"),
 
-    public static MeetingCategory ofValue(String dbData) {
-        return Arrays.stream(MeetingCategory.values())
-                .filter(v -> v.getValue().equals(dbData))
-                .findFirst()
-                .orElseThrow(() -> new BadRequestException(
-                        String.format("MeetingCategory 클래스에 value = [%s] 값을 가진 enum 객체가 없습니다.", dbData)));
-    }
+  EVENT("행사");
 
-    public String getValue() {
-        return value;
-    }
+  private final String value;
+
+  MeetingCategory(String value) {
+    this.value = value;
+  }
+
+  public static MeetingCategory ofValue(String dbData) {
+    return Arrays.stream(MeetingCategory.values()).filter(v -> v.getValue().equals(dbData))
+        .findFirst().orElseThrow(() -> new BadRequestException(
+            String.format("MeetingCategory 클래스에 value = [%s] 값을 가진 enum 객체가 없습니다.", dbData)));
+  }
+
+  public String getValue() {
+    return value;
+  }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/vo/ImageUrlVO.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/vo/ImageUrlVO.java
@@ -7,6 +7,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ImageUrlVO {
 
-  private final Integer id;
-  private final String url;
+  private Integer id;
+  private String url;
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/post/Post.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/post/Post.java
@@ -140,8 +140,7 @@ public class Post {
   private List<Report> reports;
 
   @Builder
-  public Post(String title, String contents,
-      String[] images, User user, Meeting meeting) {
+  public Post(String title, String contents, String[] images, User user, Meeting meeting) {
     this.title = title;
     this.contents = contents;
     this.viewCount = 0;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserRepository.java
@@ -9,12 +9,10 @@ public interface UserRepository extends JpaRepository<User, Integer> {
   Optional<User> findByOrgId(Integer orgId);
 
   default User findByIdOrThrow(Integer userId) {
-    return findById(userId)
-        .orElseThrow(() -> new UnAuthorizedException());
+    return findById(userId).orElseThrow(() -> new UnAuthorizedException());
   }
 
   default User findByOrgIdOrThrow(Integer orgUserId) {
-    return findByOrgId(orgUserId)
-        .orElseThrow(() -> new UnAuthorizedException());
+    return findByOrgId(orgUserId).orElseThrow(() -> new UnAuthorizedException());
   }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/vo/UserActivityVO.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/vo/UserActivityVO.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 @ToString
 public class UserActivityVO {
 
-  private final String part;
-  private final int generation;
+  private String part;
+  private int generation;
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/notification/PushNotificationService.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/notification/PushNotificationService.java
@@ -22,12 +22,8 @@ public class PushNotificationService {
   private final PushNotificationServerClient pushServerClient;
 
   public void sendPushNotification(PushNotificationRequestDto request) {
-    PushNotificationResponseDto response = pushServerClient.sendPushNotification(
-        pushNotificationApiKey,
-        PUSH_NOTIFICATION_ACTION.getValue(),
-        UUID.randomUUID().toString(),
-        service,
-        request
-    );
+    PushNotificationResponseDto response =
+        pushServerClient.sendPushNotification(pushNotificationApiKey,
+            PUSH_NOTIFICATION_ACTION.getValue(), UUID.randomUUID().toString(), service, request);
   }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -8,8 +8,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import java.security.Principal;
+import java.util.List;
+import org.sopt.makers.crew.main.common.util.UserUtil;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.service.MeetingV2Service;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,17 +34,24 @@ public class MeetingV2Controller {
   @Operation(summary = "플레이그라운드 마이페이지 내 모임 정보 조회")
   @GetMapping("/org-user")
   @ResponseStatus(HttpStatus.OK)
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "204", description = "참여했던 모임이 없습니다.", content = @Content),
-  })
-  @Parameters({
-      @Parameter(name = "page", description = "페이지, default = 1", example = "1"),
+  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "204", description = "참여했던 모임이 없습니다.", content = @Content),})
+  @Parameters({@Parameter(name = "page", description = "페이지, default = 1", example = "1"),
       @Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50"),
-      @Parameter(name = "orgUserId", description = "플레이그라운드 유저 id", example = "0")
-  })
+      @Parameter(name = "orgUserId", description = "플레이그라운드 유저 id", example = "0")})
   public ResponseEntity<MeetingV2GetAllMeetingByOrgUserDto> getAllMeetingByOrgUser(
       @ModelAttribute @Parameter(hidden = true) MeetingV2GetAllMeetingByOrgUserQueryDto queryDto) {
     return ResponseEntity.ok(meetingV2Service.getAllMeetingByOrgUser(queryDto));
+  }
+
+  @Operation(summary = "모임 둘러보기 조회")
+  @GetMapping("/banner")
+  @ResponseStatus(HttpStatus.OK)
+  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "204", description = "모임이 없습니다.", content = @Content),})
+  public ResponseEntity<List<MeetingV2GetMeetingBannerResponseDto>> getMeetingBanner(
+      Principal principal) {
+    UserUtil.getUserId(principal);
+    return ResponseEntity.ok(meetingV2Service.getMeetingBanner());
   }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingBannerResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingBannerResponseDto.java
@@ -1,0 +1,58 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class MeetingV2GetMeetingBannerResponseDto {
+
+    /** 모임 ID */
+    private Integer id;
+    /** 유저 Crew ID */
+    private Integer userId;
+    /** 모임 제목 */
+    private String title;
+    /**
+     * 모임 카테고리
+     * 
+     * @apiNote '스터디', '행사'
+     */
+    private MeetingCategory category;
+    /**
+     * 썸네일 이미지
+     * 
+     * @apiNote 여러개여도 첫번째 이미지만 사용
+     */
+    private List<ImageUrlVO> imageURL;
+    /** 모임 지원 시작일 */
+    private LocalDateTime startDate;
+    /** 모임 지원 종료일 */
+    private LocalDateTime endDate;
+    /** 모임 활동 시작일 */
+    private LocalDateTime mStartDate;
+    /** 모임 활동 종료일 */
+    private LocalDateTime mEndDate;
+    /** 모임 인원 */
+    private Integer capacity;
+    /** 최근 활동 일자 */
+    private Optional<LocalDateTime> recentActivityDate;
+    /** 모임 타겟 기수 */
+    private Integer targetActiveGeneration;
+    /** 모임 타겟 파트 */
+    private MeetingJoinablePart[] joinableParts;
+    /** 지원자 수 */
+    private Integer applicantCount;
+    /** 가입된 지원자 수 */
+    private Integer approvedUserCount;
+    /** 개설자 정보 */
+    private Optional<MeetingV2GetMeetingBannerResponseUserDto> user;
+    /** 미팅 상태 */
+    private Integer status;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingBannerResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingBannerResponseDto.java
@@ -31,10 +31,6 @@ public class MeetingV2GetMeetingBannerResponseDto {
      * @apiNote 여러개여도 첫번째 이미지만 사용
      */
     private List<ImageUrlVO> imageURL;
-    /** 모임 지원 시작일 */
-    private LocalDateTime startDate;
-    /** 모임 지원 종료일 */
-    private LocalDateTime endDate;
     /** 모임 활동 시작일 */
     private LocalDateTime mStartDate;
     /** 모임 활동 종료일 */

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingBannerResponseUserDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingBannerResponseUserDto.java
@@ -1,0 +1,17 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class MeetingV2GetMeetingBannerResponseUserDto {
+  /** 개설자 crew ID */
+  private Integer id;
+  /** 개설자 */
+  private String name;
+  /** 개설자 playground ID */
+  private Integer orgId;
+  /** 프로필 사진 */
+  private String profileImage;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -1,11 +1,14 @@
 package org.sopt.makers.crew.main.meeting.v2.service;
 
+import java.util.List;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
 
 public interface MeetingV2Service {
 
   MeetingV2GetAllMeetingByOrgUserDto getAllMeetingByOrgUser(
       MeetingV2GetAllMeetingByOrgUserQueryDto queryDto);
 
+  List<MeetingV2GetMeetingBannerResponseDto> getMeetingBanner();
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -3,19 +3,25 @@ package org.sopt.makers.crew.main.meeting.v2.service;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.crew.main.common.pagination.dto.PageMetaDto;
 import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
+import org.sopt.makers.crew.main.entity.apply.Apply;
 import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
+import org.sopt.makers.crew.main.entity.post.Post;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.entity.user.UserRepository;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserMeetingDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseUserDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +32,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
   private final UserRepository userRepository;
   private final ApplyRepository applyRepository;
+  private final MeetingRepository meetingRepository;
 
   @Override
   public MeetingV2GetAllMeetingByOrgUserDto getAllMeetingByOrgUser(
@@ -35,32 +42,54 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
     User user = userRepository.findByOrgIdOrThrow(queryDto.getOrgUserId());
 
-    List<MeetingV2GetAllMeetingByOrgUserMeetingDto> userJoinedList = Stream.concat(
-            user.getMeetings().stream(),
-            applyRepository.findAllByUserIdAndStatus(user.getId(), EnApplyStatus.APPROVE)
-                .stream()
-                .map(apply -> apply.getMeeting())
-        )
-        .map(meeting -> MeetingV2GetAllMeetingByOrgUserMeetingDto.of(
-            meeting.getId(),
-            checkMeetingLeader(meeting, user.getId()),
-            meeting.getTitle(),
-            meeting.getImageURL().get(0).getUrl(),
-            meeting.getCategory().getValue(),
-            meeting.getMStartDate(),
-            meeting.getMEndDate(),
-            checkActivityStatus(meeting)
-        ))
+    List<MeetingV2GetAllMeetingByOrgUserMeetingDto> userJoinedList = Stream
+        .concat(user.getMeetings().stream(),
+            applyRepository.findAllByUserIdAndStatus(user.getId(), EnApplyStatus.APPROVE).stream()
+                .map(apply -> apply.getMeeting()))
+        .map(meeting -> MeetingV2GetAllMeetingByOrgUserMeetingDto.of(meeting.getId(),
+            checkMeetingLeader(meeting, user.getId()), meeting.getTitle(),
+            meeting.getImageURL().get(0).getUrl(), meeting.getCategory().getValue(),
+            meeting.getMStartDate(), meeting.getMEndDate(), checkActivityStatus(meeting)))
         .sorted(Comparator.comparing(MeetingV2GetAllMeetingByOrgUserMeetingDto::getId).reversed())
         .collect(Collectors.toList());
 
-    List<MeetingV2GetAllMeetingByOrgUserMeetingDto> pagedUserJoinedList = userJoinedList.stream()
-        .skip((long) (page - 1) * take) // 스킵할 아이템 수 계산
-        .limit(take) // 페이지당 아이템 수 제한
-        .collect(Collectors.toList());
+    List<MeetingV2GetAllMeetingByOrgUserMeetingDto> pagedUserJoinedList =
+        userJoinedList.stream().skip((long) (page - 1) * take) // 스킵할 아이템 수 계산
+            .limit(take) // 페이지당 아이템 수 제한
+            .collect(Collectors.toList());
     PageOptionsDto pageOptionsDto = new PageOptionsDto(page, take);
     PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, userJoinedList.size());
     return MeetingV2GetAllMeetingByOrgUserDto.of(pagedUserJoinedList, pageMetaDto);
+  }
+
+  @Override
+  public List<MeetingV2GetMeetingBannerResponseDto> getMeetingBanner() {
+    List<MeetingV2GetMeetingBannerResponseDto> meetingBanners = this.meetingRepository.findAll()
+        .stream().sorted(Comparator.comparing(Meeting::getId).reversed()).limit(20).map(meeting -> {
+          List<Post> post = meeting.getPosts().stream()
+              .sorted(Comparator.comparing(Post::getId).reversed()).limit(1).toList();
+          List<Apply> applies = meeting.getAppliedInfo();
+
+          Integer applicantCount = applies.size();
+          Integer appliedUserCount = applies.stream()
+              .filter(apply -> apply.getStatus().equals(EnApplyStatus.APPROVE)).toList().size();
+
+          Optional<LocalDateTime> recentActivityDate =
+              post.isEmpty() ? Optional.empty() : Optional.of(post.get(0).getCreatedDate());
+
+          Optional<MeetingV2GetMeetingBannerResponseUserDto> meetingLeader = userRepository
+              .findById(meeting.getUserId()).map(user -> MeetingV2GetMeetingBannerResponseUserDto
+                  .of(user.getId(), user.getName(), user.getOrgId(), user.getProfileImage()));
+
+          return MeetingV2GetMeetingBannerResponseDto.of(meeting.getId(), meeting.getUserId(),
+              meeting.getTitle(), meeting.getCategory(), meeting.getImageURL(),
+              meeting.getStartDate(), meeting.getEndDate(), meeting.getMStartDate(),
+              meeting.getMEndDate(), meeting.getCapacity(), recentActivityDate,
+              meeting.getTargetActiveGeneration(), meeting.getJoinableParts(), applicantCount,
+              appliedUserCount, meetingLeader, meeting.getMeetingStatus());
+        }).toList();
+
+    return meetingBanners;
   }
 
   private Boolean checkMeetingLeader(Meeting meeting, Integer userId) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -83,10 +83,9 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
           return MeetingV2GetMeetingBannerResponseDto.of(meeting.getId(), meeting.getUserId(),
               meeting.getTitle(), meeting.getCategory(), meeting.getImageURL(),
-              meeting.getStartDate(), meeting.getEndDate(), meeting.getMStartDate(),
-              meeting.getMEndDate(), meeting.getCapacity(), recentActivityDate,
-              meeting.getTargetActiveGeneration(), meeting.getJoinableParts(), applicantCount,
-              appliedUserCount, meetingLeader, meeting.getMeetingStatus());
+              meeting.getMStartDate(), meeting.getMEndDate(), meeting.getCapacity(),
+              recentActivityDate, meeting.getTargetActiveGeneration(), meeting.getJoinableParts(),
+              applicantCount, appliedUserCount, meetingLeader, meeting.getMeetingStatus());
         }).toList();
 
     return meetingBanners;


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 모임 둘러보기 API 개발

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- Entity에서 `joinableParts` 필드 타입이 `MeetingJoinablePart[]`인데 converter를 이용해서 `List<MeetingJoinablePart>`로 변경할 수 있다면 좋겠습니다.
- endpoint 명을 `/meeting/v2/banner`로 정했는데 더 좋은 의견이 있으면 말씀해주시면 좋을 것 같습니다.
  - 기존 meeting 조회 API와 같은 부분이 많다고 느껴지는데, 응답모델이 특이하게 banner에서만 사용하는 형식이라 다음과 같이 정했어요.
- VO에서 final 키워드를 삭제한 것은 다음과 같은 이유에서입니다.
 > final field가 포함된 class 역시 JPA의 Entity가 될 수 없다.
 >
 > Entity class는 JPA에 의해 프록시 객체로 확장된다. 그리고 JPA는 이 프록시 객체를 생성할 때 Reflection API를 이용한다. reflection으로 객체를 생성하기 위해서는 그 객체가 기본 생성자를 가지고 있어야 한다. 이렇게 생성된 프록시 객체의 필드들을 초기화 하기 위해 setter를 사용한다. 하지만 final 필드는 setter를 이용해서 초기화할 수 없다. final 필드는 클래스 로딩 시점에 초기화 되거나 생성자를 이용해서만 초기화될 수 있다. 따라서 JPA의 Entity로 사용할 class는 final 필드를 가질 수 없다.
- 사용하지 않는 패키지를 import하는 것을 많이 봤는데, 해당 부분은 삭제하는 작업이 필요할 것 같습니다.
- vscode에서 구글 스타일 가이드를 적용해서 개발했는데, 여전히 어느정도는 포맷팅이 다른 것 같긴 합니다..!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- closed #125
