### PR TITLE
[FEAT] 인터셉터 활용한 로깅 구현

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -59,7 +59,8 @@ dependencies {
     testImplementation 'org.testcontainers:jdbc'           // DB와의 JDBC connection
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
 
-
+    // aop
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/main/src/main/java/org/sopt/makers/crew/main/MainApplication.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/MainApplication.java
@@ -2,8 +2,10 @@ package org.sopt.makers.crew.main;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
 @SpringBootApplication
+@EnableAspectJAutoProxy
 public class MainApplication {
 
 	public static void main(String[] args) {

--- a/main/src/main/java/org/sopt/makers/crew/main/common/aop/ExecutionLoggingAop.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/aop/ExecutionLoggingAop.java
@@ -1,0 +1,71 @@
+package org.sopt.makers.crew.main.common.aop;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.security.Principal;
+import java.util.Objects;
+import lombok.extern.log4j.Log4j2;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.sopt.makers.crew.main.common.util.UserUtil;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Component
+@Log4j2
+public class ExecutionLoggingAop {
+
+    // 모든 패키지 내의 controller package에 존재하는 클래스
+    @Around("execution(* org.sopt.makers.crew..*Controller.*(..))")
+    public Object logExecutionTrace(ProceedingJoinPoint pjp) throws Throwable {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        RequestMethod httpMethod = RequestMethod.valueOf(request.getMethod());
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Integer userId = (Integer) authentication.getPrincipal();
+
+        String className = pjp.getSignature().getDeclaringType().getSimpleName();
+        String methodName = pjp.getSignature().getName();
+        String task = className + "." + methodName;
+
+        log.info("[Call Method] " + httpMethod.toString() + ": " + task + " | Request userId=" + userId.toString());
+
+        Object[] paramArgs = pjp.getArgs();
+        for (Object object : paramArgs) {
+            if (Objects.nonNull(object)) {
+                log.info("[parameter type] {}", object.getClass().getSimpleName());
+                log.info("[parameter value] {}", object);
+            }
+        }
+
+        // 해당 클래스 처리 전의 시간
+        StopWatch sw = new StopWatch();
+        sw.start();
+
+        Object result = null;
+
+        // 해당 클래스의 메소드 실행
+        try{
+            result = pjp.proceed();
+        }
+        catch (Exception e){
+            log.warn("[ERROR] " + task + " 메서드 예외 발생 : " + e.getMessage());
+            throw e;
+        }
+
+        // 해당 클래스 처리 후의 시간
+        sw.stop();
+        long executionTime = sw.getTotalTimeMillis();
+
+        log.info("[ExecutionTime] " + task + " --> " + executionTime + " (ms)");
+
+        return result;
+    }
+
+}

--- a/main/src/main/resources/console-appender.xml
+++ b/main/src/main/resources/console-appender.xml
@@ -1,0 +1,8 @@
+<included>
+    <appender name="CONSOLE"
+              class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/main/src/main/resources/logback-spring.xml
+++ b/main/src/main/resources/logback-spring.xml
@@ -1,0 +1,28 @@
+<configuration>
+    <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
+    <property name="LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+
+    <springProfile name="local">
+        <include resource="console-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="dev">
+        <include resource="console-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <include resource="console-appender.xml"/>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
1. AOP 를 사용하여 인터셉터를 만들었습니다!
2. 로깅정보는 다음과 같습니다!
* 요청한 컨트롤러 메서드 종류
* 요청 파라미터, request body
* 요청한 userId
* API 실행시간

3. 로그 레벨은 5단계 중, INFO 이상으로 콘솔 출력만 하고 있습니다!

참고자료 : 
https://tecoble.techcourse.co.kr/post/2021-08-07-logback-tutorial
https://livenow14.tistory.com/64
https://jojoldu.tistory.com/773

<img width="1392" alt="스크린샷 2024-04-17 오후 11 31 49" src="https://github.com/sopt-makers/sopt-crew-backend/assets/100754581/21c74398-bb5c-489f-b12d-99af2b9b1bfe">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 컨테이너가 배포시 이전 컨테이너는 삭제되기 때문에 이전 로그파일을 볼 수 없다는 단점이 있습니다!
- 그래서 도커와 EC2간의 볼륨을 마운트하여 도커 로깅 파일을 영구적으로 저장 + 날짜 지나면 자동삭제로 구현하려고 했습니다
- 하지만 아직 인프라 작업중이기도 하고, 혹시나 1차 행사에 문제가 될까봐 조금은 방어적으로 구현했습니다..!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- closed #165
