### PR TITLE
[FEAT] 모임생성 API 마이그레이션

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -61,6 +61,10 @@ dependencies {
 
     // aop
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+    // MapStruct
+    implementation 'org.mapstruct:mapstruct:1.5.3.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
 }
 
 tasks.named('test') {

--- a/main/src/main/java/org/sopt/makers/crew/main/common/constant/CrewConst.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/constant/CrewConst.java
@@ -1,0 +1,15 @@
+package org.sopt.makers.crew.main.common.constant;
+
+public abstract class CrewConst {
+
+    /**
+     * 매 기수 시작하기 전에 수정 필요
+     * */
+    public final static Integer ACTIVE_GENERATION = 34;
+
+    public final static String DAY_START_TIME = " 00:00:00";
+    public final static String DAY_END_TIME = " 23:59:59";
+
+    public final static String DAY_FORMAT = "yyyy.MM.dd";
+    public final static String DAY_TIME_FORMAT = "yyyy.MM.dd HH:mm:ss";
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/common/response/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/response/ErrorStatus.java
@@ -15,7 +15,7 @@ public enum ErrorStatus {
   /**
    * 400 BAD_REQUEST
    */
-  VALIDATION_EXCEPTION("CR-001"), // errorCode는 예시, 추후 변경 예정 -> 잘못된 요청입니다.
+  VALIDATION_EXCEPTION("CF-001"),
   VALIDATION_REQUEST_MISSING_EXCEPTION("요청값이 입력되지 않았습니다."),
   NOT_FOUND_MEETING("모임이 없습니다."),
   NOT_FOUND_POST("존재하지 않는 게시글입니다."),

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/enums/MeetingCategory.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/enums/MeetingCategory.java
@@ -4,27 +4,25 @@ import java.util.Arrays;
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
 
 public enum MeetingCategory {
-  STUDY("스터디"),
+    STUDY("스터디"),
+    LECTURE("강연"),
+    LIGHTNING("번개"),
+    EVENT("행사"),
+    SEMINAR("세미나");
 
-  LECTURE("강연"),
+    private final String value;
 
-  LIGHTNING("번개"),
+    MeetingCategory(String value) {
+        this.value = value;
+    }
 
-  EVENT("행사");
+    public static MeetingCategory ofValue(String dbData) {
+        return Arrays.stream(MeetingCategory.values()).filter(v -> v.getValue().equals(dbData))
+                .findFirst().orElseThrow(() -> new BadRequestException(
+                        String.format("MeetingCategory 클래스에 value = [%s] 값을 가진 enum 객체가 없습니다.", dbData)));
+    }
 
-  private final String value;
-
-  MeetingCategory(String value) {
-    this.value = value;
-  }
-
-  public static MeetingCategory ofValue(String dbData) {
-    return Arrays.stream(MeetingCategory.values()).filter(v -> v.getValue().equals(dbData))
-        .findFirst().orElseThrow(() -> new BadRequestException(
-            String.format("MeetingCategory 클래스에 value = [%s] 값을 가진 enum 객체가 없습니다.", dbData)));
-  }
-
-  public String getValue() {
-    return value;
-  }
+    public String getValue() {
+        return value;
+    }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -1,0 +1,47 @@
+package org.sopt.makers.crew.main.meeting.v2;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.security.Principal;
+import java.util.List;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+
+
+@Tag(name = "모임")
+public interface MeetingV2Api {
+    @Operation(summary = "플레이그라운드 마이페이지 내 모임 정보 조회")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "성공")})
+    @Parameters({@Parameter(name = "page", description = "페이지, default = 1", example = "1"),
+            @Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50"),
+            @Parameter(name = "orgUserId", description = "플레이그라운드 유저 id", example = "0")})
+    ResponseEntity<MeetingV2GetAllMeetingByOrgUserDto> getAllMeetingByOrgUser(
+            @ModelAttribute @Parameter(hidden = true) MeetingV2GetAllMeetingByOrgUserQueryDto queryDto);
+
+    @Operation(summary = "모임 둘러보기 조회")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "204", description = "모임이 없습니다.", content = @Content),})
+    ResponseEntity<List<MeetingV2GetMeetingBannerResponseDto>> getMeetingBanner(
+            Principal principal);
+
+    @Operation(summary = "모임 생성")
+    @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "\"이미지 파일이 없습니다.\" or \"한 개 이상의 파트를 입력해주세요\" or \"프로필을 입력해주세요\"", content = @Content),})
+    ResponseEntity<MeetingV2CreateMeetingResponseDto> createMeeting(@Valid @RequestBody MeetingV2CreateMeetingBodyDto requestBody,
+                                                                    Principal principal);
+
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -1,17 +1,14 @@
 package org.sopt.makers.crew.main.meeting.v2;
 
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.crew.main.common.util.UserUtil;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.service.MeetingV2Service;
@@ -19,6 +16,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,31 +25,34 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/meeting/v2")
 @RequiredArgsConstructor
