### PR TITLE
[FIX] 플그 마이페이지 내 모임 조회 API, 401 에러 해결

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/common/exception/NoContentException.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/exception/NoContentException.java
@@ -1,0 +1,14 @@
+package org.sopt.makers.crew.main.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NoContentException extends BaseException {
+
+  public NoContentException() {
+    super(HttpStatus.NO_CONTENT);
+  }
+
+  public NoContentException(String message) {
+    super(HttpStatus.NO_CONTENT, message);
+  }
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/common/response/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/response/ErrorStatus.java
@@ -8,6 +8,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public enum ErrorStatus {
   /**
+   * 204 NO_CONTENT
+   */
+  NO_CONTENT_EXCEPTION("참여한 모임이 없습니다."),
+  
+  /**
    * 400 BAD_REQUEST
    */
   VALIDATION_EXCEPTION("CR-001"), // errorCode는 예시, 추후 변경 예정 -> 잘못된 요청입니다.

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserRepository.java
@@ -1,6 +1,9 @@
 package org.sopt.makers.crew.main.entity.user;
 
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.NO_CONTENT_EXCEPTION;
+
 import java.util.Optional;
+import org.sopt.makers.crew.main.common.exception.NoContentException;
 import org.sopt.makers.crew.main.common.exception.UnAuthorizedException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -13,6 +16,8 @@ public interface UserRepository extends JpaRepository<User, Integer> {
   }
 
   default User findByOrgIdOrThrow(Integer orgUserId) {
-    return findByOrgId(orgUserId).orElseThrow(() -> new UnAuthorizedException());
+    return findByOrgId(orgUserId).orElseThrow(
+        () -> new NoContentException(
+            NO_CONTENT_EXCEPTION.getErrorCode())); //유저가 아직 모임 서비스를 이용 전이기 때문에
   }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -1,5 +1,7 @@
 package org.sopt.makers.crew.main.meeting.v2.service;
 
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.NO_CONTENT_EXCEPTION;
+
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
@@ -7,6 +9,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import org.sopt.makers.crew.main.common.exception.NoContentException;
 import org.sopt.makers.crew.main.common.pagination.dto.PageMetaDto;
 import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
 import org.sopt.makers.crew.main.entity.apply.Apply;
@@ -52,6 +55,10 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
             meeting.getMStartDate(), meeting.getMEndDate(), checkActivityStatus(meeting)))
         .sorted(Comparator.comparing(MeetingV2GetAllMeetingByOrgUserMeetingDto::getId).reversed())
         .collect(Collectors.toList());
+
+    if (userJoinedList.isEmpty()) {
+      throw new NoContentException(NO_CONTENT_EXCEPTION.getErrorCode());
+    }
 
     List<MeetingV2GetAllMeetingByOrgUserMeetingDto> pagedUserJoinedList =
         userJoinedList.stream().skip((long) (page - 1) * take) // 스킵할 아이템 수 계산


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 플그 마이페이지 내 모임 조회 API에서 크루 DB에 등록되지 않은 orgUserId로 쿼리 넣어서 요청하면 401 에러가 발생했었습니다.
- 하지만 유저가 회원가입 직후라면 크루 DB에 등록되기 전인 것이 당연한 시나리오기 때문에, 401 에러가 아니라 204 No Content 에러를 던지도록 수정하였습니다. 

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- closed #132 
