### PR TITLE
[FEAT] 모임 신청자 리스트 조회 API 마이그레이션

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -65,6 +65,12 @@ dependencies {
     // MapStruct
     implementation 'org.mapstruct:mapstruct:1.5.3.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
+
+    // queryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/main/src/main/java/org/sopt/makers/crew/main/common/config/JpaAuditingConfig.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/config/JpaAuditingConfig.java
@@ -1,9 +1,20 @@
 package org.sopt.makers.crew.main.common.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @Configuration
 public class JpaAuditingConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/common/util/UserUtil.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/util/UserUtil.java
@@ -1,8 +1,11 @@
 package org.sopt.makers.crew.main.common.util;
 
 import java.security.Principal;
+import java.util.Comparator;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.crew.main.common.exception.UnAuthorizedException;
+import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
 
 @RequiredArgsConstructor
 public class UserUtil {
@@ -12,5 +15,9 @@ public class UserUtil {
       throw new UnAuthorizedException();
     }
     return Integer.valueOf(principal.getName());
+  }
+
+  public static UserActivityVO getRecentUserActivity(List<UserActivityVO> userActivityVOs){
+    return userActivityVOs.stream().max(Comparator.comparingInt(UserActivityVO::getGeneration)).orElse(null);
   }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
@@ -12,7 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
-public interface ApplyRepository extends JpaRepository<Apply, Integer> {
+public interface ApplyRepository extends JpaRepository<Apply, Integer>, ApplySearchRepository {
 
     @Query("select a from Apply a join fetch a.meeting m where a.userId = :userId and a.status = :statusValue")
     List<Apply> findAllByUserIdAndStatus(@Param("userId") Integer userId,

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepository.java
@@ -1,6 +1,5 @@
 package org.sopt.makers.crew.main.entity.apply;
 
-import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDto;
 import org.springframework.data.domain.Page;
@@ -8,5 +7,6 @@ import org.springframework.data.domain.Pageable;
 
 
 public interface ApplySearchRepository {
-    Page<ApplyInfoDto> findApplyList(MeetingGetApplyListCommand queryCommand, Pageable pageable, Meeting meeting, Integer userId);
+    Page<ApplyInfoDto> findApplyList(MeetingGetApplyListCommand queryCommand, Pageable pageable, Integer meetingId,
+                                     Integer studyCreatorId, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface ApplySearchRepository {
     Page<ApplyInfoDto> findApplyList(MeetingGetApplyListCommand queryCommand, Pageable pageable, Integer meetingId,
-                                     Integer studyCreatorId, Integer userId);
+                                     Integer meetingCreatorId, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.makers.crew.main.entity.apply;
+
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+
+public interface ApplySearchRepository {
+    Page<ApplyInfoDto> findApplyList(MeetingGetApplyListCommand queryCommand, Pageable pageable, Meeting meeting, Integer userId);
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepositoryImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepositoryImpl.java
@@ -1,0 +1,70 @@
+package org.sopt.makers.crew.main.entity.apply;
+
+import static org.sopt.makers.crew.main.entity.apply.QApply.apply;
+import static org.sopt.makers.crew.main.entity.user.QUser.user;
+
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.QApplicantDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.QApplyInfoDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ApplySearchRepositoryImpl implements ApplySearchRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ApplyInfoDto> findApplyList(MeetingGetApplyListCommand queryCommand, Pageable pageable, Meeting meeting, Integer userId) {
+        List<ApplyInfoDto> content = getContent(queryCommand, pageable, meeting, userId);
+        JPAQuery<Long> countQuery = getCount(queryCommand, meeting);
+
+        return PageableExecutionUtils.getPage(content,
+                PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()), countQuery::fetchFirst);
+    }
+
+    private List<ApplyInfoDto> getContent(MeetingGetApplyListCommand queryCommand, Pageable pageable, Meeting meeting, Integer userId) {
+        boolean isStudyCreator = Objects.equals(meeting.getUserId(), userId);
+        return queryFactory
+                .select(new QApplyInfoDto(
+                        apply.id, apply.type, isStudyCreator ? apply.content : Expressions.constant(""),
+                        apply.appliedDate, apply.status,
+                        new QApplicantDto(user.id, user.name, user.orgId, user.activities, user.profileImage,
+                                user.phone)))
+                .from(apply)
+                .leftJoin(apply.user, user)
+                .where(
+                        apply.meetingId.eq(meeting.getId()),
+                        apply.status.in(queryCommand.getStatuses()),
+                        apply.type.in(queryCommand.getTypes())
+                )
+                .orderBy(queryCommand.getDate().equals("desc") ? apply.appliedDate.desc() : apply.appliedDate.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private JPAQuery<Long> getCount(MeetingGetApplyListCommand queryCommand, Meeting meeting) {
+        return queryFactory
+                .select(apply.count())
+                .from(apply, user)
+                .fetchJoin()
+                .where(
+                        apply.meetingId.eq(meeting.getId()),
+                        apply.status.in(queryCommand.getStatuses()),
+                        apply.type.in(queryCommand.getTypes())
+                );
+
+    }
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepositoryImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepositoryImpl.java
@@ -56,8 +56,7 @@ public class ApplySearchRepositoryImpl implements ApplySearchRepository {
     private JPAQuery<Long> getCount(MeetingGetApplyListCommand queryCommand, Integer meetingId) {
         return queryFactory
                 .select(apply.count())
-                .from(apply, user)
-                .fetchJoin()
+                .from(apply)
                 .where(
                         apply.meetingId.eq(meetingId),
                         apply.status.in(queryCommand.getStatus())

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepositoryImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepositoryImpl.java
@@ -45,8 +45,7 @@ public class ApplySearchRepositoryImpl implements ApplySearchRepository {
                 .leftJoin(apply.user, user)
                 .where(
                         apply.meetingId.eq(meetingId),
-                        apply.status.in(queryCommand.getStatuses()),
-                        apply.type.in(queryCommand.getTypes())
+                        apply.status.in(queryCommand.getStatuses())
                 )
                 .orderBy(queryCommand.getDate().equals("desc") ? apply.appliedDate.desc() : apply.appliedDate.asc())
                 .offset(pageable.getOffset())
@@ -61,8 +60,7 @@ public class ApplySearchRepositoryImpl implements ApplySearchRepository {
                 .fetchJoin()
                 .where(
                         apply.meetingId.eq(meetingId),
-                        apply.status.in(queryCommand.getStatuses()),
-                        apply.type.in(queryCommand.getTypes())
+                        apply.status.in(queryCommand.getStatuses())
                 );
 
     }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepositoryImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepositoryImpl.java
@@ -25,16 +25,16 @@ public class ApplySearchRepositoryImpl implements ApplySearchRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<ApplyInfoDto> findApplyList(MeetingGetApplyListCommand queryCommand, Pageable pageable, Integer meetingId, Integer studyCreatorId, Integer userId) {
-        List<ApplyInfoDto> content = getContent(queryCommand, pageable, meetingId, studyCreatorId, userId);
+    public Page<ApplyInfoDto> findApplyList(MeetingGetApplyListCommand queryCommand, Pageable pageable, Integer meetingId, Integer meetingCreatorId, Integer userId) {
+        List<ApplyInfoDto> content = getContent(queryCommand, pageable, meetingId, meetingCreatorId, userId);
         JPAQuery<Long> countQuery = getCount(queryCommand, meetingId);
 
         return PageableExecutionUtils.getPage(content,
                 PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()), countQuery::fetchFirst);
     }
 
-    private List<ApplyInfoDto> getContent(MeetingGetApplyListCommand queryCommand, Pageable pageable, Integer meetingId, Integer studyCreatorId, Integer userId) {
-        boolean isStudyCreator = Objects.equals(studyCreatorId, userId);
+    private List<ApplyInfoDto> getContent(MeetingGetApplyListCommand queryCommand, Pageable pageable, Integer meetingId, Integer meetingCreatorId, Integer userId) {
+        boolean isStudyCreator = Objects.equals(meetingCreatorId, userId);
         return queryFactory
                 .select(new QApplyInfoDto(
                         apply.id, apply.type, isStudyCreator ? apply.content : Expressions.constant(""),
@@ -45,7 +45,7 @@ public class ApplySearchRepositoryImpl implements ApplySearchRepository {
                 .leftJoin(apply.user, user)
                 .where(
                         apply.meetingId.eq(meetingId),
-                        apply.status.in(queryCommand.getStatuses())
+                        apply.status.in(queryCommand.getStatus())
                 )
                 .orderBy(queryCommand.getDate().equals("desc") ? apply.appliedDate.desc() : apply.appliedDate.asc())
                 .offset(pageable.getOffset())
@@ -60,7 +60,7 @@ public class ApplySearchRepositoryImpl implements ApplySearchRepository {
                 .fetchJoin()
                 .where(
                         apply.meetingId.eq(meetingId),
-                        apply.status.in(queryCommand.getStatuses())
+                        apply.status.in(queryCommand.getStatus())
                 );
 
     }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepositoryImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepositoryImpl.java
@@ -42,7 +42,7 @@ public class ApplySearchRepositoryImpl implements ApplySearchRepository {
                         new QApplicantDto(user.id, user.name, user.orgId, user.activities, user.profileImage,
                                 user.phone)))
                 .from(apply)
-                .leftJoin(apply.user, user)
+                .innerJoin(apply.user, user)
                 .where(
                         apply.meetingId.eq(meetingId),
                         apply.status.in(queryCommand.getStatus())

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepositoryImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepositoryImpl.java
@@ -37,7 +37,7 @@ public class ApplySearchRepositoryImpl implements ApplySearchRepository {
         boolean isStudyCreator = Objects.equals(meetingCreatorId, userId);
         return queryFactory
                 .select(new QApplyInfoDto(
-                        apply.id, apply.type, isStudyCreator ? apply.content : Expressions.constant(""),
+                        apply.id, isStudyCreator ? apply.content : Expressions.constant(""),
                         apply.appliedDate, apply.status,
                         new QApplicantDto(user.id, user.name, user.orgId, user.activities, user.profileImage,
                                 user.phone)))

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -14,6 +14,7 @@ import java.util.List;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
@@ -22,6 +23,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 
 @Tag(name = "모임")
@@ -62,4 +64,15 @@ public interface MeetingV2Api {
     ResponseEntity<Void> applyMeetingCancel(@PathVariable Integer meetingId,
                                             Principal principal);
 
+
+    @Operation(summary = "모임 지원자/참여자 조회", description = "모임 지원자/참여자 조회 (모임장이면 지원자, 아니면 참여자 조회)")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "모임 지원자/참여자 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "모임이 없습니다.", content = @Content),})
+    ResponseEntity<MeetingGetApplyListResponseDto> findApplyList(@PathVariable Integer meetingId,
+                                                                 @RequestParam(value = "page", required = false, defaultValue = "1") Integer page,
+                                                                 @RequestParam(value = "take", required = false, defaultValue = "10") Integer take,
+                                                                 @RequestParam(value = "status", required = false, defaultValue = "0") List<Integer> status,
+                                                                 @RequestParam(value = "type", required = false, defaultValue = "0") List<Integer> type,
+                                                                 @RequestParam(value = "date", required = false, defaultValue = "desc") String date,
+                                                                 Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -72,7 +72,6 @@ public interface MeetingV2Api {
                                                                  @RequestParam(value = "page", required = false, defaultValue = "1") Integer page,
                                                                  @RequestParam(value = "take", required = false, defaultValue = "10") Integer take,
                                                                  @RequestParam(value = "status", required = false, defaultValue = "0") List<Integer> status,
-                                                                 @RequestParam(value = "type", required = false, defaultValue = "0") List<Integer> type,
                                                                  @RequestParam(value = "date", required = false, defaultValue = "desc") String date,
                                                                  Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.List;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
@@ -23,7 +24,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 
 
 @Tag(name = "모임")
@@ -69,9 +69,6 @@ public interface MeetingV2Api {
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "모임 지원자/참여자 조회 성공"),
             @ApiResponse(responseCode = "400", description = "모임이 없습니다.", content = @Content),})
     ResponseEntity<MeetingGetApplyListResponseDto> findApplyList(@PathVariable Integer meetingId,
-                                                                 @RequestParam(value = "page", required = false, defaultValue = "1") Integer page,
-                                                                 @RequestParam(value = "take", required = false, defaultValue = "10") Integer take,
-                                                                 @RequestParam(value = "status", required = false, defaultValue = "0") List<Integer> status,
-                                                                 @RequestParam(value = "date", required = false, defaultValue = "desc") String date,
+                                                                 @ModelAttribute MeetingGetApplyListCommand queryCommand,
                                                                  Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -87,12 +87,11 @@ public class MeetingV2Controller implements MeetingV2Api {
                                                                         @RequestParam(value = "page", required = false, defaultValue = "1") Integer page,
                                                                         @RequestParam(value = "take", required = false, defaultValue = "10") Integer take,
                                                                         @RequestParam(value = "status", required = false, defaultValue = "0") List<Integer> status,
-                                                                        @RequestParam(value = "type", required = false, defaultValue = "0") List<Integer> type,
                                                                         @RequestParam(value = "date", required = false, defaultValue = "desc") String date,
                                                                         Principal principal) {
 
         Integer userId = UserUtil.getUserId(principal);
-        MeetingGetApplyListCommand meetingGetApplyListCommand = new MeetingGetApplyListCommand(status, type, date);
+        MeetingGetApplyListCommand meetingGetApplyListCommand = new MeetingGetApplyListCommand(status, date);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(meetingV2Service.findApplyList(meetingGetApplyListCommand, page, take, meetingId, userId));

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -84,16 +84,12 @@ public class MeetingV2Controller implements MeetingV2Api {
     @Override
     @GetMapping("/{meetingId}/list")
     public ResponseEntity<MeetingGetApplyListResponseDto> findApplyList(@PathVariable Integer meetingId,
-                                                                        @RequestParam(value = "page", required = false, defaultValue = "1") Integer page,
-                                                                        @RequestParam(value = "take", required = false, defaultValue = "10") Integer take,
-                                                                        @RequestParam(value = "status", required = false, defaultValue = "0") List<Integer> status,
-                                                                        @RequestParam(value = "date", required = false, defaultValue = "desc") String date,
+                                                                        @ModelAttribute MeetingGetApplyListCommand queryCommand,
                                                                         Principal principal) {
 
         Integer userId = UserUtil.getUserId(principal);
-        MeetingGetApplyListCommand meetingGetApplyListCommand = new MeetingGetApplyListCommand(status, date);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(meetingV2Service.findApplyList(meetingGetApplyListCommand, page, take, meetingId, userId));
+                .body(meetingV2Service.findApplyList(queryCommand, meetingId, userId));
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -6,9 +6,11 @@ import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.crew.main.common.util.UserUtil;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -76,5 +79,22 @@ public class MeetingV2Controller implements MeetingV2Api {
         Integer userId = UserUtil.getUserId(principal);
         meetingV2Service.applyMeetingCancel(meetingId, userId);
         return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @Override
+    @GetMapping("/{meetingId}/list")
+    public ResponseEntity<MeetingGetApplyListResponseDto> findApplyList(@PathVariable Integer meetingId,
+                                                                        @RequestParam(value = "page", required = false, defaultValue = "1") Integer page,
+                                                                        @RequestParam(value = "take", required = false, defaultValue = "10") Integer take,
+                                                                        @RequestParam(value = "status", required = false, defaultValue = "0") List<Integer> status,
+                                                                        @RequestParam(value = "type", required = false, defaultValue = "0") List<Integer> type,
+                                                                        @RequestParam(value = "date", required = false, defaultValue = "desc") String date,
+                                                                        Principal principal) {
+
+        Integer userId = UserUtil.getUserId(principal);
+        MeetingGetApplyListCommand meetingGetApplyListCommand = new MeetingGetApplyListCommand(status, type, date);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(meetingV2Service.findApplyList(meetingGetApplyListCommand, page, take, meetingId, userId));
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/query/MeetingGetApplyListCommand.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/query/MeetingGetApplyListCommand.java
@@ -4,20 +4,16 @@ import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
-import org.sopt.makers.crew.main.entity.apply.enums.EnApplyType;
 
 @Getter
 public class MeetingGetApplyListCommand {
 
     private List<EnApplyStatus> statuses;
-    private List<EnApplyType> types;
     private String date;
 
     @Builder
-    public MeetingGetApplyListCommand(List<Integer> statuses, List<Integer> types,
-                                      String date) {
+    public MeetingGetApplyListCommand(List<Integer> statuses, String date) {
         this.statuses = statuses.stream().map(EnApplyStatus::ofValue).toList();
-        this.types = types.stream().map(EnApplyType::ofValue).toList();
         this.date = date;
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/query/MeetingGetApplyListCommand.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/query/MeetingGetApplyListCommand.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.crew.main.meeting.v2.dto.query;
 
+import java.util.Arrays;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,7 +18,8 @@ public class MeetingGetApplyListCommand extends PageOptionsDto {
     @Builder
     public MeetingGetApplyListCommand(int page, int take, List<EnApplyStatus> status, String date) {
         super(page, take);
-        this.status = status;
-        this.date = date;
+        this.status = (status == null || status.isEmpty()) ?
+                Arrays.asList(EnApplyStatus.WAITING, EnApplyStatus.APPROVE, EnApplyStatus.REJECT) : status;
+        this.date = date == null ? "desc" : date;
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/query/MeetingGetApplyListCommand.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/query/MeetingGetApplyListCommand.java
@@ -3,17 +3,21 @@ package org.sopt.makers.crew.main.meeting.v2.dto.query;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
+import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
 
 @Getter
-public class MeetingGetApplyListCommand {
+@Setter
+public class MeetingGetApplyListCommand extends PageOptionsDto {
 
-    private List<EnApplyStatus> statuses;
+    private List<EnApplyStatus> status;
     private String date;
 
     @Builder
-    public MeetingGetApplyListCommand(List<Integer> statuses, String date) {
-        this.statuses = statuses.stream().map(EnApplyStatus::ofValue).toList();
+    public MeetingGetApplyListCommand(int page, int take, List<EnApplyStatus> status, String date) {
+        super(page, take);
+        this.status = status;
         this.date = date;
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/query/MeetingGetApplyListCommand.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/query/MeetingGetApplyListCommand.java
@@ -1,0 +1,23 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.query;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyType;
+
+@Getter
+public class MeetingGetApplyListCommand {
+
+    private List<EnApplyStatus> statuses;
+    private List<EnApplyType> types;
+    private String date;
+
+    @Builder
+    public MeetingGetApplyListCommand(List<Integer> statuses, List<Integer> types,
+                                      String date) {
+        this.statuses = statuses.stream().map(EnApplyStatus::ofValue).toList();
+        this.types = types.stream().map(EnApplyType::ofValue).toList();
+        this.date = date;
+    }
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplicantDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplicantDto.java
@@ -4,6 +4,7 @@ import com.querydsl.core.annotations.QueryProjection;
 import java.util.Comparator;
 import java.util.List;
 import lombok.Getter;
+import org.sopt.makers.crew.main.common.util.UserUtil;
 import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
 
 @Getter
@@ -22,7 +23,7 @@ public class ApplicantDto {
         this.id = id;
         this.name = name;
         this.orgId = orgId;
-        this.recentActivity = userActivityVOs.stream().max(Comparator.comparingInt(UserActivityVO::getGeneration)).orElse(null);
+        this.recentActivity = UserUtil.getRecentUserActivity(userActivityVOs);
         this.profileImage = profileImage;
         this.phone = phone;
     }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplicantDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplicantDto.java
@@ -1,0 +1,29 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.util.Comparator;
+import java.util.List;
+import lombok.Getter;
+import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
+
+@Getter
+public class ApplicantDto {
+    private final Integer id;
+    private final String name;
+    private final Integer orgId;
+    private final UserActivityVO recentActivity;
+    private final String profileImage;
+    private final String phone;
+
+    @QueryProjection
+    public ApplicantDto(Integer id, String name, Integer orgId, List<UserActivityVO> userActivityVOs, String profileImage,
+                        String phone) {
+
+        this.id = id;
+        this.name = name;
+        this.orgId = orgId;
+        this.recentActivity = userActivityVOs.stream().max(Comparator.comparingInt(UserActivityVO::getGeneration)).orElse(null);
+        this.profileImage = profileImage;
+        this.phone = phone;
+    }
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyInfoDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyInfoDto.java
@@ -8,21 +8,21 @@ import org.sopt.makers.crew.main.entity.apply.enums.EnApplyType;
 
 @Getter
 public class ApplyInfoDto {
-    private final Integer applyId;
+    private final Integer id;
     private final int type;
     private final String content;
     private final LocalDateTime appliedDate;
     private final int status;
-    private final ApplicantDto applicant;
+    private final ApplicantDto user;
 
     @QueryProjection
-    public ApplyInfoDto(Integer applyId, EnApplyType type, String content, LocalDateTime appliedDate, EnApplyStatus status,
-                        ApplicantDto applicant) {
-        this.applyId = applyId;
+    public ApplyInfoDto(Integer id, EnApplyType type, String content, LocalDateTime appliedDate, EnApplyStatus status,
+                        ApplicantDto user) {
+        this.id = id;
         this.type = type.getValue();
         this.content = content;
         this.appliedDate = appliedDate;
         this.status = status.getValue();
-        this.applicant = applicant;
+        this.user = user;
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyInfoDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyInfoDto.java
@@ -4,25 +4,22 @@ import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
-import org.sopt.makers.crew.main.entity.apply.enums.EnApplyType;
 
 @Getter
 public class ApplyInfoDto {
     private final Integer id;
-    private final int type;
     private final String content;
     private final LocalDateTime appliedDate;
-    private final int status;
+    private final EnApplyStatus status;
     private final ApplicantDto user;
 
     @QueryProjection
-    public ApplyInfoDto(Integer id, EnApplyType type, String content, LocalDateTime appliedDate, EnApplyStatus status,
+    public ApplyInfoDto(Integer id, String content, LocalDateTime appliedDate, EnApplyStatus status,
                         ApplicantDto user) {
         this.id = id;
-        this.type = type.getValue();
         this.content = content;
         this.appliedDate = appliedDate;
-        this.status = status.getValue();
+        this.status = status;
         this.user = user;
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyInfoDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyInfoDto.java
@@ -1,0 +1,28 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyType;
+
+@Getter
+public class ApplyInfoDto {
+    private final Integer applyId;
+    private final int type;
+    private final String content;
+    private final LocalDateTime appliedDate;
+    private final int status;
+    private final ApplicantDto applicant;
+
+    @QueryProjection
+    public ApplyInfoDto(Integer applyId, EnApplyType type, String content, LocalDateTime appliedDate, EnApplyStatus status,
+                        ApplicantDto applicant) {
+        this.applyId = applyId;
+        this.type = type.getValue();
+        this.content = content;
+        this.appliedDate = appliedDate;
+        this.status = status.getValue();
+        this.applicant = applicant;
+    }
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingGetApplyListResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingGetApplyListResponseDto.java
@@ -1,0 +1,14 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.sopt.makers.crew.main.common.pagination.dto.PageMetaDto;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class MeetingGetApplyListResponseDto {
+
+    private final List<ApplyInfoDto> applies;
+    private final PageMetaDto meta;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingGetApplyListResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingGetApplyListResponseDto.java
@@ -9,6 +9,6 @@ import org.sopt.makers.crew.main.common.pagination.dto.PageMetaDto;
 @AllArgsConstructor(staticName = "of")
 public class MeetingGetApplyListResponseDto {
 
-    private final List<ApplyInfoDto> applies;
+    private final List<ApplyInfoDto> apply;
     private final PageMetaDto meta;
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -1,9 +1,11 @@
 package org.sopt.makers.crew.main.meeting.v2.service;
 
 import java.util.List;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
@@ -21,4 +23,7 @@ public interface MeetingV2Service {
     MeetingV2ApplyMeetingResponseDto applyMeeting(MeetingV2ApplyMeetingDto requestBody, Integer userId);
 
     void applyMeetingCancel(Integer meetingId, Integer userId);
+
+    MeetingGetApplyListResponseDto findApplyList(MeetingGetApplyListCommand queryCommand, int page, int take, Integer meetingId,
+                                                 Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -24,6 +24,6 @@ public interface MeetingV2Service {
 
     void applyMeetingCancel(Integer meetingId, Integer userId);
 
-    MeetingGetApplyListResponseDto findApplyList(MeetingGetApplyListCommand queryCommand, int page, int take, Integer meetingId,
+    MeetingGetApplyListResponseDto findApplyList(MeetingGetApplyListCommand queryCommand, Integer meetingId,
                                                  Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -185,17 +185,17 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
     @Override
     @Transactional(readOnly = true)
-    public MeetingGetApplyListResponseDto findApplyList(MeetingGetApplyListCommand queryCommand, int page, int take, Integer meetingId,
+    public MeetingGetApplyListResponseDto findApplyList(MeetingGetApplyListCommand queryCommand, int page, int take,
+                                                        Integer meetingId,
                                                         Integer userId) {
         Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
-        Page<ApplyInfoDto> applyInfoDtos = applyRepository.findApplyList(queryCommand, PageRequest.of(page - 1, take), meeting, userId);
+        Page<ApplyInfoDto> applyInfoDtos = applyRepository.findApplyList(queryCommand, PageRequest.of(page - 1, take),
+                meetingId, meeting.getUserId(), userId);
         PageOptionsDto pageOptionsDto = new PageOptionsDto(page, take);
         PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, (int) applyInfoDtos.getTotalElements());
 
         return MeetingGetApplyListResponseDto.of(applyInfoDtos.getContent(), pageMetaDto);
     }
-
-
 
     // private 메서드 들
 

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -37,15 +37,20 @@ import org.sopt.makers.crew.main.entity.user.enums.UserPart;
 import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
 import org.sopt.makers.crew.main.meeting.v2.dto.ApplyMapper;
 import org.sopt.makers.crew.main.meeting.v2.dto.MeetingMapper;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseUserDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -177,6 +182,23 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
         applyRepository.deleteByMeetingIdAndUserId(meetingId, userId);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MeetingGetApplyListResponseDto findApplyList(MeetingGetApplyListCommand queryCommand, int page, int take, Integer meetingId,
+                                                        Integer userId) {
+        Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
+        Page<ApplyInfoDto> applyInfoDtos = applyRepository.findApplyList(queryCommand, PageRequest.of(page - 1, take), meeting, userId);
+        PageOptionsDto pageOptionsDto = new PageOptionsDto(page, take);
+        PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, (int) applyInfoDtos.getTotalElements());
+
+        return MeetingGetApplyListResponseDto.of(applyInfoDtos.getContent(), pageMetaDto);
+    }
+
+
+
+    // private 메서드 들
+
 
     private Boolean checkMeetingLeader(Meeting meeting, Integer userId) {
         return meeting.getUserId().equals(userId);

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -185,13 +185,14 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
     @Override
     @Transactional(readOnly = true)
-    public MeetingGetApplyListResponseDto findApplyList(MeetingGetApplyListCommand queryCommand, int page, int take,
+    public MeetingGetApplyListResponseDto findApplyList(MeetingGetApplyListCommand queryCommand,
                                                         Integer meetingId,
                                                         Integer userId) {
         Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
-        Page<ApplyInfoDto> applyInfoDtos = applyRepository.findApplyList(queryCommand, PageRequest.of(page - 1, take),
+        Page<ApplyInfoDto> applyInfoDtos = applyRepository.findApplyList(queryCommand,
+                PageRequest.of(queryCommand.getPage() - 1, queryCommand.getTake()),
                 meetingId, meeting.getUserId(), userId);
-        PageOptionsDto pageOptionsDto = new PageOptionsDto(page, take);
+        PageOptionsDto pageOptionsDto = new PageOptionsDto(queryCommand.getPage(), queryCommand.getTake());
         PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, (int) applyInfoDtos.getTotalElements());
 
         return MeetingGetApplyListResponseDto.of(applyInfoDtos.getContent(), pageMetaDto);

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -198,8 +198,6 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
         return MeetingGetApplyListResponseDto.of(applyInfoDtos.getContent(), pageMetaDto);
     }
 
-    // private 메서드 들
-
 
     private Boolean checkMeetingLeader(Meeting meeting, Integer userId) {
         return meeting.getUserId().equals(userId);

--- a/main/src/main/resources/application-test.yml
+++ b/main/src/main/resources/application-test.yml
@@ -17,12 +17,14 @@ spring:
     hibernate:
       naming:
         physical-strategy: org.sopt.makers.crew.main.common.config.CamelCaseNamingStrategy
-      ddl-auto: create
+      ddl-auto: create-drop
     properties:
       hibernate:
         show_sql: true
         format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
       storage_engine: innodb
+    defer-datasource-initialization: true
 
 jwt:
   header: Authorization

--- a/main/src/test/java/org/sopt/makers/crew/main/common/config/TestConfig.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/common/config/TestConfig.java
@@ -1,0 +1,18 @@
+package org.sopt.makers.crew.main.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/entity/user/UserRepositoryTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/entity/user/UserRepositoryTest.java
@@ -2,14 +2,17 @@ package org.sopt.makers.crew.main.entity.user;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.sopt.makers.crew.main.common.config.TestConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(TestConfig.class)
 public class UserRepositoryTest {
 
     @Autowired

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/repository/ApplyRepositoryTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/repository/ApplyRepositoryTest.java
@@ -1,0 +1,280 @@
+package org.sopt.makers.crew.main.meeting.v2.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sopt.makers.crew.main.common.config.TestConfig;
+import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.test.context.jdbc.SqlGroup;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(TestConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@SqlGroup({
+        @Sql(value = "/sql/apply-repository-test-data.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD),
+        @Sql(value = "/sql/delete-all-data.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+
+})
+public class ApplyRepositoryTest {
+
+    @Autowired
+    private ApplyRepository applyRepository;
+
+    @Test
+    void 스터디장이_신청자_리스트_최신순으로_조회() {
+        // given
+        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(0, 1, 2),
+                List.of(0), "desc");
+        int page = 1;
+        int take = 12;
+        Integer meetingId = 1;
+        Integer studyCreatorId = 1;
+        Integer userId = 1;
+
+        // when
+        Page<ApplyInfoDto> applyInfoDtos = applyRepository.findApplyList(queryCommand, PageRequest.of(page - 1, take),
+                meetingId, studyCreatorId, userId);
+
+        // then
+        assertThat(applyInfoDtos.getTotalElements()).isEqualTo(3);
+        assertThat(applyInfoDtos.getSize()).isEqualTo(take);
+        assertThat(applyInfoDtos.getNumber()).isEqualTo(page-1);
+        assertThat(applyInfoDtos.getTotalPages()).isEqualTo(1);
+
+
+        ApplyInfoDto applyInfoDto1 = applyInfoDtos.getContent().get(0);
+        assertThat(applyInfoDto1)
+                .extracting("applyId", "type", "content", "appliedDate", "status")
+                .containsExactly(3, 0, "전할말입니다3",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 3, 413489000)), 0);
+        assertThat(applyInfoDto1.getApplicant())
+                .extracting("id", "name", "orgId", "profileImage", "phone")
+                .containsExactly(4, "이영지", 1004, "profile4.jpg", "010-5555-5555");
+        assertThat(applyInfoDto1.getApplicant().getRecentActivity().getGeneration()).isEqualTo(32);
+
+
+        ApplyInfoDto applyInfoDto2 = applyInfoDtos.getContent().get(1);
+        assertThat(applyInfoDto2)
+                .extracting("applyId", "type", "content", "appliedDate", "status")
+                .containsExactly(2, 0, "전할말입니다2",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 2, 413489000)), 1);
+        assertThat(applyInfoDto2.getApplicant())
+                .extracting("id", "name", "orgId", "profileImage", "phone")
+                .containsExactly(3, "김철수", 1003, "profile3.jpg", "010-3333-4444");
+        assertThat(applyInfoDto2.getApplicant().getRecentActivity().getGeneration()).isEqualTo(34);
+
+
+        ApplyInfoDto applyInfoDto3 = applyInfoDtos.getContent().get(2);
+        assertThat(applyInfoDto3)
+                .extracting("applyId", "type", "content", "appliedDate", "status")
+                .containsExactly(1, 0, "전할말입니다1",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 0, 913489000)), 1);
+        assertThat(applyInfoDto3.getApplicant())
+                .extracting("id", "name", "orgId", "profileImage", "phone")
+                .containsExactly(2, "홍길동", 1002, "profile2.jpg", "010-1111-2222");
+        assertThat(applyInfoDto3.getApplicant().getRecentActivity().getGeneration()).isEqualTo(33);
+    }
+
+    @Test
+    void 스터디장이_신청자_리스트_오래된순으로_조회() {
+        // given
+        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(0, 1, 2),
+                List.of(0), "asc");
+        int page = 1;
+        int take = 12;
+        Integer meetingId = 1;
+        Integer studyCreatorId = 1;
+        Integer userId = 1;
+
+        // when
+        Page<ApplyInfoDto> applyInfoDtos = applyRepository.findApplyList(queryCommand, PageRequest.of(page - 1, take),
+                meetingId, studyCreatorId, userId);
+
+        // then
+        assertThat(applyInfoDtos.getTotalElements()).isEqualTo(3);
+        assertThat(applyInfoDtos.getSize()).isEqualTo(take);
+        assertThat(applyInfoDtos.getNumber()).isEqualTo(page-1);
+        assertThat(applyInfoDtos.getTotalPages()).isEqualTo(1);
+
+        ApplyInfoDto applyInfoDto3 = applyInfoDtos.getContent().get(0);
+        assertThat(applyInfoDto3)
+                .extracting("applyId", "type", "content", "appliedDate", "status")
+                .containsExactly(1, 0, "전할말입니다1",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 0, 913489000)), 1);
+        assertThat(applyInfoDto3.getApplicant())
+                .extracting("id", "name", "orgId", "profileImage", "phone")
+                .containsExactly(2, "홍길동", 1002, "profile2.jpg", "010-1111-2222");
+        assertThat(applyInfoDto3.getApplicant().getRecentActivity().getGeneration()).isEqualTo(33);
+
+        ApplyInfoDto applyInfoDto2 = applyInfoDtos.getContent().get(1);
+        assertThat(applyInfoDto2)
+                .extracting("applyId", "type", "content", "appliedDate", "status")
+                .containsExactly(2, 0, "전할말입니다2",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 2, 413489000)), 1);
+        assertThat(applyInfoDto2.getApplicant())
+                .extracting("id", "name", "orgId", "profileImage", "phone")
+                .containsExactly(3, "김철수", 1003, "profile3.jpg", "010-3333-4444");
+        assertThat(applyInfoDto2.getApplicant().getRecentActivity().getGeneration()).isEqualTo(34);
+
+        ApplyInfoDto applyInfoDto1 = applyInfoDtos.getContent().get(2);
+        assertThat(applyInfoDto1)
+                .extracting("applyId", "type", "content", "appliedDate", "status")
+                .containsExactly(3, 0, "전할말입니다3",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 3, 413489000)), 0);
+        assertThat(applyInfoDto1.getApplicant())
+                .extracting("id", "name", "orgId", "profileImage", "phone")
+                .containsExactly(4, "이영지", 1004, "profile4.jpg", "010-5555-5555");
+        assertThat(applyInfoDto1.getApplicant().getRecentActivity().getGeneration()).isEqualTo(32);
+
+    }
+
+    @Test
+    void 스터디장이_신청자_리스트_대기상태만_오래된순으로_조회() {
+        // given
+        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(0),
+                List.of(0), "asc");
+        int page = 1;
+        int take = 12;
+        Integer meetingId = 1;
+        Integer studyCreatorId = 1;
+        Integer userId = 1;
+
+        // when
+        Page<ApplyInfoDto> applyInfoDtos = applyRepository.findApplyList(queryCommand, PageRequest.of(page - 1, take),
+                meetingId, studyCreatorId, userId);
+
+        // then
+        assertThat(applyInfoDtos.getTotalElements()).isEqualTo(1);
+        assertThat(applyInfoDtos.getSize()).isEqualTo(take);
+        assertThat(applyInfoDtos.getNumber()).isEqualTo(page-1);
+        assertThat(applyInfoDtos.getTotalPages()).isEqualTo(1);
+
+        ApplyInfoDto applyInfoDto1 = applyInfoDtos.getContent().get(0);
+        assertThat(applyInfoDto1)
+                .extracting("applyId", "type", "content", "appliedDate", "status")
+                .containsExactly(3, 0, "전할말입니다3",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 3, 413489000)), 0);
+        assertThat(applyInfoDto1.getApplicant())
+                .extracting("id", "name", "orgId", "profileImage", "phone")
+                .containsExactly(4, "이영지", 1004, "profile4.jpg", "010-5555-5555");
+        assertThat(applyInfoDto1.getApplicant().getRecentActivity().getGeneration()).isEqualTo(32);
+
+    }
+
+    @Test
+    void 스터디장이_신청자_리스트_승인상태만_오래된순으로_조회() {
+        // given
+        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(1),
+                List.of(0), "asc");
+        int page = 1;
+        int take = 12;
+        Integer meetingId = 1;
+        Integer studyCreatorId = 1;
+        Integer userId = 1;
+
+        // when
+        Page<ApplyInfoDto> applyInfoDtos = applyRepository.findApplyList(queryCommand, PageRequest.of(page - 1, take),
+                meetingId, studyCreatorId, userId);
+
+        // then
+        assertThat(applyInfoDtos.getTotalElements()).isEqualTo(2);
+        assertThat(applyInfoDtos.getSize()).isEqualTo(take);
+        assertThat(applyInfoDtos.getNumber()).isEqualTo(page-1);
+        assertThat(applyInfoDtos.getTotalPages()).isEqualTo(1);
+
+        ApplyInfoDto applyInfoDto3 = applyInfoDtos.getContent().get(0);
+        assertThat(applyInfoDto3)
+                .extracting("applyId", "type", "content", "appliedDate", "status")
+                .containsExactly(1, 0, "전할말입니다1",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 0, 913489000)), 1);
+        assertThat(applyInfoDto3.getApplicant())
+                .extracting("id", "name", "orgId", "profileImage", "phone")
+                .containsExactly(2, "홍길동", 1002, "profile2.jpg", "010-1111-2222");
+        assertThat(applyInfoDto3.getApplicant().getRecentActivity().getGeneration()).isEqualTo(33);
+
+        ApplyInfoDto applyInfoDto2 = applyInfoDtos.getContent().get(1);
+        assertThat(applyInfoDto2)
+                .extracting("applyId", "type", "content", "appliedDate", "status")
+                .containsExactly(2, 0, "전할말입니다2",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 2, 413489000)), 1);
+        assertThat(applyInfoDto2.getApplicant())
+                .extracting("id", "name", "orgId", "profileImage", "phone")
+                .containsExactly(3, "김철수", 1003, "profile3.jpg", "010-3333-4444");
+        assertThat(applyInfoDto2.getApplicant().getRecentActivity().getGeneration()).isEqualTo(34);
+
+    }
+
+
+    @Test
+    void 스터디장이_아닌_사람이_신청자_리스트_조회() {
+        // given
+        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(0, 1, 2),
+                List.of(0), "desc");
+        int page = 1;
+        int take = 12;
+        Integer meetingId = 1;
+        Integer studyCreatorId = 1;
+        Integer userId = 2;
+
+        // when
+        Page<ApplyInfoDto> applyInfoDtos = applyRepository.findApplyList(queryCommand, PageRequest.of(page - 1, take),
+                meetingId, studyCreatorId, userId);
+
+        // then
+        assertThat(applyInfoDtos.getTotalElements()).isEqualTo(3);
+        assertThat(applyInfoDtos.getSize()).isEqualTo(take);
+        assertThat(applyInfoDtos.getNumber()).isEqualTo(page-1);
+        assertThat(applyInfoDtos.getTotalPages()).isEqualTo(1);
+
+        ApplyInfoDto applyInfoDto1 = applyInfoDtos.getContent().get(0);
+        assertThat(applyInfoDto1)
+                .extracting("applyId", "type", "content", "appliedDate", "status")
+                .containsExactly(3, 0, "",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 3, 413489000)), 0);
+        assertThat(applyInfoDto1.getApplicant())
+                .extracting("id", "name", "orgId", "profileImage", "phone")
+                .containsExactly(4, "이영지", 1004, "profile4.jpg", "010-5555-5555");
+        assertThat(applyInfoDto1.getApplicant().getRecentActivity().getGeneration()).isEqualTo(32);
+
+
+        ApplyInfoDto applyInfoDto2 = applyInfoDtos.getContent().get(1);
+        assertThat(applyInfoDto2)
+                .extracting("applyId", "type", "content", "appliedDate", "status")
+                .containsExactly(2, 0, "",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 2, 413489000)), 1);
+        assertThat(applyInfoDto2.getApplicant())
+                .extracting("id", "name", "orgId", "profileImage", "phone")
+                .containsExactly(3, "김철수", 1003, "profile3.jpg", "010-3333-4444");
+        assertThat(applyInfoDto2.getApplicant().getRecentActivity().getGeneration()).isEqualTo(34);
+
+
+        ApplyInfoDto applyInfoDto3 = applyInfoDtos.getContent().get(2);
+        assertThat(applyInfoDto3)
+                .extracting("applyId", "type", "content", "appliedDate", "status")
+                .containsExactly(1, 0, "",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 0, 913489000)), 1);
+        assertThat(applyInfoDto3.getApplicant())
+                .extracting("id", "name", "orgId", "profileImage", "phone")
+                .containsExactly(2, "홍길동", 1002, "profile2.jpg", "010-1111-2222");
+        assertThat(applyInfoDto3.getApplicant().getRecentActivity().getGeneration()).isEqualTo(33);
+    }
+
+
+
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/repository/ApplyRepositoryTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/repository/ApplyRepositoryTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.sopt.makers.crew.main.common.config.TestConfig;
 import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDto;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,9 +40,9 @@ public class ApplyRepositoryTest {
     @Test
     void 스터디장이_신청자_리스트_최신순으로_조회() {
         // given
-        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(0, 1, 2), "desc");
         int page = 1;
         int take = 12;
+        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(page, take, List.of(EnApplyStatus.WAITING, EnApplyStatus.APPROVE, EnApplyStatus.REJECT), "desc");
         Integer meetingId = 1;
         Integer studyCreatorId = 1;
         Integer userId = 1;
@@ -59,43 +60,43 @@ public class ApplyRepositoryTest {
 
         ApplyInfoDto applyInfoDto1 = applyInfoDtos.getContent().get(0);
         assertThat(applyInfoDto1)
-                .extracting("applyId", "type", "content", "appliedDate", "status")
-                .containsExactly(3, 0, "전할말입니다3",
-                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 3, 413489000)), 0);
-        assertThat(applyInfoDto1.getApplicant())
+                .extracting("id", "content", "appliedDate", "status")
+                .containsExactly(3, "전할말입니다3",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 3, 413489000)), EnApplyStatus.WAITING);
+        assertThat(applyInfoDto1.getUser())
                 .extracting("id", "name", "orgId", "profileImage", "phone")
                 .containsExactly(4, "이영지", 1004, "profile4.jpg", "010-5555-5555");
-        assertThat(applyInfoDto1.getApplicant().getRecentActivity().getGeneration()).isEqualTo(32);
+        assertThat(applyInfoDto1.getUser().getRecentActivity().getGeneration()).isEqualTo(32);
 
 
         ApplyInfoDto applyInfoDto2 = applyInfoDtos.getContent().get(1);
         assertThat(applyInfoDto2)
-                .extracting("applyId", "type", "content", "appliedDate", "status")
-                .containsExactly(2, 0, "전할말입니다2",
-                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 2, 413489000)), 1);
-        assertThat(applyInfoDto2.getApplicant())
+                .extracting("id", "content", "appliedDate", "status")
+                .containsExactly(2, "전할말입니다2",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 2, 413489000)), EnApplyStatus.APPROVE);
+        assertThat(applyInfoDto2.getUser())
                 .extracting("id", "name", "orgId", "profileImage", "phone")
                 .containsExactly(3, "김철수", 1003, "profile3.jpg", "010-3333-4444");
-        assertThat(applyInfoDto2.getApplicant().getRecentActivity().getGeneration()).isEqualTo(34);
+        assertThat(applyInfoDto2.getUser().getRecentActivity().getGeneration()).isEqualTo(34);
 
 
         ApplyInfoDto applyInfoDto3 = applyInfoDtos.getContent().get(2);
         assertThat(applyInfoDto3)
-                .extracting("applyId", "type", "content", "appliedDate", "status")
-                .containsExactly(1, 0, "전할말입니다1",
-                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 0, 913489000)), 1);
-        assertThat(applyInfoDto3.getApplicant())
+                .extracting("id", "content", "appliedDate", "status")
+                .containsExactly(1, "전할말입니다1",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 0, 913489000)), EnApplyStatus.APPROVE);
+        assertThat(applyInfoDto3.getUser())
                 .extracting("id", "name", "orgId", "profileImage", "phone")
                 .containsExactly(2, "홍길동", 1002, "profile2.jpg", "010-1111-2222");
-        assertThat(applyInfoDto3.getApplicant().getRecentActivity().getGeneration()).isEqualTo(33);
+        assertThat(applyInfoDto3.getUser().getRecentActivity().getGeneration()).isEqualTo(33);
     }
 
     @Test
     void 스터디장이_신청자_리스트_오래된순으로_조회() {
         // given
-        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(0, 1, 2), "asc");
         int page = 1;
         int take = 12;
+        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(page, take, List.of(EnApplyStatus.WAITING, EnApplyStatus.APPROVE, EnApplyStatus.REJECT), "asc");
         Integer meetingId = 1;
         Integer studyCreatorId = 1;
         Integer userId = 1;
@@ -112,42 +113,42 @@ public class ApplyRepositoryTest {
 
         ApplyInfoDto applyInfoDto3 = applyInfoDtos.getContent().get(0);
         assertThat(applyInfoDto3)
-                .extracting("applyId", "type", "content", "appliedDate", "status")
-                .containsExactly(1, 0, "전할말입니다1",
-                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 0, 913489000)), 1);
-        assertThat(applyInfoDto3.getApplicant())
+                .extracting("id", "content", "appliedDate", "status")
+                .containsExactly(1, "전할말입니다1",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 0, 913489000)), EnApplyStatus.APPROVE);
+        assertThat(applyInfoDto3.getUser())
                 .extracting("id", "name", "orgId", "profileImage", "phone")
                 .containsExactly(2, "홍길동", 1002, "profile2.jpg", "010-1111-2222");
-        assertThat(applyInfoDto3.getApplicant().getRecentActivity().getGeneration()).isEqualTo(33);
+        assertThat(applyInfoDto3.getUser().getRecentActivity().getGeneration()).isEqualTo(33);
 
         ApplyInfoDto applyInfoDto2 = applyInfoDtos.getContent().get(1);
         assertThat(applyInfoDto2)
-                .extracting("applyId", "type", "content", "appliedDate", "status")
-                .containsExactly(2, 0, "전할말입니다2",
-                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 2, 413489000)), 1);
-        assertThat(applyInfoDto2.getApplicant())
+                .extracting("id", "content", "appliedDate", "status")
+                .containsExactly(2, "전할말입니다2",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 2, 413489000)), EnApplyStatus.APPROVE);
+        assertThat(applyInfoDto2.getUser())
                 .extracting("id", "name", "orgId", "profileImage", "phone")
                 .containsExactly(3, "김철수", 1003, "profile3.jpg", "010-3333-4444");
-        assertThat(applyInfoDto2.getApplicant().getRecentActivity().getGeneration()).isEqualTo(34);
+        assertThat(applyInfoDto2.getUser().getRecentActivity().getGeneration()).isEqualTo(34);
 
         ApplyInfoDto applyInfoDto1 = applyInfoDtos.getContent().get(2);
         assertThat(applyInfoDto1)
-                .extracting("applyId", "type", "content", "appliedDate", "status")
-                .containsExactly(3, 0, "전할말입니다3",
-                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 3, 413489000)), 0);
-        assertThat(applyInfoDto1.getApplicant())
+                .extracting("id", "content", "appliedDate", "status")
+                .containsExactly(3, "전할말입니다3",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 3, 413489000)), EnApplyStatus.WAITING);
+        assertThat(applyInfoDto1.getUser())
                 .extracting("id", "name", "orgId", "profileImage", "phone")
                 .containsExactly(4, "이영지", 1004, "profile4.jpg", "010-5555-5555");
-        assertThat(applyInfoDto1.getApplicant().getRecentActivity().getGeneration()).isEqualTo(32);
+        assertThat(applyInfoDto1.getUser().getRecentActivity().getGeneration()).isEqualTo(32);
 
     }
 
     @Test
     void 스터디장이_신청자_리스트_대기상태만_오래된순으로_조회() {
         // given
-        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(0), "asc");
         int page = 1;
         int take = 12;
+        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(page, take, List.of(EnApplyStatus.WAITING), "asc");
         Integer meetingId = 1;
         Integer studyCreatorId = 1;
         Integer userId = 1;
@@ -164,22 +165,22 @@ public class ApplyRepositoryTest {
 
         ApplyInfoDto applyInfoDto1 = applyInfoDtos.getContent().get(0);
         assertThat(applyInfoDto1)
-                .extracting("applyId", "type", "content", "appliedDate", "status")
-                .containsExactly(3, 0, "전할말입니다3",
-                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 3, 413489000)), 0);
-        assertThat(applyInfoDto1.getApplicant())
+                .extracting("id", "content", "appliedDate", "status")
+                .containsExactly(3, "전할말입니다3",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 3, 413489000)), EnApplyStatus.WAITING);
+        assertThat(applyInfoDto1.getUser())
                 .extracting("id", "name", "orgId", "profileImage", "phone")
                 .containsExactly(4, "이영지", 1004, "profile4.jpg", "010-5555-5555");
-        assertThat(applyInfoDto1.getApplicant().getRecentActivity().getGeneration()).isEqualTo(32);
+        assertThat(applyInfoDto1.getUser().getRecentActivity().getGeneration()).isEqualTo(32);
 
     }
 
     @Test
     void 스터디장이_신청자_리스트_승인상태만_오래된순으로_조회() {
         // given
-        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(1), "asc");
         int page = 1;
         int take = 12;
+        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(page, take, List.of(EnApplyStatus.APPROVE), "asc");
         Integer meetingId = 1;
         Integer studyCreatorId = 1;
         Integer userId = 1;
@@ -196,23 +197,23 @@ public class ApplyRepositoryTest {
 
         ApplyInfoDto applyInfoDto3 = applyInfoDtos.getContent().get(0);
         assertThat(applyInfoDto3)
-                .extracting("applyId", "type", "content", "appliedDate", "status")
-                .containsExactly(1, 0, "전할말입니다1",
-                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 0, 913489000)), 1);
-        assertThat(applyInfoDto3.getApplicant())
+                .extracting("id", "content", "appliedDate", "status")
+                .containsExactly(1, "전할말입니다1",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 0, 913489000)), EnApplyStatus.APPROVE);
+        assertThat(applyInfoDto3.getUser())
                 .extracting("id", "name", "orgId", "profileImage", "phone")
                 .containsExactly(2, "홍길동", 1002, "profile2.jpg", "010-1111-2222");
