### PR TITLE
[CHORE] 응답값 형태 변경

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/common/response/SuccessResponse.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/response/SuccessResponse.java
@@ -1,0 +1,15 @@
+package org.sopt.makers.crew.main.common.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class SuccessResponse<T> {
+    private final T data;
+
+    public static <T> SuccessResponse<T> of(T data){
+        return new SuccessResponse<>(data);
+    }
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.List;
+import org.sopt.makers.crew.main.common.response.SuccessResponse;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
@@ -68,7 +69,7 @@ public interface MeetingV2Api {
     @Operation(summary = "모임 지원자/참여자 조회", description = "모임 지원자/참여자 조회 (모임장이면 지원자, 아니면 참여자 조회)")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "모임 지원자/참여자 조회 성공"),
             @ApiResponse(responseCode = "400", description = "모임이 없습니다.", content = @Content),})
-    ResponseEntity<MeetingGetApplyListResponseDto> findApplyList(@PathVariable Integer meetingId,
-                                                                 @ModelAttribute MeetingGetApplyListCommand queryCommand,
-                                                                 Principal principal);
+    ResponseEntity<SuccessResponse<MeetingGetApplyListResponseDto>> findApplyList(@PathVariable Integer meetingId,
+                                                                                  @ModelAttribute MeetingGetApplyListCommand queryCommand,
+                                                                                  Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.makers.crew.main.common.response.SuccessResponse;
 import org.sopt.makers.crew.main.common.util.UserUtil;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
@@ -25,7 +26,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -83,13 +83,13 @@ public class MeetingV2Controller implements MeetingV2Api {
 
     @Override
     @GetMapping("/{meetingId}/list")
-    public ResponseEntity<MeetingGetApplyListResponseDto> findApplyList(@PathVariable Integer meetingId,
-                                                                        @ModelAttribute MeetingGetApplyListCommand queryCommand,
-                                                                        Principal principal) {
+    public ResponseEntity<SuccessResponse<MeetingGetApplyListResponseDto>> findApplyList(@PathVariable Integer meetingId,
+                                                                                         @ModelAttribute MeetingGetApplyListCommand queryCommand,
+                                                                                         Principal principal) {
 
         Integer userId = UserUtil.getUserId(principal);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(meetingV2Service.findApplyList(queryCommand, meetingId, userId));
+                .body(SuccessResponse.of(meetingV2Service.findApplyList(queryCommand, meetingId, userId)));
     }
 }


### PR DESCRIPTION
## 👩‍💻 Contents
- API 응답 형태를 변경했습니다. 해당 변경은 FE 측 요청에 의한 수정입니다.
- 맥락 : https://sopt-makers.slack.com/archives/C042SGKBFK7/p1716882212259729
- 변수명을 `ApiResponse`로 하려다가 스웨거의 `ApiResponse`와 겹쳐서 `SuccessResponse` 라고 변경했습니다. 성공된 응답에서만 사용되기에 나쁘지 않다고 생각했는데, 다른 의견 편하게 주세요!

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #206 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?