-@Tag(name = "모임")
-public class MeetingV2Controller {
+public class MeetingV2Controller implements MeetingV2Api {
 
   private final MeetingV2Service meetingV2Service;
 
-  @Operation(summary = "플레이그라운드 마이페이지 내 모임 정보 조회")
+  @Override
   @GetMapping("/org-user")
   @ResponseStatus(HttpStatus.OK)
-  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "성공")})
-  @Parameters({@Parameter(name = "page", description = "페이지, default = 1", example = "1"),
-      @Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50"),
-      @Parameter(name = "orgUserId", description = "플레이그라운드 유저 id", example = "0")})
   public ResponseEntity<MeetingV2GetAllMeetingByOrgUserDto> getAllMeetingByOrgUser(
       @ModelAttribute @Parameter(hidden = true) MeetingV2GetAllMeetingByOrgUserQueryDto queryDto) {
     return ResponseEntity.ok(meetingV2Service.getAllMeetingByOrgUser(queryDto));
   }
 
-  @Operation(summary = "모임 둘러보기 조회")
+  @Override
   @GetMapping("/banner")
   @ResponseStatus(HttpStatus.OK)
-  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "204", description = "모임이 없습니다.", content = @Content),})
   public ResponseEntity<List<MeetingV2GetMeetingBannerResponseDto>> getMeetingBanner(
       Principal principal) {
     UserUtil.getUserId(principal);
     return ResponseEntity.ok(meetingV2Service.getMeetingBanner());
   }
