### PR TITLE
[CHORE] logger 개선

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,11 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     restart: unless-stopped
+    labels:
+      caddy.log: ""
+      caddy.log.output: stdout
+      caddy.log.format: json
+      caddy.log.include: http.log.access.localhost
 
   swagger:
     image: swaggerapi/swagger-ui
@@ -40,6 +45,10 @@ services:
 
   nestjs-green:
     image: makerscrew/server:latest
+    container_name: nestjs-green
+    ports:
+      - 3001:3000
+    restart: unless-stopped
     env_file:
       - ./.env
     environment:
@@ -55,14 +64,17 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_REGION=${AWS_REGION}
       - JWT_SECRET=${JWT_SECRET}
-
-    container_name: nestjs-green
-    ports:
-      - 3001:3000
-    restart: unless-stopped
+    depends_on:
+      - nestjs
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     networks:
       - caddy
     labels:
+      caddy.log: "localhost"
       # for Swagger spec
       caddy.route_0: /api-docs-json
       caddy.route_0.reverse_proxy: "{{ upstreams 3000 }}"
@@ -96,8 +108,6 @@ services:
       caddy.route_14: /users/*
       caddy.route_14.reverse_proxy: "{{ upstreams 3000 }}"
 
-
-
   spring-green:
     image: makerscrew/main:latest
     environment:
@@ -111,6 +121,7 @@ services:
     networks:
       - caddy
     labels:
+      caddy.log: "localhost"
       # for Swagger spec
       caddy.route_0: /api-docs/json
       caddy.route_0.reverse_proxy: "{{ upstreams 4000 }}"
@@ -145,7 +156,6 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_REGION=${AWS_REGION}
       - JWT_SECRET=${JWT_SECRET}
-
     container_name: nestjs-blue
     ports:
       - 3002:3000
@@ -153,6 +163,7 @@ services:
     networks:
       - caddy
     labels:
+      caddy.log: "localhost"
       # for Swagger spec
       caddy.route_0: /api-docs-json
       caddy.route_0.reverse_proxy: "{{ upstreams 3000 }}"
@@ -186,7 +197,6 @@ services:
       caddy.route_14: /users/*
       caddy.route_14.reverse_proxy: "{{ upstreams 3000 }}"
 
-
   spring-blue:
     image: makerscrew/main:latest
     environment:
@@ -200,6 +210,7 @@ services:
     networks:
       - caddy
     labels:
+      caddy.log: "localhost"
       # for Swagger spec
       caddy.route_0: /api-docs/json
       caddy.route_0.reverse_proxy: "{{ upstreams 4000 }}"
@@ -216,6 +227,7 @@ services:
       caddy.route_5.reverse_proxy: "{{ upstreams 4000 }}"
       caddy.route_6: /comment/v2
       caddy.route_6.reverse_proxy: "{{ upstreams 4000 }}"
+
 networks:
   caddy:
     external: true

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { MeetingModule } from './meeting/meeting.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
@@ -10,6 +10,7 @@ import { TransformInterceptor } from './common/interceptor/transform.interceptor
 import { NoticeModule } from './notice/notice.module';
 import { PostModule } from './post/post.module';
 import { CommentModule } from './comment/comment.module';
+import { LoggerMiddleware } from './common/middleware/logger.middleware';
 
 @Module({
   imports: [
@@ -46,4 +47,8 @@ import { CommentModule } from './comment/comment.module';
     },
   ],
 })
-export class AppModule {}
+export class AppModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(LoggerMiddleware).forRoutes('*');
+  }
+}

--- a/server/src/common/middleware/logger.middleware.ts
+++ b/server/src/common/middleware/logger.middleware.ts
@@ -1,0 +1,31 @@
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+
+@Injectable()
+export class LoggerMiddleware implements NestMiddleware {
+  private readonly logger = new Logger('HTTP');
+
+  use(request: Request, response: Response, next: NextFunction) {
+    const start = Date.now();
+
+    response.on('finish', () => {
+      const { method, originalUrl } = request;
+      const { statusCode, statusMessage } = response;
+      const duration = Date.now() - start;
+
+      const message = `[${duration}ms] ${method} ${originalUrl} ${statusCode} ${statusMessage}`;
+
+      if (statusCode >= 500) {
+        return this.logger.error(message);
+      }
+
+      if (statusCode >= 400) {
+        return this.logger.warn(message);
+      }
+
+      return this.logger.log(message);
+    });
+
+    next();
+  }
+}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -6,8 +6,12 @@ import { setupSwagger } from './common/utils/swagger';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     cors: true,
-    bufferLogs: true,
+    logger:
+      process.env.NODE_ENV === 'production'
+        ? ['log', 'error', 'warn']
+        : ['log', 'error', 'warn', 'debug', 'verbose'],
   });
+
   setupSwagger(app);
   app.useGlobalPipes(
     new ValidationPipe({
@@ -23,4 +27,5 @@ async function bootstrap() {
   const port = process.env.PORT || 3000;
   await app.listen(port);
 }
+
 bootstrap();


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- Nest.js와 caddy의 액세스 로그를 남깁니다.
- 
### Nestjs log 예시
<img width="776" alt="image" src="https://github.com/sopt-makers/sopt-crew-backend/assets/46023074/d9910b63-7d63-4af2-b453-b9b1fe6a0052">

### Caddy log 예시
<img width="815" alt="image" src="https://github.com/sopt-makers/sopt-crew-backend/assets/46023074/f703746e-04c4-4389-b87c-c0589354267a">


## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 참고 링크
- [캐디 공식문서 로그 format](https://caddyserver.com/docs/json/logging/)
- [캐디 공식문서 로그](https://caddyserver.com/docs/caddyfile/directives/log#multiple-outputs)
- [캐디 docker-proxy 문서](https://github.com/lucaslorentz/caddy-docker-proxy?tab=readme-ov-file#sites-snippets-and-global-options)
- [캐디 공식문서 캐디파일 format](https://caddyserver.com/docs/caddyfile/concepts)
- [express access log time diff 스택오버플로우](https://stackoverflow.com/questions/18538537/time-requests-in-nodejs-express)
- [NestJS 공식문서 log](https://docs.nestjs.com/techniques/logger)

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #26 

## ✅ 점검사항

- [x] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [x] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [x] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?