### PR TITLE
[FIX] 피드 작성 시간 표기 오류

### DIFF
--- a/server/src/post/v1/dto/get-meeting-post/post-v1-get-post-response.dto.ts
+++ b/server/src/post/v1/dto/get-meeting-post/post-v1-get-post-response.dto.ts
@@ -96,9 +96,9 @@ export class PostV1GetPostResponseDto {
   @IsString()
   contents: string;
 
-  /** 게시글 게시/업데이트 일자 */
+  /** 게시글 게시/생성 일자 */
   @IsDate()
-  updatedDate: Date;
+  createdDate: Date;
 
   /** 첨부 이미지 */
   @IsOptional()

--- a/server/src/post/v1/dto/get-meeting-posts/post-v1-get-posts-response-post.dto.ts
+++ b/server/src/post/v1/dto/get-meeting-posts/post-v1-get-posts-response-post.dto.ts
@@ -68,9 +68,9 @@ export class PostV1GetPostsResponsePostDto {
   @IsString()
   contents: string;
 
-  /** 게시글 게시/업데이트 일자 */
+  /** 게시글 게시/생성 일자 */
   @IsDate()
-  updatedDate: Date;
+  createdDate: Date;
 
   /** 첨부 이미지 */
   @IsOptional()

--- a/server/src/post/v1/post-v1.service.ts
+++ b/server/src/post/v1/post-v1.service.ts
@@ -102,7 +102,7 @@ export class PostV1Service {
           id: post.id,
           title: post.title,
           contents: post.contents,
-          updatedDate: post.updatedDate,
+          createdDate: post.createdDate,
           images: post.images,
           user: {
             id: post.user.id,
@@ -161,7 +161,7 @@ export class PostV1Service {
       id: post.id,
       title: post.title,
       contents: post.contents,
-      updatedDate: post.updatedDate,
+      createdDate: post.createdDate,
       images: post.images,
       user: {
         id: post.user.id,


### PR DESCRIPTION
## 👩‍💻 Contents
- 피드 목록과 상세 정보를 불러올 때 생성 시간이 아닌 수정 시간을 불러오는 문제 발견

## 📝 Test Result
- 스프링 코드 수정할 때는 테스트 코드로 검증해보겠습니다~

<img width="400" alt="image" src="https://github.com/sopt-makers/sopt-crew-backend/assets/62228195/11bacffe-de4f-407d-84cb-0adb8c804c00">

</br>

<img width="400" alt="image" src="https://github.com/sopt-makers/sopt-crew-backend/assets/62228195/1dfb21c3-5e7a-4732-8940-cd9a27f4c405">


## 📣 Related Issue
- closed https://github.com/sopt-makers/sopt-crew-backend/issues/199

## ✅ 점검사항

- [x] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [x] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [x] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?