-        assertThat(applyInfoDto3.getApplicant().getRecentActivity().getGeneration()).isEqualTo(33);
+        assertThat(applyInfoDto3.getUser().getRecentActivity().getGeneration()).isEqualTo(33);
 
         ApplyInfoDto applyInfoDto2 = applyInfoDtos.getContent().get(1);
         assertThat(applyInfoDto2)
-                .extracting("applyId", "type", "content", "appliedDate", "status")
-                .containsExactly(2, 0, "전할말입니다2",
-                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 2, 413489000)), 1);
-        assertThat(applyInfoDto2.getApplicant())
+                .extracting("id", "content", "appliedDate", "status")
+                .containsExactly(2, "전할말입니다2",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 2, 413489000)), EnApplyStatus.APPROVE);
+        assertThat(applyInfoDto2.getUser())
                 .extracting("id", "name", "orgId", "profileImage", "phone")
                 .containsExactly(3, "김철수", 1003, "profile3.jpg", "010-3333-4444");
-        assertThat(applyInfoDto2.getApplicant().getRecentActivity().getGeneration()).isEqualTo(34);
+        assertThat(applyInfoDto2.getUser().getRecentActivity().getGeneration()).isEqualTo(34);
 
     }
 
@@ -220,9 +221,9 @@ public class ApplyRepositoryTest {
     @Test
     void 스터디장이_아닌_사람이_신청자_리스트_조회() {
         // given
-        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(0, 1, 2), "desc");
         int page = 1;
         int take = 12;
+        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(page, take, List.of(EnApplyStatus.WAITING, EnApplyStatus.APPROVE, EnApplyStatus.REJECT), "desc");
         Integer meetingId = 1;
         Integer studyCreatorId = 1;
         Integer userId = 2;
@@ -239,35 +240,35 @@ public class ApplyRepositoryTest {
 
         ApplyInfoDto applyInfoDto1 = applyInfoDtos.getContent().get(0);
         assertThat(applyInfoDto1)
-                .extracting("applyId", "type", "content", "appliedDate", "status")
-                .containsExactly(3, 0, "",
-                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 3, 413489000)), 0);
-        assertThat(applyInfoDto1.getApplicant())
+                .extracting("id", "content", "appliedDate", "status")
+                .containsExactly(3, "",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 3, 413489000)), EnApplyStatus.WAITING);
+        assertThat(applyInfoDto1.getUser())
                 .extracting("id", "name", "orgId", "profileImage", "phone")
                 .containsExactly(4, "이영지", 1004, "profile4.jpg", "010-5555-5555");
