### PR TITLE
[FIX] 익명 유저 처리를 위한 수정

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/common/aop/ExecutionLoggingAop.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/aop/ExecutionLoggingAop.java
@@ -28,13 +28,13 @@ public class ExecutionLoggingAop {
         RequestMethod httpMethod = RequestMethod.valueOf(request.getMethod());
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Integer userId = (Integer) authentication.getPrincipal();
+        Object userId = authentication.getPrincipal().toString();
 
         String className = pjp.getSignature().getDeclaringType().getSimpleName();
         String methodName = pjp.getSignature().getName();
         String task = className + "." + methodName;
 
-        log.info("[Call Method] " + httpMethod.toString() + ": " + task + " | Request userId=" + userId.toString());
+        log.info("[Call Method] " + httpMethod.toString() + ": " + task + " | Request userId=" + userId);
 
         Object[] paramArgs = pjp.getArgs();
         for (Object object : paramArgs) {


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 저희 서비스는 모든 API 요청을 위해선 토큰이 필요한 줄 알았는데 그게 아니었습니다 !
- 플그에서 요청하는 "플레이그라운드 마이페이지 내 모임 정보 조회 API" 한에서는 플그에서 토큰없이 요청을 하고 있더라고요!
- 그래서 제가 며칠전에 구현한 로깅 인터셉터에서는 무조건 토큰을 가지고 요청하기에 `principle`이 항상 존재한다고 생각해서 구현을 했었는데요!
- 인터셉터에서 익명유저 요청(토큰없이 요청)로 요청할 경우 `userId` 를 가지고 올 수 없기 떄문에 에러가 발생하는 것을 확인했습니다!
- 그래서 해당 사항 수정해서 PR 올렸습니다!

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- closed #171
