### PR TITLE
[FEAT] 댓글 삭제 V2 API 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,12 +97,14 @@ services:
       caddy.route_9.reverse_proxy: "{{ upstreams 3000 }}"
       caddy.route_10: /notice/v1/*
       caddy.route_10.reverse_proxy: "{{ upstreams 3000 }}"
-      caddy.route_11: /post/v1/*
+      caddy.route_11: /post/v1
       caddy.route_11.reverse_proxy: "{{ upstreams 3000 }}"
-      caddy.route_12: /users
+      caddy.route_12: /post/v1/*
       caddy.route_12.reverse_proxy: "{{ upstreams 3000 }}"
-      caddy.route_13: /users/*
+      caddy.route_13: /users
       caddy.route_13.reverse_proxy: "{{ upstreams 3000 }}"
+      caddy.route_14: /users/*
+      caddy.route_14.reverse_proxy: "{{ upstreams 3000 }}"
 
   spring-green:
     image: makerscrew/main:latest
@@ -188,12 +190,14 @@ services:
       caddy.route_9.reverse_proxy: "{{ upstreams 3000 }}"
       caddy.route_10: /notice/v1/*
       caddy.route_10.reverse_proxy: "{{ upstreams 3000 }}"
-      caddy.route_11: /post/v1/*
+      caddy.route_11: /post/v1
       caddy.route_11.reverse_proxy: "{{ upstreams 3000 }}"
-      caddy.route_12: /users
+      caddy.route_12: /post/v1/*
       caddy.route_12.reverse_proxy: "{{ upstreams 3000 }}"
-      caddy.route_13: /users/*
+      caddy.route_13: /users
       caddy.route_13.reverse_proxy: "{{ upstreams 3000 }}"
+      caddy.route_14: /users/*
+      caddy.route_14.reverse_proxy: "{{ upstreams 3000 }}"
 
   spring-blue:
     image: makerscrew/main:latest

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/CommentV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/CommentV2Controller.java
@@ -13,6 +13,8 @@ import org.sopt.makers.crew.main.comment.v2.service.CommentV2Service;
 import org.sopt.makers.crew.main.common.util.UserUtil;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,6 +39,22 @@ public class CommentV2Controller {
       @Valid @RequestBody CommentV2CreateCommentBodyDto requestBody, Principal principal) {
     Integer userId = UserUtil.getUserId(principal);
     return ResponseEntity.ok(commentV2Service.createComment(requestBody, userId));
+  }
+
+  @Operation(summary = "모임 게시글 댓글 삭제")
+  @DeleteMapping("/{commentId}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "성공"),
+  })
+  public ResponseEntity<Void> deleteComment(
+      Principal principal,
+      @PathVariable Integer commentId) {
+    Integer userId = UserUtil.getUserId(principal);
+
+    commentV2Service.deleteComment(commentId, userId);
+
+    return ResponseEntity.noContent().build();
   }
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2Service.java
@@ -7,4 +7,6 @@ public interface CommentV2Service {
 
   CommentV2CreateCommentResponseDto createComment(CommentV2CreateCommentBodyDto requestBody,
       Integer userId);
+
+  void deleteComment(Integer commentId, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2Service.java
@@ -2,11 +2,12 @@ package org.sopt.makers.crew.main.comment.v2.service;
 
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2CreateCommentBodyDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2CreateCommentResponseDto;
+import org.sopt.makers.crew.main.common.exception.ForbiddenException;
 
 public interface CommentV2Service {
 
   CommentV2CreateCommentResponseDto createComment(CommentV2CreateCommentBodyDto requestBody,
       Integer userId);
 
-  void deleteComment(Integer commentId, Integer userId);
+  void deleteComment(Integer commentId, Integer userId) throws ForbiddenException;
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
@@ -39,7 +39,6 @@ public class CommentV2ServiceImpl implements CommentV2Service {
    */
   @Override
   @Transactional
