### PR TITLE
[FEAT] 모임 지원 신청/취소 API 마이그레이션

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/common/response/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/response/ErrorStatus.java
@@ -7,34 +7,41 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public enum ErrorStatus {
-  /**
-   * 204 NO_CONTENT
-   */
-  NO_CONTENT_EXCEPTION("참여한 모임이 없습니다."),
+    /**
+     * 204 NO_CONTENT
+     */
+    NO_CONTENT_EXCEPTION("참여한 모임이 없습니다."),
 
-  /**
-   * 400 BAD_REQUEST
-   */
-  VALIDATION_EXCEPTION("CF-001"),
-  VALIDATION_REQUEST_MISSING_EXCEPTION("요청값이 입력되지 않았습니다."),
-  NOT_FOUND_MEETING("모임이 없습니다."),
-  NOT_FOUND_POST("존재하지 않는 게시글입니다."),
+    /**
+     * 400 BAD_REQUEST
+     */
+    VALIDATION_EXCEPTION("CF-001"),
+    VALIDATION_REQUEST_MISSING_EXCEPTION("요청값이 입력되지 않았습니다."),
+    NOT_FOUND_MEETING("모임이 없습니다."),
+    NOT_FOUND_POST("존재하지 않는 게시글입니다."),
+    FULL_MEETING_CAPACITY("정원이 꽉 찼습니다."),
+    ALREADY_APPLIED_MEETING("이미 지원한 모임입니다."),
+    NOT_IN_APPLY_PERIOD("모임 지원 기간이 아닙니다."),
+    MISSING_GENERATION_PART("기수/파트를 설정해주세요."),
+    NOT_ACTIVE_GENERATION("활동 기수가 아닙니다."),
+    NOT_TARGET_PART("지원 가능한 파트가 아닙니다."),
+    NOT_APPLIED_MEETING("지원한 모임이 아닙니다."),
 
-  /**
-   * 401 UNAUTHORIZED
-   */
-  UNAUTHORIZED_TOKEN("유효하지 않은 토큰입니다."),
+    /**
+     * 401 UNAUTHORIZED
+     */
+    UNAUTHORIZED_TOKEN("유효하지 않은 토큰입니다."),
 
-  /**
-   * 403 FORBIDDEN
-   */
-  FORBIDDEN_EXCEPTION("권한이 없습니다."),
+    /**
+     * 403 FORBIDDEN
+     */
+    FORBIDDEN_EXCEPTION("권한이 없습니다."),
 
-  /**
-   * 500 SERVER_ERROR
-   */
-  INTERNAL_SERVER_ERROR("예상치 못한 서버 에러가 발생했습니다.");
+    /**
+     * 500 SERVER_ERROR
+     */
+    INTERNAL_SERVER_ERROR("예상치 못한 서버 에러가 발생했습니다.");
 
-  private final String errorCode;
+    private final String errorCode;
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/common/response/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/response/ErrorStatus.java
@@ -25,7 +25,7 @@ public enum ErrorStatus {
     MISSING_GENERATION_PART("기수/파트를 설정해주세요."),
     NOT_ACTIVE_GENERATION("활동 기수가 아닙니다."),
     NOT_TARGET_PART("지원 가능한 파트가 아닙니다."),
-    NOT_APPLIED_MEETING("지원한 모임이 아닙니다."),
+    NOT_FOUND_APPLY("존재하지 않는 모임 신청입니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/main/src/main/java/org/sopt/makers/crew/main/common/util/UserPartUtil.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/util/UserPartUtil.java
@@ -1,4 +1,35 @@
 package org.sopt.makers.crew.main.common.util;
 
+import lombok.RequiredArgsConstructor;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.user.enums.UserPart;
+
+@RequiredArgsConstructor
 public class UserPartUtil {
+
+    public static MeetingJoinablePart getMeetingJoinablePart(UserPart userPart) {
+        switch (userPart) {
+            case PM:
+            case PM_LEADER:
+                return MeetingJoinablePart.PM;
+            case DESIGN:
+            case DESIGN_LEADER:
+                return MeetingJoinablePart.DESIGN;
+            case IOS:
+            case IOS_LEADER:
+                return MeetingJoinablePart.IOS;
+            case ANDROID:
+            case ANDROID_LEADER:
+                return MeetingJoinablePart.ANDROID;
+            case SERVER:
+            case SERVER_LEADER:
+                return MeetingJoinablePart.SERVER;
+            case WEB:
+            case WEB_LEADER:
+                return MeetingJoinablePart.WEB;
+            default:
+                // 임원진 등
+                return null;
+        }
+    }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/common/util/UserPartUtil.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/util/UserPartUtil.java
@@ -1,0 +1,4 @@
+package org.sopt.makers.crew.main.common.util;
+
+public class UserPartUtil {
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/Apply.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/Apply.java
@@ -33,76 +33,81 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(name = "apply")
 public class Apply {
 
-  /**
-   * Primary Key
-   */
-  @Id
-  @GeneratedValue(strategy = IDENTITY)
-  private Integer id;
+    /**
+     * Primary Key
+     */
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
 
-  /**
-   * 지원 타입
-   */
-  @Column(name = "type", nullable = false, columnDefinition = "integer default 0")
-  @Convert(converter = ApplyTypeConverter.class)
-  private EnApplyType type;
+    /**
+     * 지원 타입
+     */
+    @Column(name = "type", nullable = false, columnDefinition = "integer default 0")
+    @Convert(converter = ApplyTypeConverter.class)
+    private EnApplyType type;
 
-  /**
-   * 지원한 모임
-   */
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "meetingId", nullable = false)
-  private Meeting meeting;
+    /**
+     * 지원한 모임
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meetingId", nullable = false)
+    private Meeting meeting;
 
-  /**
-   * 지원한 모임 ID
-   */
-  @Column(insertable = false, updatable = false)
-  private Integer meetingId;
+    /**
+     * 지원한 모임 ID
+     */
+    @Column(insertable = false, updatable = false)
+    private Integer meetingId;
 
-  /**
-   * 지원자
-   */
-  @ManyToOne(fetch = FetchType.EAGER)
-  @JoinColumn(name = "userId", nullable = false)
-  private User user;
+    /**
+     * 지원자
+     */
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;
 
-  /**
-   * 지원자 ID
-   */
-  @Column(insertable = false, updatable = false)
-  private Integer userId;
+    /**
+     * 지원자 ID
+     */
+    @Column(insertable = false, updatable = false)
+    private Integer userId;
 
-  /**
-   * 지원 동기
-   */
-  @Column(name = "content", nullable = false)
-  private String content;
+    /**
+     * 지원 동기
+     */
+    @Column(name = "content", nullable = false)
+    private String content;
 
-  /**
-   * 지원한 날짜
-   */
-  @Column(name = "appliedDate", nullable = false, columnDefinition = "TIMESTAMP")
-  @CreatedDate
-  private LocalDateTime appliedDate;
+    /**
+     * 지원한 날짜
+     */
+    @Column(name = "appliedDate", nullable = false, columnDefinition = "TIMESTAMP")
+    @CreatedDate
+    private LocalDateTime appliedDate;
 
-  /**
-   * 지원 상태
-   */
-  @Column(name = "status", nullable = false, columnDefinition = "integer default 0")
-  @Convert(converter = ApplyStatusConverter.class)
-  private EnApplyStatus status;
+    /**
+     * 지원 상태
+     */
+    @Column(name = "status", nullable = false, columnDefinition = "integer default 0")
+    @Convert(converter = ApplyStatusConverter.class)
+    private EnApplyStatus status;
 
-  @Builder
-  public Apply(EnApplyType type, Meeting meeting, Integer meetingId, User user, Integer userId,
-      String content, EnApplyStatus status) {
-    this.type = type;
-    this.meeting = meeting;
-    this.meetingId = meetingId;
-    this.user = user;
-    this.userId = userId;
-    this.content = content;
-    this.appliedDate = LocalDateTime.now();
-    this.status = status;
-  }
+    @Builder
+    public Apply(EnApplyType type, Meeting meeting, Integer meetingId, User user, Integer userId,
+                 String content) {
+        this.type = type;
+        this.meeting = meeting;
+        this.meetingId = meetingId;
+        this.user = user;
+        this.userId = userId;
+        this.content = content;
+        this.appliedDate = LocalDateTime.now();
+        this.status = EnApplyStatus.WAITING;
+        this.meeting.addApply(this);
+    }
+
+    public void updateApplyStatus(EnApplyStatus status) {
+        this.status = status;
+    }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/Apply.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/Apply.java
@@ -63,7 +63,7 @@ public class Apply {
     /**
      * 지원자
      */
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId", nullable = false)
     private User user;
 

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
@@ -1,6 +1,10 @@
 package org.sopt.makers.crew.main.entity.apply;
 
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.NOT_FOUND_APPLY;
+
 import java.util.List;
+import java.util.Optional;
+import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -8,10 +12,17 @@ import org.springframework.data.repository.query.Param;
 
 public interface ApplyRepository extends JpaRepository<Apply, Integer> {
 
-  @Query("select a from Apply a join fetch a.meeting m where a.userId = :userId and a.status = :statusValue")
-  List<Apply> findAllByUserIdAndStatus(@Param("userId") Integer userId,
-      @Param("statusValue") EnApplyStatus statusValue);
+    @Query("select a from Apply a join fetch a.meeting m where a.userId = :userId and a.status = :statusValue")
+    List<Apply> findAllByUserIdAndStatus(@Param("userId") Integer userId,
+                                         @Param("statusValue") EnApplyStatus statusValue);
 
-  List<Apply> findAllByMeetingIdAndStatus(Integer meetingId, EnApplyStatus statusValue);
+    List<Apply> findAllByMeetingIdAndStatus(Integer meetingId, EnApplyStatus statusValue);
+
+    Optional<Apply> findById(Integer applyId);
+
+    default Apply findByIdOrThrow(Integer applyId) {
+        return findById(applyId)
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_APPLY.getErrorCode()));
+    }
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -17,15 +17,14 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
-import org.hibernate.type.SqlTypes;
 import org.sopt.makers.crew.main.entity.apply.Apply;
 import org.sopt.makers.crew.main.entity.meeting.converter.MeetingCategoryConverter;
 import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
@@ -43,200 +42,200 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(name = "meeting")
 public class Meeting {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Integer id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
 
-  /**
-   * 개설한 유저
-   */
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "userId", nullable = false)
-  private User user;
+    /**
+     * 개설한 유저
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;
 
-  /**
-   * 유저 id
-   */
-  @Column(insertable = false, updatable = false)
-  private Integer userId;
+    /**
+     * 유저 id
+     */
+    @Column(insertable = false, updatable = false)
+    private Integer userId;
 
-  /**
-   * 지원 or 초대 정보
-   */
-  @OneToMany(mappedBy = "meeting", cascade = CascadeType.REMOVE)
-  private List<Apply> appliedInfo;
+    /**
+     * 지원 or 초대 정보
+     */
+    @OneToMany(mappedBy = "meeting", cascade = CascadeType.REMOVE)
+    private List<Apply> appliedInfo;
 
-  /**
-   * 모임 제목
-   */
-  @Column(nullable = false)
-  private String title;
+    /**
+     * 모임 제목
+     */
+    @Column(nullable = false)
+    private String title;
 
-  /**
-   * 모임 카테고리
-   */
-  @Column(name = "category", nullable = false)
-  @Convert(converter = MeetingCategoryConverter.class)
-  private MeetingCategory category;
+    /**
+     * 모임 카테고리
+     */
+    @Column(name = "category", nullable = false)
+    @Convert(converter = MeetingCategoryConverter.class)
+    private MeetingCategory category;
 
-  /**
-   * 이미지
-   */
-  @Column(name = "imageURL",columnDefinition = "jsonb")
-  @Type(JsonBinaryType.class)
-  //@JdbcTypeCode(SqlTypes.JSON)
-  private List<ImageUrlVO> imageURL;
+    /**
+     * 이미지
+     */
+    @Column(name = "imageURL", columnDefinition = "jsonb")
+    @Type(JsonBinaryType.class)
+    //@JdbcTypeCode(SqlTypes.JSON)
+    private List<ImageUrlVO> imageURL;
 
-  /**
-   * 모집 시작 기간
-   */
-  @Column(name = "startDate", nullable = false, columnDefinition = "TIMESTAMP")
-  private LocalDateTime startDate;
+    /**
+     * 모집 시작 기간
+     */
+    @Column(name = "startDate", nullable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime startDate;
 
-  /**
-   * 모집 마감 기간
-   */
-  @Column(name = "endDate", nullable = false, columnDefinition = "TIMESTAMP")
-  private LocalDateTime endDate;
+    /**
+     * 모집 마감 기간
+     */
+    @Column(name = "endDate", nullable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime endDate;
 
-  /**
-   * 모집 인원
-   */
-  @Column(name = "capacity", nullable = false)
-  private Integer capacity;
+    /**
+     * 모집 인원
+     */
+    @Column(name = "capacity", nullable = false)
+    private Integer capacity;
 
-  /**
-   * 모임 소개
-   */
-  @Column(name = "desc", nullable = false)
-  private String desc;
+    /**
+     * 모임 소개
+     */
+    @Column(name = "desc", nullable = false)
+    private String desc;
 
-  /**
-   * 진행방식 소개
-   */
-  @Column(name = "processDesc", nullable = false)
-  private String processDesc;
+    /**
+     * 진행방식 소개
+     */
+    @Column(name = "processDesc", nullable = false)
+    private String processDesc;
 
-  /**
-   * 모임 시작 기간
-   */
-  @Column(name = "mStartDate", nullable = false, columnDefinition = "TIMESTAMP")
-  private LocalDateTime mStartDate;
+    /**
+     * 모임 시작 기간
+     */
+    @Column(name = "mStartDate", nullable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime mStartDate;
 
-  /**
-   * 모임 마감 기간
-   */
-  @Column(name = "mEndDate", nullable = false, columnDefinition = "TIMESTAMP")
-  private LocalDateTime mEndDate;
+    /**
+     * 모임 마감 기간
+     */
+    @Column(name = "mEndDate", nullable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime mEndDate;
 
-  /**
-   * 개설자 소개
-   */
-  @Column(name = "leaderDesc", nullable = false)
-  private String leaderDesc;
+    /**
+     * 개설자 소개
+     */
+    @Column(name = "leaderDesc", nullable = false)
+    private String leaderDesc;
 
-  /**
-   * 모집 대상
-   */
-  @Column(name = "targetDesc", nullable = false)
-  private String targetDesc;
+    /**
+     * 모집 대상
+     */
+    @Column(name = "targetDesc", nullable = false)
+    private String targetDesc;
 
-  /**
-   * 유의 사항
-   */
-  @Column(name = "note")
-  private String note;
+    /**
+     * 유의 사항
+     */
+    @Column(name = "note")
+    private String note;
 
-  /**
-   * 멘토 필요 여부
-   */
-  @Column(name = "isMentorNeeded", nullable = false)
-  private Boolean isMentorNeeded;
+    /**
+     * 멘토 필요 여부
+     */
+    @Column(name = "isMentorNeeded", nullable = false)
+    private Boolean isMentorNeeded;
 
-  /**
-   * 활동 기수만 참여 가능한지 여부
-   */
-  @Column(name = "canJoinOnlyActiveGeneration", nullable = false)
-  private Boolean canJoinOnlyActiveGeneration;
+    /**
+     * 활동 기수만 참여 가능한지 여부
+     */
+    @Column(name = "canJoinOnlyActiveGeneration", nullable = false)
+    private Boolean canJoinOnlyActiveGeneration;
 
-  /**
-   * 모임 기수
-   */
-  @Column(name = "createdGeneration", nullable = false)
-  private Integer createdGeneration;
+    /**
+     * 모임 기수
+     */
+    @Column(name = "createdGeneration", nullable = false)
+    private Integer createdGeneration;
 
-  /**
-   * 대상 활동 기수
-   */
-  @Column(name = "targetActiveGeneration")
-  private Integer targetActiveGeneration;
+    /**
+     * 대상 활동 기수
+     */
+    @Column(name = "targetActiveGeneration")
+    private Integer targetActiveGeneration;
 
-  /**
-   * 모임 참여 가능한 파트
-   */
-  @Type(value = EnumArrayType.class,
-      parameters = @Parameter(name = AbstractArrayType.SQL_ARRAY_TYPE,
-          value = "meeting_joinableparts_enum"))
-  @Column(name = "joinableParts", columnDefinition = "meeting_joinableparts_enum[]")
-  private MeetingJoinablePart[] joinableParts;
+    /**
+     * 모임 참여 가능한 파트
+     */
+    @Type(value = EnumArrayType.class,
+            parameters = @Parameter(name = AbstractArrayType.SQL_ARRAY_TYPE,
+                    value = "meeting_joinableparts_enum"))
+    @Column(name = "joinableParts", columnDefinition = "meeting_joinableparts_enum[]")
+    private MeetingJoinablePart[] joinableParts;
 
-  /**
-   * 게시글 리스트
-   */
-  @OneToMany(mappedBy = "meeting", cascade = CascadeType.REMOVE)
-  private List<Post> posts;
+    /**
+     * 게시글 리스트
+     */
+    @OneToMany(mappedBy = "meeting", cascade = CascadeType.REMOVE)
+    private List<Post> posts;
 
-  @Builder
-  public Meeting(User user, Integer userId, List<Apply> appliedInfo, String title, MeetingCategory category,
-      List<ImageUrlVO> imageURL, LocalDateTime startDate, LocalDateTime endDate, Integer capacity,
-      String desc, String processDesc, LocalDateTime mStartDate, LocalDateTime mEndDate,
-      String leaderDesc, String targetDesc, String note, Boolean isMentorNeeded,
-      Boolean canJoinOnlyActiveGeneration, Integer createdGeneration,
-      Integer targetActiveGeneration, MeetingJoinablePart[] joinableParts) {
-    this.user = user;
-    this.userId = userId;
-    this.appliedInfo = appliedInfo;
-    this.title = title;
-    this.category = category;
-    this.imageURL = imageURL;
-    this.startDate = startDate;
-    this.endDate = endDate;
-    this.capacity = capacity;
-    this.desc = desc;
-    this.processDesc = processDesc;
-    this.mStartDate = mStartDate;
-    this.mEndDate = mEndDate;
-    this.leaderDesc = leaderDesc;
-    this.targetDesc = targetDesc;
-    this.note = note;
-    this.isMentorNeeded = isMentorNeeded;
-    this.canJoinOnlyActiveGeneration = canJoinOnlyActiveGeneration;
-    this.createdGeneration = createdGeneration;
-    this.targetActiveGeneration = targetActiveGeneration;
-    this.joinableParts = joinableParts;
-  }
-
-  public void addApply(Apply apply) {
-    appliedInfo.add(apply);
-  }
-
-  public void addPost(Post post) {
-    posts.add(post);
-  }
-
-  /**
-   * 모임 모집상태 확인
-   * 
-   * @return 모임 모집상태
-   */
-  public Integer getMeetingStatus() {
-    LocalDateTime now = LocalDateTime.now();
-    if (now.isBefore(startDate)) {
-      return EnMeetingStatus.BEFORE_START.getValue();
-    } else if (now.isBefore(endDate)) {
-      return EnMeetingStatus.APPLY_ABLE.getValue();
-    } else {
-      return EnMeetingStatus.RECRUITMENT_COMPLETE.getValue();
+    @Builder
+    public Meeting(User user, Integer userId, List<Apply> appliedInfo, String title, MeetingCategory category,
+                   List<ImageUrlVO> imageURL, LocalDateTime startDate, LocalDateTime endDate, Integer capacity,
+                   String desc, String processDesc, LocalDateTime mStartDate, LocalDateTime mEndDate,
+                   String leaderDesc, String targetDesc, String note, Boolean isMentorNeeded,
+                   Boolean canJoinOnlyActiveGeneration, Integer createdGeneration,
+                   Integer targetActiveGeneration, MeetingJoinablePart[] joinableParts) {
+        this.user = user;
+        this.userId = userId;
+        this.appliedInfo = appliedInfo != null ? appliedInfo : new ArrayList<>();
+        this.title = title;
+        this.category = category;
+        this.imageURL = imageURL;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.capacity = capacity;
+        this.desc = desc;
+        this.processDesc = processDesc;
+        this.mStartDate = mStartDate;
+        this.mEndDate = mEndDate;
+        this.leaderDesc = leaderDesc;
+        this.targetDesc = targetDesc;
+        this.note = note;
+        this.isMentorNeeded = isMentorNeeded;
+        this.canJoinOnlyActiveGeneration = canJoinOnlyActiveGeneration;
+        this.createdGeneration = createdGeneration;
+        this.targetActiveGeneration = targetActiveGeneration;
+        this.joinableParts = joinableParts;
     }
-  }
+
+    public void addApply(Apply apply) {
+        appliedInfo.add(apply);
+    }
+
+    public void addPost(Post post) {
+        posts.add(post);
+    }
+
+    /**
+     * 모임 모집상태 확인
+     *
+     * @return 모임 모집상태
+     */
+    public Integer getMeetingStatus() {
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isBefore(startDate)) {
+            return EnMeetingStatus.BEFORE_START.getValue();
+        } else if (now.isBefore(endDate)) {
+            return EnMeetingStatus.APPLY_ABLE.getValue();
+        } else {
+            return EnMeetingStatus.RECRUITMENT_COMPLETE.getValue();
+        }
+    }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -41,14 +41,16 @@ public interface MeetingV2Api {
     @Operation(summary = "모임 생성")
     @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "성공"),
             @ApiResponse(responseCode = "400", description = "\"이미지 파일이 없습니다.\" or \"한 개 이상의 파트를 입력해주세요\" or \"프로필을 입력해주세요\"", content = @Content),})
-    ResponseEntity<MeetingV2CreateMeetingResponseDto> createMeeting(@Valid @RequestBody MeetingV2CreateMeetingBodyDto requestBody,
-                                                                    Principal principal);
+    ResponseEntity<MeetingV2CreateMeetingResponseDto> createMeeting(
+            @Valid @RequestBody MeetingV2CreateMeetingBodyDto requestBody,
+            Principal principal);
 
     @Operation(summary = "모임 지원")
     @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "지원 완료"),
-            @ApiResponse(responseCode = "400", description = "\"모임이 없습니다\" or \"기수/파트를 설정해주세요\" or \"정원이 꽉찼습니다\" or \"활동 기수가 아닙니다\" " +
-                    "or \"지원 가능한 파트가 아닙니다\" or \"지원 가능한 기간이 아닙니다\"", content = @Content),})
-    ResponseEntity applyMeeting(@RequestBody MeetingV2ApplyMeetingDto requestBody, Principal principal);
+            @ApiResponse(responseCode = "400", description =
+                    "\"모임이 없습니다\" or \"기수/파트를 설정해주세요\" or \"정원이 꽉찼습니다\" or \"활동 기수가 아닙니다\" " +
+                            "or \"지원 가능한 파트가 아닙니다\" or \"지원 가능한 기간이 아닙니다\"", content = @Content),})
+    ResponseEntity<Void> applyMeeting(@RequestBody MeetingV2ApplyMeetingDto requestBody, Principal principal);
 
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.List;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
@@ -42,6 +43,12 @@ public interface MeetingV2Api {
             @ApiResponse(responseCode = "400", description = "\"이미지 파일이 없습니다.\" or \"한 개 이상의 파트를 입력해주세요\" or \"프로필을 입력해주세요\"", content = @Content),})
     ResponseEntity<MeetingV2CreateMeetingResponseDto> createMeeting(@Valid @RequestBody MeetingV2CreateMeetingBodyDto requestBody,
                                                                     Principal principal);
+
+    @Operation(summary = "모임 지원")
+    @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "지원 완료"),
+            @ApiResponse(responseCode = "400", description = "\"모임이 없습니다\" or \"기수/파트를 설정해주세요\" or \"정원이 꽉찼습니다\" or \"활동 기수가 아닙니다\" " +
+                    "or \"지원 가능한 파트가 아닙니다\" or \"지원 가능한 기간이 아닙니다\"", content = @Content),})
+    ResponseEntity applyMeeting(@RequestBody MeetingV2ApplyMeetingDto requestBody, Principal principal);
 
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.List;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingCancelBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
@@ -54,5 +55,11 @@ public interface MeetingV2Api {
     ResponseEntity<MeetingV2ApplyMeetingResponseDto> applyMeeting(@RequestBody MeetingV2ApplyMeetingDto requestBody,
                                                                   Principal principal);
 
+    @Operation(summary = "모임 지원 취소")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "지원 취소 완료"),
+            @ApiResponse(responseCode = "400", description =
+                    "\"존재하지 않는 모임 신청입니다.\" or \"권한이 없습니다.\"", content = @Content),})
+    ResponseEntity<Void> applyMeetingCancel(@Valid @RequestBody MeetingV2ApplyMeetingCancelBodyDto requestBody,
+                                            Principal principal);
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -14,6 +14,7 @@ import java.util.List;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
@@ -50,7 +51,8 @@ public interface MeetingV2Api {
             @ApiResponse(responseCode = "400", description =
                     "\"모임이 없습니다\" or \"기수/파트를 설정해주세요\" or \"정원이 꽉찼습니다\" or \"활동 기수가 아닙니다\" " +
                             "or \"지원 가능한 파트가 아닙니다\" or \"지원 가능한 기간이 아닙니다\"", content = @Content),})