-        assertThat(applyInfoDto1.getApplicant().getRecentActivity().getGeneration()).isEqualTo(32);
+        assertThat(applyInfoDto1.getUser().getRecentActivity().getGeneration()).isEqualTo(32);
 
 
         ApplyInfoDto applyInfoDto2 = applyInfoDtos.getContent().get(1);
         assertThat(applyInfoDto2)
-                .extracting("applyId", "type", "content", "appliedDate", "status")
-                .containsExactly(2, 0, "",
-                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 2, 413489000)), 1);
-        assertThat(applyInfoDto2.getApplicant())
+                .extracting("id", "content", "appliedDate", "status")
+                .containsExactly(2, "",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 2, 413489000)), EnApplyStatus.APPROVE);
+        assertThat(applyInfoDto2.getUser())
                 .extracting("id", "name", "orgId", "profileImage", "phone")
                 .containsExactly(3, "김철수", 1003, "profile3.jpg", "010-3333-4444");
-        assertThat(applyInfoDto2.getApplicant().getRecentActivity().getGeneration()).isEqualTo(34);
+        assertThat(applyInfoDto2.getUser().getRecentActivity().getGeneration()).isEqualTo(34);
 
 
         ApplyInfoDto applyInfoDto3 = applyInfoDtos.getContent().get(2);
         assertThat(applyInfoDto3)