+
+  @Override
+  @PostMapping
+  public ResponseEntity<MeetingV2CreateMeetingResponseDto> createMeeting(@Valid @RequestBody MeetingV2CreateMeetingBodyDto requestBody,
+                                                                         Principal principal) {
+    Integer userId = UserUtil.getUserId(principal);
+    return ResponseEntity.status(HttpStatus.CREATED).body(meetingV2Service.createMeeting(requestBody, userId));
+  }
+
+
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/MeetingMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/MeetingMapper.java
@@ -1,0 +1,56 @@
+package org.sopt.makers.crew.main.meeting.v2.dto;
+
+import static org.sopt.makers.crew.main.common.constant.CrewConst.DAY_END_TIME;
+import static org.sopt.makers.crew.main.common.constant.CrewConst.DAY_START_TIME;
+import static org.sopt.makers.crew.main.common.constant.CrewConst.DAY_TIME_FORMAT;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
+import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+
+@Mapper(componentModel = "spring")
+public interface MeetingMapper {
+
+    @Mapping(source = "requestBody.files", target = "imageURL", qualifiedByName = "getImageURL")
+    @Mapping(source = "requestBody.category", target = "category", qualifiedByName = "getCategory")
+    @Mapping(source = "requestBody.startDate", target = "startDate", qualifiedByName = "getStartDate")
+    @Mapping(source = "requestBody.endDate", target = "endDate", qualifiedByName = "getEndDate")
+    @Mapping(source = "requestBody.mStartDate", target = "mStartDate", qualifiedByName = "getStartDate")
+    @Mapping(source = "requestBody.mEndDate", target = "mEndDate", qualifiedByName = "getEndDate")
+    Meeting toMeetingEntity(MeetingV2CreateMeetingBodyDto requestBody, Integer targetActiveGeneration,
+                            Integer createdGeneration, User user, Integer userId);
+
+    @Named("getImageURL")
+    static List<ImageUrlVO> getImageURL(List<String> files) {
+        AtomicInteger index = new AtomicInteger(0);
+
+        return files.stream()
+                .map(url -> new ImageUrlVO(index.getAndIncrement(), url))
+                .toList();
+    }
+
+    @Named("getCategory")
+    static MeetingCategory getCategory(String category) {
+        return MeetingCategory.ofValue(category);
+    }
+
+    @Named("getStartDate")
+    static LocalDateTime getStartDate(String date) {
+        return LocalDateTime.parse(date + DAY_START_TIME, DateTimeFormatter.ofPattern(DAY_TIME_FORMAT));
+    }
+
+    @Named("getEndDate")
+    static LocalDateTime getEndDate(String date) {
+        return LocalDateTime.parse(date + DAY_END_TIME, DateTimeFormatter.ofPattern(DAY_TIME_FORMAT));
+
+    }
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/MeetingV2CreateMeetingBodyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/MeetingV2CreateMeetingBodyDto.java
@@ -1,0 +1,93 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "모임 생성 request body dto")
+public class MeetingV2CreateMeetingBodyDto {
+
+    @Schema(example = "알고보면 쓸데있는 개발 프로세스", description = "모임 제목")
+    @NotNull
+    private String title;
+
+    @Schema(example = "[\n"
+            + "    \"https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2023/04/12/7bd87736-b557-4b26-a0d5-9b09f1f1d7df\"\n"
+            + "  ]", description = "모임 이미지 리스트, 최대 6개")
+    @NotEmpty
+    @Size(max=6)
+    private List<String> files;
+
+    @Schema(example = "스터디", description = "모임 카테고리")
+    @NotNull
+    private String category;
+
+    @Schema(example = "2022.10.08", description = "모집 기간 시작 날짜")
+    @NotNull
+    private String startDate;
+
+    @Schema(example = "2022.10.09", description = "모집 기간 끝 날짜")
+    @NotNull
+    private String endDate;
+
+    @Schema(example = "5", description = "모집 인원")
+    @NotNull
+    private Integer capacity;
+
+    @Schema(example = "api 가 터졌다고? 깃이 터졌다고?", description = "모집 정보")
+    @NotNull
+    private String desc;
+
+    @Schema(example = "소요 시간 : 1시간 예상", description = "진행 방식 소개")
+    @NotNull
+    private String processDesc;
+
+    @Schema(example = "2022.10.29", description = "모임 활동 시작 날짜", name = "mStartDate")
+    @NotNull
+    private String mStartDate;
+
+    @Schema(example = "2022.10.30", description = "모임 활동 종료 날짜", name = "mEndDate")
+    @NotNull
+    private String mEndDate;
+
+    @Schema(example = "안녕하세요 기획 파트 000입니다", description = "개설자 소개")
+    @NotNull
+    private String leaderDesc;
+
+    @Schema(example = "개발 모르는 사람도 환영", description = "모집 대상 소개")
+    @NotNull
+    private String targetDesc;
+
+    @Schema(example = "유의할 사항", description = "유의할 사항")
+    private String note;
+
+    @Schema(example = "false", description = "멘토 필요 여부")
+    @NotNull
+    private Boolean isMentorNeeded;
+
+    @Schema(example = "false", description = "활동기수만 지원 가능 여부")
+    @NotNull
+    private Boolean canJoinOnlyActiveGeneration;
+
+    @Schema(example = "[\n"
+            + "    \"ANDROID\",\n"
+            + "    \"IOS\"\n"
+            + "  ]", description = "대상 파트 목록")
+    @NotNull
+    private MeetingJoinablePart[] joinableParts;
+
+    public String getmStartDate() {
+        return mStartDate;
+    }
+
+    public String getmEndDate() {
+        return mEndDate;
+    }
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2CreateMeetingResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2CreateMeetingResponseDto.java
@@ -1,0 +1,10 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class MeetingV2CreateMeetingResponseDto {
+    private Integer meetingId;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -2,13 +2,17 @@ package org.sopt.makers.crew.main.meeting.v2.service;
 
 import java.util.List;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
 
 public interface MeetingV2Service {
 
-  MeetingV2GetAllMeetingByOrgUserDto getAllMeetingByOrgUser(
+    MeetingV2GetAllMeetingByOrgUserDto getAllMeetingByOrgUser(
       MeetingV2GetAllMeetingByOrgUserQueryDto queryDto);
 
-  List<MeetingV2GetMeetingBannerResponseDto> getMeetingBanner();
+    List<MeetingV2GetMeetingBannerResponseDto> getMeetingBanner();
+
+    MeetingV2CreateMeetingResponseDto createMeeting(MeetingV2CreateMeetingBodyDto requestBody, Integer userId);
 }

--- a/server/src/entity/meeting/enum/meeting-category.enum.ts
+++ b/server/src/entity/meeting/enum/meeting-category.enum.ts
@@ -3,4 +3,5 @@ export enum MeetingCategory {
   LECTURE = '강연',
   LIGHTNING = '번개',
   EVENT = '행사',
+  SEMINAR = '세미나',
 }


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 모임생성 API 마이그레이션 했습니다.
- dev db에도 저장해봤는데 "SP1 세미나 테스트"라는 모임을 만들어 봤습니다. (기존에 저장된 방식이랑 크게 다르지 않은지, 크게 문제가 없을지 더블체크 해주시면 감사할 것 같습니다..!)
- 최대한 기존 스펙에 어긋나지 않게 구현하려고 했고, 클라 입장에서 수정할게 없게끔 구현했습니다.
- SP1 관련해서 Enum에 세미나도 추가했습니다.
- 테스트 코드는 추가해서 다시 언급드리겠습니다.


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
### 시간데이터 관련
- 시간 데이터 관련해서 `LocalDateTime`으로 되어있는데요! 기존 db에는 ms까지 적혀있어서 `ZonedDateTime`으로 해야할까 고민입니다! (종료 날짜를 자세히 보면 ms가 현재 구현된 방식으론 0으로 되어있는 반면, 기존 저장된 데이터는 ms가 999로 되어있습니다!)

### 스웨거 관련
- 기존 코드에서는 스웨거 관련된 코드가 비즈니스 로직과 혼재되어 있다는 생각이 들었습니다.
- 그래서 `MeetingApi` 인터페이스로 스웨거 관련된 내용을 따로 뺐고, 이를 컨트롤러에서 `implements` 했는데 의견 궁금합니다!

### MapStruct
- 저는 개인적으로 Dto-엔티티 변환해줄 때 MapSturct를 선호해서 사용해봤습니다! 이에 대한 의견도 궁금합니다
- 참고링크 : https://medium.com/naver-cloud-platform/%EA%B8%B0%EC%88%A0-%EC%BB%A8%ED%85%90%EC%B8%A0-%EB%AC%B8%EC%9E%90-%EC%95%8C%EB%A6%BC-%EB%B0%9C%EC%86%A1-%EC%84%9C%EB%B9%84%EC%8A%A4-sens%EC%9D%98-mapstruct-%EC%A0%81%EC%9A%A9%EA%B8%B0-8fd2bc2bc33b

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- closed #169