-
   public CommentV2CreateCommentResponseDto createComment(CommentV2CreateCommentBodyDto requestBody,
       Integer userId) {
     Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
@@ -68,5 +67,26 @@ public class CommentV2ServiceImpl implements CommentV2Service {
     pushNotificationService.sendPushNotification(pushRequestDto);
 
     return CommentV2CreateCommentResponseDto.of(savedComment.getId());
+  }
+
+  /**
+   * 모임 게시글 댓글 삭제
+   *
+   * @throws 400 댓글 작성자가 아닐 때
+   * @apiNote 댓글 삭제시 게시글의 댓글 수를 1 감소시킴
+   */
+  @Override
+  @Transactional
+  public void deleteComment(Integer commentId, Integer userId) {
+    Comment comment = commentRepository.findByIdOrThrow(commentId);
+
+    if (!comment.getUser().getId().equals(userId)) {
+      throw new SecurityException("댓글 작성자만 삭제할 수 있습니다.");
+    }
+
+    Post post = comment.getPost();
+
+    post.decreaseCommentCount();
+    commentRepository.delete(comment);
   }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
@@ -6,6 +6,8 @@ import static org.sopt.makers.crew.main.internal.notification.PushNotificationEn
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2CreateCommentBodyDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2CreateCommentResponseDto;
+import org.sopt.makers.crew.main.common.exception.ForbiddenException;
+import org.sopt.makers.crew.main.common.response.ErrorStatus;
 import org.sopt.makers.crew.main.entity.comment.Comment;
 import org.sopt.makers.crew.main.entity.comment.CommentRepository;
 import org.sopt.makers.crew.main.entity.post.Post;
@@ -72,16 +74,16 @@ public class CommentV2ServiceImpl implements CommentV2Service {
   /**
    * 모임 게시글 댓글 삭제
    *
-   * @throws 400 댓글 작성자가 아닐 때
+   * @exception ForbiddenException 댓글 작성자가 아닐 때
    * @apiNote 댓글 삭제시 게시글의 댓글 수를 1 감소시킴
    */
   @Override
   @Transactional
-  public void deleteComment(Integer commentId, Integer userId) {
+  public void deleteComment(Integer commentId, Integer userId) throws ForbiddenException {
     Comment comment = commentRepository.findByIdOrThrow(commentId);
 
     if (!comment.getUserId().equals(userId)) {
-      throw new SecurityException("댓글 작성자만 삭제할 수 있습니다.");
+      throw new ForbiddenException();
     }
 
     Post post = comment.getPost();

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
@@ -80,7 +80,7 @@ public class CommentV2ServiceImpl implements CommentV2Service {
   public void deleteComment(Integer commentId, Integer userId) {
     Comment comment = commentRepository.findByIdOrThrow(commentId);
 
-    if (!comment.getUser().getId().equals(userId)) {
+    if (!comment.getUserId().equals(userId)) {
       throw new SecurityException("댓글 작성자만 삭제할 수 있습니다.");
     }
 

--- a/main/src/main/java/org/sopt/makers/crew/main/common/response/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/response/ErrorStatus.java
@@ -19,6 +19,7 @@ public enum ErrorStatus {
     VALIDATION_REQUEST_MISSING_EXCEPTION("요청값이 입력되지 않았습니다."),
     NOT_FOUND_MEETING("모임이 없습니다."),
     NOT_FOUND_POST("존재하지 않는 게시글입니다."),
+    NOT_FOUND_COMMENT("존재하지 않는 댓글입니다."),
     FULL_MEETING_CAPACITY("정원이 꽉 찼습니다."),
     ALREADY_APPLIED_MEETING("이미 지원한 모임입니다."),
     NOT_IN_APPLY_PERIOD("모임 지원 기간이 아닙니다."),

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
@@ -132,6 +132,7 @@ public class Comment {
     public Comment(String contents, User user, Post post, Comment parent) {
         this.contents = contents;
         this.user = user;
+        this.userId = user.getId();
         this.post = post;
         this.parent = parent;
         this.depth = 0;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
@@ -78,11 +78,11 @@ public class Comment {
     @JoinColumn(name = "userId", nullable = false)
     private User user;
 
-    /**
-     * 작성자의 고유 식별자
-     */
-    @Column(insertable = false, updatable = false)
-    private int userId;
+  /**
+   * 작성자의 고유 식별자
+   */
+  @Column(insertable = false, updatable = false)
+  private Integer userId;
 
     /**
      * 댓글이 속한 게시글 정보

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
@@ -32,12 +32,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(name = "comment")
 public class Comment {
 
-    /**
-     * 댓글의 고유 식별자
-     */
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int id;
+  /**
+   * 댓글의 고유 식별자
+   */
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer id;
 
     /**
      * 댓글 내용
@@ -110,11 +110,11 @@ public class Comment {
     @JoinColumn(name = "parentId")
     private Comment parent;
 
-    /**
-     * 부모 댓글의 고유 식별자
-     */
-    @Column(insertable = false, updatable = false)
-    private int parentId;
+  /**
+   * 부모 댓글의 고유 식별자
+   */
+  @Column(insertable = false, updatable = false)
+  private Integer parentId;
 
     /**
      * 자식 댓글 목록

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentRepository.java
@@ -4,4 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Integer> {
 
+  default Comment findByIdOrThrow(Integer commentId) {
+    return findById(commentId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+  }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentRepository.java
@@ -1,11 +1,13 @@
 package org.sopt.makers.crew.main.entity.comment;
 
+import org.sopt.makers.crew.main.common.exception.BadRequestException;
+import org.sopt.makers.crew.main.common.response.ErrorStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Integer> {
 
   default Comment findByIdOrThrow(Integer commentId) {
     return findById(commentId)
-        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+        .orElseThrow(() -> new BadRequestException(ErrorStatus.NOT_FOUND_COMMENT.getErrorCode()));
   }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/post/Post.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/post/Post.java
@@ -149,7 +149,11 @@ public class Post {
         this.commentCount++;
     }
 
-    public void addReport(Report report) {
-        this.reports.add(report);
-    }
+  public void addReport(Report report) {
+    this.reports.add(report);
+  }
+
+  public void decreaseCommentCount() {
+    this.commentCount--;
+  }
 }

--- a/main/src/test/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceTest.java
@@ -1,0 +1,75 @@
+package org.sopt.makers.crew.main.comment.v2.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.makers.crew.main.common.exception.BadRequestException;
+import org.sopt.makers.crew.main.entity.comment.Comment;
+import org.sopt.makers.crew.main.entity.comment.CommentRepository;
+import org.sopt.makers.crew.main.entity.post.Post;
+import org.sopt.makers.crew.main.entity.post.PostRepository;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.UserFixture;
+import org.sopt.makers.crew.main.entity.user.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class CommentV2ServiceTest {
+    @InjectMocks
+    private CommentV2ServiceImpl commentV2Service;
+    @Mock
+    private CommentRepository commentRepository;
+    @Mock
+    private PostRepository postRepository;
+
+    private Comment comment;
+
+    private Post post;
+
+    private User user;
+
+    @BeforeEach
+    void init() {
+        user = UserFixture.createStaticUser();
+        user.setUserIdForTest(1);
+
+        String[] images = {"image1", "image2", "image3"};
+        this.post = Post.builder().user(user).title("title").contents("contents").images(images).build();
+        this.comment = Comment.builder().contents("contents").post(post).user(user).build();
+        post.addComment(this.comment);
+    }
+
+    @Test
+    void 댓글_삭제_성공() {
+        // given
+        int initialCommentCount = post.getCommentCount();
+        doReturn(comment).when(commentRepository).findByIdOrThrow(any());
+
+        // when
+        commentV2Service.deleteComment(comment.getId(), comment.getUser().getId());
+
+        // then
+        Assertions.assertThat(commentRepository.findById(comment.getId())).isEqualTo(Optional.empty());
+        Assertions.assertThat(post.getCommentCount()).isEqualTo(initialCommentCount - 1);
+    }
+
+    @Test
+    void 댓글_삭제_실패_본인_작성_댓글_아님() {
+        // given
+        doReturn(comment).when(commentRepository).findByIdOrThrow(any());
+
+        // when & then
+        assertThrows(SecurityException.class, () -> {
+            commentV2Service.deleteComment(comment.getId(), comment.getUser().getId() + 1);
+        });
+    }
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
+import org.sopt.makers.crew.main.common.exception.ForbiddenException;
 import org.sopt.makers.crew.main.entity.comment.Comment;
 import org.sopt.makers.crew.main.entity.comment.CommentRepository;
 import org.sopt.makers.crew.main.entity.post.Post;
@@ -55,7 +56,7 @@ public class CommentV2ServiceTest {
         doReturn(comment).when(commentRepository).findByIdOrThrow(any());
 
         // when
-        commentV2Service.deleteComment(comment.getId(), comment.getUser().getId());
+        commentV2Service.deleteComment(comment.getId(), user.getId());
 
         // then
         Assertions.assertThat(commentRepository.findById(comment.getId())).isEqualTo(Optional.empty());
@@ -68,7 +69,7 @@ public class CommentV2ServiceTest {
         doReturn(comment).when(commentRepository).findByIdOrThrow(any());
 
         // when & then
-        assertThrows(SecurityException.class, () -> {
+        assertThrows(ForbiddenException.class, () -> {
             commentV2Service.deleteComment(comment.getId(), comment.getUser().getId() + 1);
         });
     }

--- a/server/src/comment/v1/comment-v1.controller.ts
+++ b/server/src/comment/v1/comment-v1.controller.ts
@@ -137,8 +137,12 @@ export class CommentV1Controller {
     });
   }
 
+  /**
+   * @deprecated
+   */
   @ApiOperation({
     summary: '모임 게시글 댓글 삭제',
+    deprecated: true,
   })
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- Spring 프로젝트에 댓글 삭제 V2 API 구현
- 사용하지 않는 댓글 삭제 V1 API에 deprecated 처리

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 없습니다!

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #215 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?