-                .extracting("applyId", "type", "content", "appliedDate", "status")
-                .containsExactly(1, 0, "",
-                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 0, 913489000)), 1);
-        assertThat(applyInfoDto3.getApplicant())
+                .extracting("id", "content", "appliedDate", "status")
+                .containsExactly(1, "",
+                        LocalDateTime.of(LocalDate.of(2024, 05, 19), LocalTime.of(0, 0, 0, 913489000)), EnApplyStatus.APPROVE);
+        assertThat(applyInfoDto3.getUser())
                 .extracting("id", "name", "orgId", "profileImage", "phone")
                 .containsExactly(2, "홍길동", 1002, "profile2.jpg", "010-1111-2222");
-        assertThat(applyInfoDto3.getApplicant().getRecentActivity().getGeneration()).isEqualTo(33);
+        assertThat(applyInfoDto3.getUser().getRecentActivity().getGeneration()).isEqualTo(33);
     }
 
 

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/repository/ApplyRepositoryTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/repository/ApplyRepositoryTest.java
@@ -39,8 +39,7 @@ public class ApplyRepositoryTest {
     @Test
     void 스터디장이_신청자_리스트_최신순으로_조회() {
         // given
-        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(0, 1, 2),
-                List.of(0), "desc");
+        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(0, 1, 2), "desc");
         int page = 1;
         int take = 12;
         Integer meetingId = 1;
