### PR TITLE
[FIX] 메이커스 팀장 버그 & 라우팅 규칙 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,12 +132,14 @@ services:
       caddy.route_2.reverse_proxy: "{{ upstreams 4000 }}"
       caddy.route_3: /user/v2/*
       caddy.route_3.reverse_proxy: "{{ upstreams 4000 }}"
-      caddy.route_4: /meeting/v2/*
+      caddy.route_4: /meeting/v2
       caddy.route_4.reverse_proxy: "{{ upstreams 4000 }}"
-      caddy.route_5: /post/v2
+      caddy.route_5: /meeting/v2/*
       caddy.route_5.reverse_proxy: "{{ upstreams 4000 }}"
-      caddy.route_6: /comment/v2
+      caddy.route_6: /post/v2
       caddy.route_6.reverse_proxy: "{{ upstreams 4000 }}"
+      caddy.route_7: /comment/v2
+      caddy.route_7.reverse_proxy: "{{ upstreams 4000 }}"
 
   nestjs-blue:
     image: makerscrew/server:latest
@@ -221,12 +223,14 @@ services:
       caddy.route_2.reverse_proxy: "{{ upstreams 4000 }}"
       caddy.route_3: /user/v2/*
       caddy.route_3.reverse_proxy: "{{ upstreams 4000 }}"
-      caddy.route_4: /meeting/v2/*
+      caddy.route_4: /meeting/v2
       caddy.route_4.reverse_proxy: "{{ upstreams 4000 }}"
-      caddy.route_5: /post/v2
+      caddy.route_5: /meeting/v2/*
       caddy.route_5.reverse_proxy: "{{ upstreams 4000 }}"
-      caddy.route_6: /comment/v2
+      caddy.route_6: /post/v2
       caddy.route_6.reverse_proxy: "{{ upstreams 4000 }}"
+      caddy.route_7: /comment/v2
+      caddy.route_7.reverse_proxy: "{{ upstreams 4000 }}"
 
 networks:
   caddy:

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/enums/UserPart.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/enums/UserPart.java
@@ -28,7 +28,7 @@ public enum UserPart {
   GENERAL_AFFAIRS("총무"),
   OPERATION_LEADER("운영 팀장"),
   MEDIA_LEADER("미디어 팀장"),
-  MAKERS_LEADER("메이커스 리드");
+  MAKERS_LEADER("메이커스 팀장");
 
   private final String value;
 

--- a/server/src/entity/user/enum/user-part.enum.ts
+++ b/server/src/entity/user/enum/user-part.enum.ts
@@ -22,6 +22,6 @@ export enum UserPart {
   GENERAL_AFFAIRS = '총무',
   OPERATION_LEADER = '운영 팀장',
   MEDIA_LEADER = '미디어 팀장',
-  MAKERS_LEADER = '메이커스 리드',
+  MAKERS_LEADER = '메이커스 팀장',
 
 }


### PR DESCRIPTION
## 👩‍💻 Contents
### #196 이슈
- `메이커스 리드` -> `메이커스 팀장`으로 변경했습니다.
- db에도 `메이커스 팀장`으로 저장된 것 확인했습니다!
<img width="138" alt="스크린샷 2024-06-03 오후 11 27 41" src="https://github.com/sopt-makers/sopt-crew-backend/assets/100754581/bef2fdd2-c206-4ba8-9d3c-11b6da76fede">

### #193 이슈
- 라우팅 규칙에서 빠트린 부분이 있어서 추가했습니다.
- 머지 전에 dev, prod ec2내에 반영후에 머지 하겠습니다!

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #196 
- closed #193 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?