### PR TITLE
Hotfix/cicd workflow 수정

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,15 +1,16 @@
 name: Makers_Crew Dev CD
 on:
   workflow_run:
-    workflows: [ "Makers_Crew CI" ]
-    branches: [ "develop" ]
-    types: [ completed ]
+    workflows: ["Makers_Crew CI"]
+    branches: [develop]
+    types: [completed]
 
   push:
     branches: [ "develop" ]
 jobs:
   deploy:
     runs-on: ubuntu-22.04
+    if: github.event.workflow_run.conclusion == 'success'
     env:
       working-directory-spring: main
       working-directory-nestjs: server

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-22.04
-    if: github.event.workflow_run.conclusion == 'success'
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
       working-directory-spring: main
       working-directory-nestjs: server

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -2,11 +2,9 @@ name: Makers_Crew Dev CD
 on:
   workflow_run:
     workflows: ["Makers_Crew CI"]
-    branches: [develop]
+    branches: ["develop"]
     types: [completed]
 
-  push:
-    branches: [ "develop" ]
 jobs:
   deploy:
     runs-on: ubuntu-22.04

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -1,15 +1,16 @@
 name: Makers_Crew Main CD
 on:
   workflow_run:
-    workflows: [ "Makers_Crew CI" ]
-    branches: [ "main" ]
-    types: [ completed ]
+    workflows: ["Makers_Crew CI"]
+    branches: [main]
+    types: [completed]
 
   push:
     branches: [ "main" ]
 jobs:
   deploy:
     runs-on: ubuntu-22.04
+    if: github.event.workflow_run.conclusion == 'success'
     env:
       working-directory-spring: main
       working-directory-nestjs: server

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-22.04
-    if: github.event.workflow_run.conclusion == 'success'
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
       working-directory-spring: main
       working-directory-nestjs: server

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -2,11 +2,9 @@ name: Makers_Crew Main CD
 on:
   workflow_run:
     workflows: ["Makers_Crew CI"]
-    branches: [main]
+    branches: ["main"]
     types: [completed]
 
-  push:
-    branches: [ "main" ]
 jobs:
   deploy:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: Makers_Crew CI
 
 on:
-  push:
-    branches:
-      - develop, main
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [develop, main]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: Makers_Crew CI
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches: [develop, main]
+  push:
+    branches:
+      - '**'
 
 jobs:
   build-springboot:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,11 @@ name: Makers_Crew CI
 on:
   push:
     branches:
-      - '**'
-
+      - develop, main
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [opened, synchronize, reopened]
+    branches: [develop, main]
+
 jobs:
   build-springboot:
     name: Build and analyze (SpringBoot)


### PR DESCRIPTION
## 👩‍💻 Contents
- develop 브랜치에 merge시 ci, cd가 두번씩 실행되는 현상 확인
  - develop, main 브랜치에 pr을 통해 merge 되면 CI를 수행 후 수행이 성공 했을 때만 CD를 수행하도록 개선

## 📝 Review Note
- 문제 발생 원인
  - main, dev 브랜치 직접 푸쉬하는 경우도 있을 것 같아서 그것도 CI를 수행하도록 설정 해뒀는데, 이 경우 PR 날려서 Merge 하는 경우 CI가 두 번 수행되고 CI가 성공하면 CD 프로세스를 진행하도록 해둬서 CD도 두 번 수행됨

## 📣 Related Issue


## ✅ 점검사항

- [x] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [x] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [x] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?