### PR TITLE
[FEAT] 모임 지원 취소 API 수정 

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
@@ -7,8 +7,10 @@ import java.util.Optional;
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface ApplyRepository extends JpaRepository<Apply, Integer> {
 
@@ -17,6 +19,13 @@ public interface ApplyRepository extends JpaRepository<Apply, Integer> {
                                          @Param("statusValue") EnApplyStatus statusValue);
 
     List<Apply> findAllByMeetingIdAndStatus(Integer meetingId, EnApplyStatus statusValue);
+
+    boolean existsByMeetingIdAndUserId(Integer meetingId, Integer userId);
+
+    @Transactional
+    @Modifying
+    @Query("delete from Apply a where a.meeting.id = :meetingId and a.userId = :userId")
+    void deleteByMeetingIdAndUserId(@Param("meetingId") Integer meetingId, @Param("userId") Integer userId);
 
     Optional<Apply> findById(Integer applyId);
 

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -12,7 +12,6 @@ import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.List;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
-import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingCancelBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
@@ -21,6 +20,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingB
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 
@@ -58,8 +58,8 @@ public interface MeetingV2Api {
     @Operation(summary = "모임 지원 취소")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "지원 취소 완료"),
             @ApiResponse(responseCode = "400", description =
-                    "\"존재하지 않는 모임 신청입니다.\" or \"권한이 없습니다.\"", content = @Content),})
-    ResponseEntity<Void> applyMeetingCancel(@Valid @RequestBody MeetingV2ApplyMeetingCancelBodyDto requestBody,
+                    "존재하지 않는 모임 신청입니다.", content = @Content),})
+    ResponseEntity<Void> applyMeetingCancel(@PathVariable Integer meetingId,
                                             Principal principal);
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -7,7 +7,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.crew.main.common.util.UserUtil;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
-import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingCancelBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
@@ -20,6 +19,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -69,12 +69,12 @@ public class MeetingV2Controller implements MeetingV2Api {
     }
 
     @Override
-    @DeleteMapping("/apply")
+    @DeleteMapping("/{meetingId}/apply")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<Void> applyMeetingCancel(@Valid @RequestBody MeetingV2ApplyMeetingCancelBodyDto requestBody,
+    public ResponseEntity<Void> applyMeetingCancel(@PathVariable Integer meetingId,
                                                    Principal principal) {
         Integer userId = UserUtil.getUserId(principal);
-        meetingV2Service.applyMeetingCancel(requestBody, userId);
+        meetingV2Service.applyMeetingCancel(meetingId, userId);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -2,7 +2,6 @@ package org.sopt.makers.crew.main.meeting.v2.service;
 
 import java.util.List;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
-import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingCancelBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
@@ -21,5 +20,5 @@ public interface MeetingV2Service {
 
     MeetingV2ApplyMeetingResponseDto applyMeeting(MeetingV2ApplyMeetingDto requestBody, Integer userId);
 
-    void applyMeetingCancel(MeetingV2ApplyMeetingCancelBodyDto requestBody, Integer userId);
+    void applyMeetingCancel(Integer meetingId, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -2,10 +2,10 @@ package org.sopt.makers.crew.main.meeting.v2.service;
 
 import static org.sopt.makers.crew.main.common.constant.CrewConst.ACTIVE_GENERATION;
 import static org.sopt.makers.crew.main.common.response.ErrorStatus.ALREADY_APPLIED_MEETING;
-import static org.sopt.makers.crew.main.common.response.ErrorStatus.FORBIDDEN_EXCEPTION;
 import static org.sopt.makers.crew.main.common.response.ErrorStatus.FULL_MEETING_CAPACITY;
 import static org.sopt.makers.crew.main.common.response.ErrorStatus.MISSING_GENERATION_PART;
 import static org.sopt.makers.crew.main.common.response.ErrorStatus.NOT_ACTIVE_GENERATION;
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.NOT_FOUND_APPLY;
 import static org.sopt.makers.crew.main.common.response.ErrorStatus.NOT_IN_APPLY_PERIOD;
 import static org.sopt.makers.crew.main.common.response.ErrorStatus.NOT_TARGET_PART;
 import static org.sopt.makers.crew.main.common.response.ErrorStatus.VALIDATION_EXCEPTION;
@@ -38,7 +38,6 @@ import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
 import org.sopt.makers.crew.main.meeting.v2.dto.ApplyMapper;
 import org.sopt.makers.crew.main.meeting.v2.dto.MeetingMapper;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
-import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingCancelBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
@@ -169,14 +168,14 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
     @Override
     @Transactional
-    public void applyMeetingCancel(MeetingV2ApplyMeetingCancelBodyDto requestBody, Integer userId) {
-        Apply apply = applyRepository.findByIdOrThrow(requestBody.getApplyId());
+    public void applyMeetingCancel(Integer meetingId, Integer userId) {
+        boolean exists = applyRepository.existsByMeetingIdAndUserId(meetingId, userId);
 
-        if (!apply.getUserId().equals(userId)) {
-            throw new BadRequestException(FORBIDDEN_EXCEPTION.getErrorCode());
+        if (!exists) {
+            throw new BadRequestException(NOT_FOUND_APPLY.getErrorCode());
         }
 
-        applyRepository.delete(apply);
+        applyRepository.deleteByMeetingIdAndUserId(meetingId, userId);
     }
 
     private Boolean checkMeetingLeader(Meeting meeting, Integer userId) {


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->

- 클라선생님들의 요구사항에 따라 API request 방식을 변경했습니다. (request body -> path variable)

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

- meetingId를 쿼리 파라미터로 받을까 하다가, RESTful API의 원칙 중 하나인 URL이 리소스를 표현해야 한다는 원칙을 좀 더 지키고자 path variable로 받도록 하였습니다 !

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #181 

## ✅ 점검사항

- [x] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [x] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [x] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?