-    ResponseEntity<Void> applyMeeting(@RequestBody MeetingV2ApplyMeetingDto requestBody, Principal principal);
+    ResponseEntity<MeetingV2ApplyMeetingResponseDto> applyMeeting(@RequestBody MeetingV2ApplyMeetingDto requestBody,
+                                                                  Principal principal);
 
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -61,12 +61,11 @@ public class MeetingV2Controller implements MeetingV2Api {
 
     @Override
     @PostMapping("/apply")
-    @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<MeetingV2ApplyMeetingResponseDto> applyMeeting(
             @Valid @RequestBody MeetingV2ApplyMeetingDto requestBody,
             Principal principal) {
         Integer userId = UserUtil.getUserId(principal);
-        return ResponseEntity.ok(meetingV2Service.applyMeeting(requestBody, userId));
+        return ResponseEntity.status(HttpStatus.CREATED).body(meetingV2Service.applyMeeting(requestBody, userId));
     }
 
     @Override

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -9,6 +9,7 @@ import org.sopt.makers.crew.main.common.util.UserUtil;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
@@ -59,12 +60,10 @@ public class MeetingV2Controller implements MeetingV2Api {
     @Override
     @PostMapping("/apply")
     @ResponseStatus(HttpStatus.CREATED)
-    public ResponseEntity<Void> applyMeeting(@Valid @RequestBody MeetingV2ApplyMeetingDto requestBody,
-                                             Principal principal) {
+    public ResponseEntity<MeetingV2ApplyMeetingResponseDto> applyMeeting(
+            @Valid @RequestBody MeetingV2ApplyMeetingDto requestBody,
+            Principal principal) {
         Integer userId = UserUtil.getUserId(principal);
-        meetingV2Service.applyMeeting(requestBody, userId);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.ok(meetingV2Service.applyMeeting(requestBody, userId));
     }
-
-
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -7,6 +7,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.crew.main.common.util.UserUtil;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
@@ -27,32 +28,42 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MeetingV2Controller implements MeetingV2Api {
 
-  private final MeetingV2Service meetingV2Service;
+    private final MeetingV2Service meetingV2Service;
 
-  @Override
-  @GetMapping("/org-user")
-  @ResponseStatus(HttpStatus.OK)
-  public ResponseEntity<MeetingV2GetAllMeetingByOrgUserDto> getAllMeetingByOrgUser(
-      @ModelAttribute @Parameter(hidden = true) MeetingV2GetAllMeetingByOrgUserQueryDto queryDto) {
-    return ResponseEntity.ok(meetingV2Service.getAllMeetingByOrgUser(queryDto));
-  }
+    @Override
+    @GetMapping("/org-user")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<MeetingV2GetAllMeetingByOrgUserDto> getAllMeetingByOrgUser(
+            @ModelAttribute @Parameter(hidden = true) MeetingV2GetAllMeetingByOrgUserQueryDto queryDto) {
+        return ResponseEntity.ok(meetingV2Service.getAllMeetingByOrgUser(queryDto));
+    }
 
-  @Override
-  @GetMapping("/banner")
-  @ResponseStatus(HttpStatus.OK)
-  public ResponseEntity<List<MeetingV2GetMeetingBannerResponseDto>> getMeetingBanner(
-      Principal principal) {
-    UserUtil.getUserId(principal);
-    return ResponseEntity.ok(meetingV2Service.getMeetingBanner());
-  }
+    @Override
+    @GetMapping("/banner")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<List<MeetingV2GetMeetingBannerResponseDto>> getMeetingBanner(
+            Principal principal) {
+        UserUtil.getUserId(principal);
+        return ResponseEntity.ok(meetingV2Service.getMeetingBanner());
+    }
 
-  @Override
-  @PostMapping
-  public ResponseEntity<MeetingV2CreateMeetingResponseDto> createMeeting(@Valid @RequestBody MeetingV2CreateMeetingBodyDto requestBody,
-                                                                         Principal principal) {
-    Integer userId = UserUtil.getUserId(principal);
-    return ResponseEntity.status(HttpStatus.CREATED).body(meetingV2Service.createMeeting(requestBody, userId));
-  }
+    @Override
+    @PostMapping
+    public ResponseEntity<MeetingV2CreateMeetingResponseDto> createMeeting(
+            @Valid @RequestBody MeetingV2CreateMeetingBodyDto requestBody,
+            Principal principal) {
+        Integer userId = UserUtil.getUserId(principal);
+        return ResponseEntity.status(HttpStatus.CREATED).body(meetingV2Service.createMeeting(requestBody, userId));
+    }
+
+    @Override
+    @PostMapping("/apply")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ResponseEntity applyMeeting(@Valid @RequestBody MeetingV2ApplyMeetingDto requestBody, Principal principal) {
+        Integer userId = UserUtil.getUserId(principal);
+        meetingV2Service.applyMeeting(requestBody, userId);
+        return null;
+    }
 
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -59,10 +59,11 @@ public class MeetingV2Controller implements MeetingV2Api {
     @Override
     @PostMapping("/apply")
     @ResponseStatus(HttpStatus.CREATED)
-    public ResponseEntity applyMeeting(@Valid @RequestBody MeetingV2ApplyMeetingDto requestBody, Principal principal) {
+    public ResponseEntity<Void> applyMeeting(@Valid @RequestBody MeetingV2ApplyMeetingDto requestBody,
+                                             Principal principal) {
         Integer userId = UserUtil.getUserId(principal);
         meetingV2Service.applyMeeting(requestBody, userId);
-        return null;
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
 

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -7,6 +7,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.crew.main.common.util.UserUtil;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingCancelBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
@@ -16,6 +17,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBann
 import org.sopt.makers.crew.main.meeting.v2.service.MeetingV2Service;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -65,5 +67,15 @@ public class MeetingV2Controller implements MeetingV2Api {
             Principal principal) {
         Integer userId = UserUtil.getUserId(principal);
         return ResponseEntity.ok(meetingV2Service.applyMeeting(requestBody, userId));
+    }
+
+    @Override
+    @DeleteMapping("/apply")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<Void> applyMeetingCancel(@Valid @RequestBody MeetingV2ApplyMeetingCancelBodyDto requestBody,
+                                                   Principal principal) {
+        Integer userId = UserUtil.getUserId(principal);
+        meetingV2Service.applyMeetingCancel(requestBody, userId);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/ApplyMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/ApplyMapper.java
@@ -1,0 +1,19 @@
+package org.sopt.makers.crew.main.meeting.v2.dto;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.sopt.makers.crew.main.entity.apply.Apply;
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyType;
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
+
+@Mapper(componentModel = "spring")
+public interface ApplyMapper {
+
+    @Mapping(source = "requestBody.meetingId", target = "meetingId")
+    @Mapping(source = "requestBody.content", target = "content")
+    Apply toApplyEntity(MeetingV2ApplyMeetingDto requestBody, EnApplyType type, Meeting meeting,
+                        User user,
+                        Integer userId);
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/ApplyMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/ApplyMapper.java
@@ -13,6 +13,9 @@ public interface ApplyMapper {
 
     @Mapping(source = "requestBody.meetingId", target = "meetingId")
     @Mapping(source = "requestBody.content", target = "content")
+    @Mapping(source = "meeting", target = "meeting")
+    @Mapping(source = "user", target = "user")
+    @Mapping(source = "userId", target = "userId")
     Apply toApplyEntity(MeetingV2ApplyMeetingDto requestBody, EnApplyType type, Meeting meeting,
                         User user,
                         Integer userId);

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/MeetingV2ApplyMeetingCancelBodyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/MeetingV2ApplyMeetingCancelBodyDto.java
@@ -1,0 +1,17 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "모임 지원 취소 request body dto")
+public class MeetingV2ApplyMeetingCancelBodyDto {
+    @Schema(example = "1", required = true, description = "지원 ID")
+    @NotNull
+    private Integer applyId;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/MeetingV2ApplyMeetingDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/MeetingV2ApplyMeetingDto.java
@@ -1,0 +1,20 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "모임 지원 request body dto")
+public class MeetingV2ApplyMeetingDto {
+    @Schema(example = "4", required = true, description = "모임 ID")
+    @NotNull
+    private Integer meetingId;
+
+    @Schema(example = "꼭 지원하고 싶습니다.", description = "지원 각오")
+    @NotNull
+    private String content;
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2ApplyMeetingResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2ApplyMeetingResponseDto.java
@@ -1,0 +1,10 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class MeetingV2ApplyMeetingResponseDto {
+    private Integer applyId;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -2,6 +2,7 @@ package org.sopt.makers.crew.main.meeting.v2.service;
 
 import java.util.List;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingCancelBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
@@ -19,4 +20,6 @@ public interface MeetingV2Service {
     MeetingV2CreateMeetingResponseDto createMeeting(MeetingV2CreateMeetingBodyDto requestBody, Integer userId);
 
     MeetingV2ApplyMeetingResponseDto applyMeeting(MeetingV2ApplyMeetingDto requestBody, Integer userId);
+
+    void applyMeetingCancel(MeetingV2ApplyMeetingCancelBodyDto requestBody, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
@@ -17,5 +18,5 @@ public interface MeetingV2Service {
 
     MeetingV2CreateMeetingResponseDto createMeeting(MeetingV2CreateMeetingBodyDto requestBody, Integer userId);
 
-    void applyMeeting(MeetingV2ApplyMeetingDto requestBody, Integer userId);
+    MeetingV2ApplyMeetingResponseDto applyMeeting(MeetingV2ApplyMeetingDto requestBody, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -2,6 +2,7 @@ package org.sopt.makers.crew.main.meeting.v2.service;
 
 import java.util.List;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
@@ -10,9 +11,11 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBann
 public interface MeetingV2Service {
 
     MeetingV2GetAllMeetingByOrgUserDto getAllMeetingByOrgUser(
-      MeetingV2GetAllMeetingByOrgUserQueryDto queryDto);
+            MeetingV2GetAllMeetingByOrgUserQueryDto queryDto);
 
     List<MeetingV2GetMeetingBannerResponseDto> getMeetingBanner();
 
     MeetingV2CreateMeetingResponseDto createMeeting(MeetingV2CreateMeetingBodyDto requestBody, Integer userId);
+
+    void applyMeeting(MeetingV2ApplyMeetingDto requestBody, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -2,6 +2,7 @@ package org.sopt.makers.crew.main.meeting.v2.service;
 
 import static org.sopt.makers.crew.main.common.constant.CrewConst.ACTIVE_GENERATION;
 import static org.sopt.makers.crew.main.common.response.ErrorStatus.ALREADY_APPLIED_MEETING;
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.FORBIDDEN_EXCEPTION;
 import static org.sopt.makers.crew.main.common.response.ErrorStatus.FULL_MEETING_CAPACITY;
 import static org.sopt.makers.crew.main.common.response.ErrorStatus.MISSING_GENERATION_PART;
 import static org.sopt.makers.crew.main.common.response.ErrorStatus.NOT_IN_APPLY_PERIOD;
@@ -36,6 +37,7 @@ import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
 import org.sopt.makers.crew.main.meeting.v2.dto.ApplyMapper;
 import org.sopt.makers.crew.main.meeting.v2.dto.MeetingMapper;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingCancelBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
@@ -162,6 +164,18 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
                 userId);
         Apply savedApply = applyRepository.save(apply);
         return MeetingV2ApplyMeetingResponseDto.of(savedApply.getId());
+    }
+
+    @Override
+    @Transactional
+    public void applyMeetingCancel(MeetingV2ApplyMeetingCancelBodyDto requestBody, Integer userId) {
+        Apply apply = applyRepository.findByIdOrThrow(requestBody.getApplyId());
+
+        if (!apply.getUserId().equals(userId)) {
+            throw new BadRequestException(FORBIDDEN_EXCEPTION.getErrorCode());
+        }
+
+        applyRepository.delete(apply);
     }
 
     private Boolean checkMeetingLeader(Meeting meeting, Integer userId) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -244,27 +244,29 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
     }
 
     private void validateUserJoinableParts(User user, Meeting meeting) {
-        if (meeting.getJoinableParts().length > 0) {
-            List<UserActivityVO> userActivities = filterUserActivities(user, meeting);
-            List<String> userJoinableParts = userActivities.stream()
-                    .map(UserActivityVO::getPart)
-                    .filter(part -> {
-                        MeetingJoinablePart meetingJoinablePart = UserPartUtil.getMeetingJoinablePart(
-                                UserPart.ofValue(part));
+        if (meeting.getJoinableParts().length == 0) {
+            return;
+        }
 
-                        // 임원진이라면 패스
-                        if (meetingJoinablePart == null) {
-                            return true;
-                        }
+        List<UserActivityVO> userActivities = filterUserActivities(user, meeting);
+        List<String> userJoinableParts = userActivities.stream()
+                .map(UserActivityVO::getPart)
+                .filter(part -> {
+                    MeetingJoinablePart meetingJoinablePart = UserPartUtil.getMeetingJoinablePart(
+                            UserPart.ofValue(part));
 
-                        return Arrays.stream(meeting.getJoinableParts())
-                                .anyMatch(joinablePart -> joinablePart == meetingJoinablePart);
-                    })
-                    .collect(Collectors.toList());
+                    // 임원진이라면 패스
+                    if (meetingJoinablePart == null) {
+                        return true;
+                    }
 
-            if (userJoinableParts.isEmpty()) {
-                throw new BadRequestException(NOT_TARGET_PART.getErrorCode());
-            }
+                    return Arrays.stream(meeting.getJoinableParts())
+                            .anyMatch(joinablePart -> joinablePart == meetingJoinablePart);
+                })
+                .collect(Collectors.toList());
+
+        if (userJoinableParts.isEmpty()) {
+            throw new BadRequestException(NOT_TARGET_PART.getErrorCode());
         }
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -38,6 +38,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.MeetingMapper;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserMeetingDto;
@@ -147,7 +148,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
     @Override
     @Transactional
-    public void applyMeeting(MeetingV2ApplyMeetingDto requestBody, Integer userId) {
+    public MeetingV2ApplyMeetingResponseDto applyMeeting(MeetingV2ApplyMeetingDto requestBody, Integer userId) {
         Meeting meeting = meetingRepository.findByIdOrThrow(requestBody.getMeetingId());
         User user = userRepository.findByIdOrThrow(userId);
 
@@ -159,7 +160,8 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
         Apply apply = applyMapper.toApplyEntity(requestBody, EnApplyType.APPLY, meeting, user,
                 userId);
-        applyRepository.save(apply);
+        Apply savedApply = applyRepository.save(apply);
+        return MeetingV2ApplyMeetingResponseDto.of(savedApply.getId());
     }
 
     private Boolean checkMeetingLeader(Meeting meeting, Integer userId) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -1,10 +1,16 @@
 package org.sopt.makers.crew.main.meeting.v2.service;
 
 import static org.sopt.makers.crew.main.common.constant.CrewConst.ACTIVE_GENERATION;
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.ALREADY_APPLIED_MEETING;
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.FULL_MEETING_CAPACITY;
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.MISSING_GENERATION_PART;
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.NOT_IN_APPLY_PERIOD;
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.NOT_TARGET_PART;
 import static org.sopt.makers.crew.main.common.response.ErrorStatus.VALIDATION_EXCEPTION;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -14,16 +20,23 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.common.pagination.dto.PageMetaDto;
 import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
+import org.sopt.makers.crew.main.common.util.UserPartUtil;
 import org.sopt.makers.crew.main.entity.apply.Apply;
 import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyType;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.post.Post;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.entity.user.UserRepository;
+import org.sopt.makers.crew.main.entity.user.enums.UserPart;
+import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
+import org.sopt.makers.crew.main.meeting.v2.dto.ApplyMapper;
 import org.sopt.makers.crew.main.meeting.v2.dto.MeetingMapper;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
@@ -45,6 +58,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
     private final MeetingRepository meetingRepository;
 
     private final MeetingMapper meetingMapper;
+    private final ApplyMapper applyMapper;
 
     @Override
     public MeetingV2GetAllMeetingByOrgUserDto getAllMeetingByOrgUser(
@@ -131,6 +145,23 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
         return MeetingV2CreateMeetingResponseDto.of(savedMeeting.getId());
     }
 
+    @Override
+    @Transactional
+    public void applyMeeting(MeetingV2ApplyMeetingDto requestBody, Integer userId) {
+        Meeting meeting = meetingRepository.findByIdOrThrow(requestBody.getMeetingId());
+        User user = userRepository.findByIdOrThrow(userId);
+
+        validateMeetingCapacity(meeting);
+        validateUserAlreadyApplied(meeting, userId);
+        validateApplyPeriod(meeting);
+        validateUserActivities(user);
+        validateUserJoinableParts(user, meeting);
+
+        Apply apply = applyMapper.toApplyEntity(requestBody, EnApplyType.APPLY, meeting, user,
+                userId);
+        applyRepository.save(apply);
+    }
+
     private Boolean checkMeetingLeader(Meeting meeting, Integer userId) {
         return meeting.getUserId().equals(userId);
     }
@@ -144,5 +175,74 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
     private Integer getTargetActiveGeneration(Boolean canJoinOnlyActiveGeneration) {
         return canJoinOnlyActiveGeneration ? ACTIVE_GENERATION : null;
+    }
+
+    private List<UserActivityVO> filterUserActivities(User user, Meeting meeting) {
+        // 현재 활동기수만 지원 가능할 경우 -> 현재 활동 기수에 해당하는 파트만 필터링
+        if (meeting.getTargetActiveGeneration() == ACTIVE_GENERATION && meeting.getCanJoinOnlyActiveGeneration()) {
+            return user.getActivities().stream()
+                    .filter(activity -> activity.getGeneration() == ACTIVE_GENERATION)
+                    .findFirst()
+                    .map(List::of)
+                    .orElseThrow(() -> new BadRequestException(NOT_TARGET_PART.getErrorCode()));
+        }
+        return user.getActivities();
+    }
+
+    private void validateMeetingCapacity(Meeting meeting) {
+        List<Apply> approvedApplies = meeting.getAppliedInfo().stream()
+                .filter(apply -> EnApplyStatus.APPROVE.equals(apply.getStatus()))
+                .collect(Collectors.toList());
+
+        if (approvedApplies.size() >= meeting.getCapacity()) {
+            throw new BadRequestException(FULL_MEETING_CAPACITY.getErrorCode());
+        }
+    }
+
+    private void validateUserAlreadyApplied(Meeting meeting, Integer userId) {
+        boolean hasApplied = meeting.getAppliedInfo().stream()
+                .anyMatch(appliedInfo -> appliedInfo.getUser().getId().equals(userId));
+
+        if (hasApplied) {
+            throw new BadRequestException(ALREADY_APPLIED_MEETING.getErrorCode());
+        }
+    }
+
+    private void validateApplyPeriod(Meeting meeting) {
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isAfter(meeting.getEndDate()) || now.isBefore(meeting.getStartDate())) {
+            throw new BadRequestException(NOT_IN_APPLY_PERIOD.getErrorCode());
+        }
+    }
+
+    private void validateUserActivities(User user) {
+        if (user.getActivities().isEmpty()) {
+            throw new BadRequestException(MISSING_GENERATION_PART.getErrorCode());
+        }
+    }
+
+    private void validateUserJoinableParts(User user, Meeting meeting) {
+        if (meeting.getJoinableParts().length > 0) {
+            List<UserActivityVO> userActivities = filterUserActivities(user, meeting);
+            List<String> userJoinableParts = userActivities.stream()
+                    .map(UserActivityVO::getPart)
+                    .filter(part -> {
+                        MeetingJoinablePart meetingJoinablePart = UserPartUtil.getMeetingJoinablePart(
+                                UserPart.ofValue(part));
+
+                        // 임원진이라면 패스
+                        if (meetingJoinablePart == null) {
+                            return true;
+                        }
+
+                        return Arrays.stream(meeting.getJoinableParts())
+                                .anyMatch(joinablePart -> joinablePart == meetingJoinablePart);
+                    })
+                    .collect(Collectors.toList());
+
+            if (userJoinableParts.isEmpty()) {
+                throw new BadRequestException(NOT_TARGET_PART.getErrorCode());
+            }
+        }
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
@@ -23,22 +23,22 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/post/v2")
 @RequiredArgsConstructor
-@Tag(name = "모임")
+@Tag(name = "게시글")
 public class PostV2Controller {
 
-  private final PostV2Service postV2Service;
+    private final PostV2Service postV2Service;
 
-  @Operation(summary = "모임 게시글 작성")
-  @PostMapping()
-  @ResponseStatus(HttpStatus.CREATED)
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "201", description = "성공"),
-      @ApiResponse(responseCode = "400", description = "모임이 없습니다.", content = @Content),
-      @ApiResponse(responseCode = "403", description = "권한이 없습니다.", content = @Content),
-  })
-  public ResponseEntity<PostV2CreatePostResponseDto> createPost(
-      @Valid @RequestBody PostV2CreatePostBodyDto requestBody, Principal principal) {
-    Integer userId = UserUtil.getUserId(principal);
-    return ResponseEntity.ok(postV2Service.createPost(requestBody, userId));
-  }
+    @Operation(summary = "모임 게시글 작성")
+    @PostMapping()
+    @ResponseStatus(HttpStatus.CREATED)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "모임이 없습니다.", content = @Content),
+            @ApiResponse(responseCode = "403", description = "권한이 없습니다.", content = @Content),
+    })
+    public ResponseEntity<PostV2CreatePostResponseDto> createPost(
+            @Valid @RequestBody PostV2CreatePostBodyDto requestBody, Principal principal) {
+        Integer userId = UserUtil.getUserId(principal);
+        return ResponseEntity.ok(postV2Service.createPost(requestBody, userId));
+    }
 }

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -1,7 +1,11 @@
 package org.sopt.makers.crew.main.meeting.v2.service;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.FULL_MEETING_CAPACITY;
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.NOT_IN_APPLY_PERIOD;
 
 import java.time.LocalDateTime;
 import java.time.Month;
@@ -15,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.entity.apply.Apply;
 import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
@@ -28,7 +33,9 @@ import org.sopt.makers.crew.main.entity.user.UserFixture;
 import org.sopt.makers.crew.main.entity.user.UserRepository;
 import org.sopt.makers.crew.main.entity.user.enums.UserPart;
 import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
+import org.sopt.makers.crew.main.meeting.v2.dto.ApplyMapper;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,6 +48,8 @@ public class MeetingV2ServiceTest {
     private ApplyRepository applyRepository;
     @Mock
     private MeetingRepository meetingRepository;
+    @Mock
+    private ApplyMapper applyMapper;
 
 
     private List<Apply> applies;
@@ -131,5 +140,81 @@ public class MeetingV2ServiceTest {
                 .extracting("isMeetingLeader", "title", "category", "mStartDate", "mEndDate", "isActiveMeeting")
                 .containsExactly(false, meeting.getTitle(), meeting.getCategory().getValue(), meeting.getMStartDate(),
                         meeting.getMEndDate(), true);
+    }
+
+    @Test
+    public void 모임신청시_정원이찼을때_예외발생() {
+        // given
+        for (int i = 0; i < meeting.getCapacity(); i++) {
+            User tempUser = User.builder()
+                    .name("user" + i)
+                    .orgId(2 + i)
+                    .phone("010-0000-000" + i)
+                    .build();
+            tempUser.setUserIdForTest(3 + i); // 3부터 시작하는 userId 설정
+
+            Apply apply = Apply.builder()
+                    .meeting(meeting)
+                    .meetingId(meeting.getId())
+                    .user(tempUser)
+                    .userId(tempUser.getId())
+                    .content("꼭 하고 싶어요" + i)
+                    .build();
+
+            apply.updateApplyStatus(EnApplyStatus.APPROVE); // 승인 상태로 변경
+        }
+        applies = new ArrayList<>(meeting.getAppliedInfo());
+        MeetingV2ApplyMeetingDto requestBody = new MeetingV2ApplyMeetingDto(meeting.getId(), "열심히 하겠습니다.");
+
+        doReturn(meeting).when(meetingRepository).findByIdOrThrow(requestBody.getMeetingId());
+        doReturn(applyUser).when(userRepository).findByIdOrThrow(applyUser.getId());
+
+        // when & then
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+            meetingV2Service.applyMeeting(requestBody, applyUser.getId());
+        });
+
+        assertEquals(FULL_MEETING_CAPACITY.getErrorCode(), exception.getMessage());
+    }
+
+    @Test
+    public void 모집시작시간이전_모임지원시_예외발생() {
+        // given
+        LocalDateTime oneMinuteAfterNow = LocalDateTime.now().plusMinutes(1);
+
+        meeting = Meeting.builder()
+                .user(ownerUser)
+                .userId(ownerUser.getId())
+                .title("사람 구해요")
+                .category(MeetingCategory.STUDY)
+                .startDate(oneMinuteAfterNow) // 모집 시작 시간을 현재 시간으로부터 1분 후로 설정
+                .endDate(oneMinuteAfterNow.plusDays(1))
+                .capacity(10)
+                .desc("열정 많은 사람 구해요")
+                .processDesc("이렇게 할거에여")
+                .mStartDate(LocalDateTime.of(2028, Month.APRIL, 20, 0, 0))
+                .mEndDate(LocalDateTime.of(2030, Month.APRIL, 20, 0, 0))
+                .leaderDesc("저는 이런 사람이에요.")
+                .targetDesc("이런 사람이 왔으면 좋겠어요")
+                .note("유의사항은 이거에요")
+                .isMentorNeeded(true)
+                .canJoinOnlyActiveGeneration(true)
+                .createdGeneration(33)
+                .targetActiveGeneration(33)
+                .joinableParts(MeetingJoinablePart.values())
+                .appliedInfo(new ArrayList<>())
+                .build();
+
+        MeetingV2ApplyMeetingDto requestBody = new MeetingV2ApplyMeetingDto(meeting.getId(), "열심히 하겠습니다.");
+
+        doReturn(meeting).when(meetingRepository).findByIdOrThrow(requestBody.getMeetingId());
+        doReturn(applyUser).when(userRepository).findByIdOrThrow(applyUser.getId());
+
+        // when & then
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+            meetingV2Service.applyMeeting(requestBody, applyUser.getId());
+        });
+
+        assertEquals(NOT_IN_APPLY_PERIOD.getErrorCode(), exception.getMessage());
     }
 }

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -98,18 +98,16 @@ public class MeetingV2ServiceTest {
                 .appliedInfo(new ArrayList<>())
                 .build();
 
-
         Apply apply = Apply.builder()
                 .meeting(meeting)
                 .meetingId(1)
                 .user(applyUser)
                 .userId(2)
                 .content("제 지원동기는요")
-                .status(EnApplyStatus.APPROVE)
                 .build();
 
-
         meeting.addApply(apply);
+        apply.updateApplyStatus(EnApplyStatus.APPROVE);
 
         applies = new ArrayList<>();
         applies.add(apply);

--- a/server/src/meeting/v0/meeting-v0.controller.ts
+++ b/server/src/meeting/v0/meeting-v0.controller.ts
@@ -90,6 +90,7 @@ export class MeetingV0Controller {
   @ApiOperation({
     summary: '모임 지원/취소',
     description: '모임 지원/취소',
+    deprecated: true,
   })
   @ApiResponse({
     status: HttpStatus.CREATED,

--- a/server/src/meeting/v1/meeting-v1.controller.ts
+++ b/server/src/meeting/v1/meeting-v1.controller.ts
@@ -84,6 +84,7 @@ export class MeetingV1Controller {
   @ApiOperation({
     summary: '모임 생성',
     description: '모임 생성',
+    deprecated: true,
   })
   @ApiOkResponseCommon(MeetingV1CreateMeetingResponseDto)
   @ApiResponse({

--- a/server/src/post/v1/post-v1.controller.ts
+++ b/server/src/post/v1/post-v1.controller.ts
@@ -101,6 +101,7 @@ export class PostV1Controller {
 
   @ApiOperation({
     summary: '모임 게시글 작성',
+    deprecated: true,
   })
   @ApiOkResponseCommon(PostV1CreatePostResponseDto)
   @ApiResponse({


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->

- 모임 지원/신청 API를 스프링 서버로 마이그레이션 했습니다.
- 마이그레이션 하면서 지원과 신청 API를 분리 하였습니다.
- 기존 Nest.js 에서 하드코딩 되어있던 행사 부분 레거시로 판단하고 제외하였습니다. 행사, 스터디 모두 개설할 때 모집 기간에 맞춰 validation 할 수 있도록 구현하였습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

- 모임 신청 같은 경우에는 중요한 로직이고, 발생되는 예외가 많다보니 해당 로직에 관한 테스트 코드까지 작성하여 검증하고자 하였으나, 시간 관계상 우선 스웨거로 각 케이스 테스트 해봤습니다. 
- 이상 없는 것 같아 작업한 내용 먼저 올려두고, 테스트 코드 지금 작성해보고 있는데 오늘 저녁~밤 이전까지 완료하여 다시 언급 드리도록 하겠습니다 !
- 조금 급하게 구현한 부분이 없지 않아서 이상한 부분이 있다면 바로 리뷰 남겨주세요 ! 빠르게 수정하도록 하겠습니다!

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #175 

## ✅ 점검사항

- [x] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [x] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [x] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?