@@ -94,8 +93,7 @@ public class ApplyRepositoryTest {
     @Test
     void 스터디장이_신청자_리스트_오래된순으로_조회() {
         // given
-        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(0, 1, 2),
-                List.of(0), "asc");
+        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(0, 1, 2), "asc");
         int page = 1;
         int take = 12;
         Integer meetingId = 1;
@@ -147,8 +145,7 @@ public class ApplyRepositoryTest {
     @Test
     void 스터디장이_신청자_리스트_대기상태만_오래된순으로_조회() {
         // given
-        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(0),
-                List.of(0), "asc");
+        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(0), "asc");
         int page = 1;
         int take = 12;
         Integer meetingId = 1;
@@ -180,8 +177,7 @@ public class ApplyRepositoryTest {
     @Test
     void 스터디장이_신청자_리스트_승인상태만_오래된순으로_조회() {
         // given
-        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(1),
-                List.of(0), "asc");
+        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(1), "asc");
         int page = 1;
         int take = 12;
         Integer meetingId = 1;
@@ -224,8 +220,7 @@ public class ApplyRepositoryTest {
     @Test
     void 스터디장이_아닌_사람이_신청자_리스트_조회() {
         // given
-        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(0, 1, 2),
-                List.of(0), "desc");
+        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(List.of(0, 1, 2), "desc");
         int page = 1;
         int take = 12;
         Integer meetingId = 1;

--- a/main/src/test/resources/sql/apply-repository-test-data.sql
+++ b/main/src/test/resources/sql/apply-repository-test-data.sql
@@ -1,0 +1,55 @@
+CREATE TYPE meeting_joinableparts_enum AS ENUM ('PM', 'DESIGN', 'IOS', 'ANDROID', 'SERVER', 'WEB');
+
+INSERT INTO "user" (id, name, "orgId", activities, "profileImage", phone)
+VALUES (1, '김삼순', 1001,
+        '[{"part": "서버", "generation": 33}, {"part": "iOS", "generation": 32}]',
+        'profile1.jpg', '010-1234-5678'),
+       (2, '홍길동', 1002,
+        '[{"part": "기획", "generation": 32}, {"part": "기획", "generation": 29}, {"part": "기획", "generation": 33}, {"part": "기획", "generation": 30}]',
+        'profile2.jpg', '010-1111-2222'),
+       (3, '김철수', 1003,
+        '[{"part": "웹", "generation": 34}]',
+        'profile3.jpg', '010-3333-4444'),
+       (4, '이영지', 1004,
+        '[{"part": "iOS", "generation": 32}, {"part": "안드로이드", "generation": 29}]',
+        'profile4.jpg', '010-5555-5555');
+
+create table "meeting" (
+                           "canJoinOnlyActiveGeneration" boolean not null,
+                           "capacity" integer not null,
+                           "createdGeneration" integer not null,
+                           "id" serial not null,
+                           "isMentorNeeded" boolean not null,
+                           "targetActiveGeneration" integer,
+                           "userId" integer,
+                           "endDate" TIMESTAMP not null,
+                           "mEndDate" TIMESTAMP not null,
+                           "mStartDate" TIMESTAMP not null,
+                           "startDate" TIMESTAMP not null,
+                           "category" varchar(255) not null,
+                           "desc" varchar(255) not null,
+                           "leaderDesc" varchar(255) not null,
+                           "note" varchar(255),
+                           "processDesc" varchar(255) not null,
+                           "targetDesc" varchar(255) not null,
+                           "title" varchar(255) not null,
+                           "imageURL" jsonb,
+                           "joinableParts" meeting_joinableparts_enum[],
+                           primary key ("id")
+);
+
+INSERT INTO meeting (id, "userId", title, category, "imageURL", "startDate", "endDate", capacity,
+                       "desc", "processDesc", "mStartDate", "mEndDate", "leaderDesc", "targetDesc",
+                       note, "isMentorNeeded", "canJoinOnlyActiveGeneration", "createdGeneration",
+                       "targetActiveGeneration", "joinableParts")
+VALUES (1, 1, '스터디 구합니다1', '행사',
+        '[{"id": 0, "url": "https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/05/19/79ba8312-0ebf-48a2-9a5e-b372fb8a9e64.png"}]',
+        '2024-05-19 00:00:00.000000', '2024-05-24 23:59:59.000000', 10,
+        '스터디 설명입니다.', '스터디 진행방식입니다.',
+        '2024-05-29 00:00:00.000000', '2024-05-31 00:00:00.000000', '스터디장 설명입니다.',
+        '누구나 들어올 수 있어요.', '시간지키세요.', true, false, 34, 34, '{PM,DESIGN,WEB,ANDROID,IOS,SERVER}');
+
+INSERT INTO apply (type, "meetingId", "userId", content, "appliedDate", status)
+VALUES (0, 1, 2, '전할말입니다1', '2024-05-19 00:00:00.913489', 1),
+       (0, 1, 3, '전할말입니다2', '2024-05-19 00:00:02.413489', 1),
+       (0, 1, 4, '전할말입니다3', '2024-05-19 00:00:03.413489', 0);

--- a/main/src/test/resources/sql/delete-all-data.sql
+++ b/main/src/test/resources/sql/delete-all-data.sql
@@ -1,0 +1,30 @@
+-- 테이블의 데이터 삭제
+DELETE FROM "apply";
+DELETE FROM "comment";
+DELETE FROM "like";
+DELETE FROM "meeting";
+DELETE FROM "notice";
+DELETE FROM "post";
+DELETE FROM "user";
+
+-- 시퀀스 초기화
+-- apply 테이블의 시퀀스 초기화
+ALTER SEQUENCE "apply_id_seq" RESTART WITH 1;
+
+-- comment 테이블의 시퀀스 초기화
+ALTER SEQUENCE "comment_id_seq" RESTART WITH 1;
+
+-- "like" 테이블의 시퀀스 초기화
+ALTER SEQUENCE "like_id_seq" RESTART WITH 1;
+
+-- meeting 테이블의 시퀀스 초기화
+ALTER SEQUENCE "meeting_id_seq" RESTART WITH 1;
+
+-- notice 테이블의 시퀀스 초기화
+ALTER SEQUENCE "notice_id_seq" RESTART WITH 1;
+
+-- post 테이블의 시퀀스 초기화
+ALTER SEQUENCE "post_id_seq" RESTART WITH 1;
+
+-- user 테이블의 시퀀스 초기화
+ALTER SEQUENCE "user_id_seq" RESTART WITH 1;


### PR DESCRIPTION
## 👩‍💻 Contents
- 맥락 : `모임 신청자 리스트 조회 API` 에 기능적 이슈가 있었고, 해당 API에 대한 수정이 필요한 상황이었습니다. 이왕 수정해야하기 때문에 아예 spring으로 마이그레이션하면서 수정하는게 더 낫겠다고 판단해서 진행했습니다.

- 모임 신청자 리스트 조회 API 마이그레이션 했습니다.
- 스터디 개설자가 아닌 경우 `전하는 말`에 빈값이 들어가도록 구현했습니다.

## 📝 Review Note
### 페이지네이션
- 이전 구현은 제가 이해하기론 먼저 메모리에 올린 후, 서비스 레이어에서 페이지네이션 작업을 해준 것으로 이해했습니다! 해당 방식은 쿼리가 1번 나간다는 장점이 있다고 생각이 들었지만, "서비스 레이어 코드의 복잡함 + 테이블 전체 데이터를 메모리에 올린다는 부담감"이 있다고 생각했습니다.
- 그래서 repository 단에서 querydsl과 offset를 활용해서 페이지네이션을 구현해봤습니다! 카운트 쿼리 1번이 추가됐지만 성능에 큰 차이를 주진 않을 것 같았습니다! 해당 제안에 대해 어떻게 생각하시는지 궁금합니다!
- 또한, Pageable 객체를 사용해봤습니다! 휴먼에러를 방지할 수 있는 것 같아서 저는 애용하는데요! 현재 ApplySearchRepositoryImpl 에서 파라미터로 받고 있습니다.

### querydsl 
- @QueryProjection : 해당 어노테이션을 사용해서 querydsl를 사용했습니다. 엔티티와 다른 반환 타입인 경우 주로 Projections를 사용하는데요! 그 중 @QueryProjection 은 가장 안전한 바인딩 방법이라고 생각해서 자주 사용하는데 의견 궁금합니다!
- @QueryProjection 참고링크1 : https://cheese10yun.github.io/querydsl-projections/#null
- @QueryProjection 성능 관련 참고링크2 : https://jojoldu.tistory.com/518
<br></br>
- count 성능 : count 연산의 성능을 높이기 위해 count 쿼리에 `fetchFirst` 를 사용했습니다!
- 성능 관련 참고링크 : https://cheese10yun.github.io/page-performance/#null

### 테스트 코드
- 이 API는 querydsl를 사용했기 때문에 Repository 쪽 테스트가 가장 중요하다고 생각했습니다.
- 그래서 그 쪽을 조금 더 꼼꼼히 봤고, 나머지 레이어도 추가하겠습니다..!
- 또한, mock 데이터를 위해 `@Sql` 를 사용했습니다. 해당 sql 파일은 오직 `ApplyRepositoryTest` 클래스에서만 사용하는 것을 의도했습니다. 
- 참고링크 : https://cheese10yun.github.io/spring-about-test/#null
- sql 파일을 gitignore를 하려다가 말았는데요! 저희 코드가 public여서 db구조는 누구나 볼 수 있기에 큰 의미가 없다고 생각했습니다. 또한, 개발자간 sql파일을 sync 맞추는데도 꽤 리소스가 들기 때문에 그냥 github에 일부러 올려뒀습니다!
- 테스트 컨테이너를 사용하고 있기 때문에 테스트 코드 성공을 위해선 도커 데몬이 돌아가고 있어야 합니다!


### 아쉬운 점
- status(모임 승인, 거절, 대기 상태)를 받아서 Enum으로 변경하는 과정을 `MeetingGetApplyListCommand` 내에서 구현했는데요! 이 부분이 뭔가 좀 어색하게 느껴져서 더 좋은 방법있으시면 환영입니다..!
- 뿐만 아니라 jsonb 타입도 db에서 불러오는 과정에서 가장 최근 활동(UserActivity)를 찾는 로직을 `ApplicantDto` 에 구현했는데요! 이 부분도 어색하다고는 느껴졌지만 더 좋은 방법이 안 떠올라 일단 말씀드려봅니다!

<img width="660" alt="스크린샷 2024-05-26 오전 12 06 00" src="https://github.com/sopt-makers/sopt-crew-backend/assets/100754581/6dc1b5e7-22cf-414f-9ebd-c1e82b5461fc">

<img width="848" alt="스크린샷 2024-05-26 오전 12 11 31" src="https://github.com/sopt-makers/sopt-crew-backend/assets/100754581/ddbe4fb6-2cce-4a8e-8e9d-213bcde5a729">
<img width="830" alt="스크린샷 2024-05-26 오전 12 11 42" src="https://github.com/sopt-makers/sopt-crew-backend/assets/100754581/434be856-97a3-4428-9bf5-0b947f345738">


## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #198 

## ✅ 점검사항

- [x] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [x] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [x] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?