### PR TITLE
[REFACTOR] 모임 상세 조회 V2 API 구현

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyGroups.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyGroups.java
@@ -1,0 +1,30 @@
+package org.sopt.makers.crew.main.entity.apply;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
+
+@RequiredArgsConstructor
+@Getter
+public class ApplyGroups {
+    private final List<Apply> applyList;
+
+    public long getApprovedCount() {
+        return applyList.stream()
+                .filter(apply -> apply.getStatus().equals(EnApplyStatus.APPROVE))
+                .count();
+    }
+
+    public Boolean isApply(Integer userId) {
+        return applyList.stream()
+                .anyMatch(apply -> apply.getUserId().equals(userId));
+    }
+
+    public Boolean isApproved(Integer userId) {
+        return applyList.stream()
+                .anyMatch(apply -> apply.getUserId().equals(userId)
+                        && apply.getStatus().equals(EnApplyStatus.APPROVE));
+    }
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
@@ -20,18 +20,14 @@ public interface ApplyRepository extends JpaRepository<Apply, Integer>, ApplySea
 
     List<Apply> findAllByMeetingIdAndStatus(Integer meetingId, EnApplyStatus statusValue);
 
+    @Query("select a from Apply a join fetch a.user u where a.meetingId = :meetingId")
+    List<Apply> findAllByMeetingIdWithUser(Integer meetingId);
+
     boolean existsByMeetingIdAndUserId(Integer meetingId, Integer userId);
 
     @Transactional
     @Modifying
     @Query("delete from Apply a where a.meeting.id = :meetingId and a.userId = :userId")
     void deleteByMeetingIdAndUserId(@Param("meetingId") Integer meetingId, @Param("userId") Integer userId);
-
-    Optional<Apply> findById(Integer applyId);
-
-    default Apply findByIdOrThrow(Integer applyId) {
-        return findById(applyId)
-                .orElseThrow(() -> new BadRequestException(NOT_FOUND_APPLY.getErrorCode()));
-    }
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/common/RealTime.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/common/RealTime.java
@@ -1,0 +1,14 @@
+package org.sopt.makers.crew.main.entity.common;
+
+import java.time.LocalDateTime;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile({"local", "dev", "prod"})
+public class RealTime implements Time {
+    @Override
+    public LocalDateTime now() {
+        return LocalDateTime.now();
+    }
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/common/Time.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/common/Time.java
@@ -1,0 +1,8 @@
+package org.sopt.makers.crew.main.entity.common;
+
+import java.time.LocalDateTime;
+
+public interface Time {
+    LocalDateTime now();
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -219,8 +219,8 @@ public class Meeting {
         appliedInfo.add(apply);
     }
 
-    public void addPost(Post post) {
-        posts.add(post);
+    public Boolean isHost(Integer userId){
+        return this.getUserId().equals(userId);
     }
 
     /**
@@ -228,14 +228,17 @@ public class Meeting {
      *
      * @return 모임 모집상태
      */
-    public Integer getMeetingStatus() {
-        LocalDateTime now = LocalDateTime.now();
+    public EnMeetingStatus getMeetingStatus(LocalDateTime now) {
         if (now.isBefore(startDate)) {
-            return EnMeetingStatus.BEFORE_START.getValue();
+            return EnMeetingStatus.BEFORE_RECRUITMENT;
         } else if (now.isBefore(endDate)) {
-            return EnMeetingStatus.APPLY_ABLE.getValue();
+            return EnMeetingStatus.RECRUITING;
+        } else if (now.isBefore(mStartDate)) {
+            return EnMeetingStatus.CLOSE_RECRUITMENT;
+        } else if (now.isBefore(mEndDate)) {
+            return EnMeetingStatus.ACTIVE;
         } else {
-            return EnMeetingStatus.RECRUITMENT_COMPLETE.getValue();
+            return EnMeetingStatus.ACTIVITY_END;
         }
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/enums/EnMeetingStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/enums/EnMeetingStatus.java
@@ -5,6 +5,8 @@ import org.sopt.makers.crew.main.common.exception.BadRequestException;
 
 /** 모임 상태 */
 public enum EnMeetingStatus {
+
+  // 1. 모집 전, 2. 모집 중, 3. 모집 마감, 4. 활동 중, 5. 활동 종료
   /** 시작 전 */
   BEFORE_START(0),
 

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/enums/EnMeetingStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/enums/EnMeetingStatus.java
@@ -1,34 +1,25 @@
 package org.sopt.makers.crew.main.entity.meeting.enums;
 
-import java.util.Arrays;
-import org.sopt.makers.crew.main.common.exception.BadRequestException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
-/** 모임 상태 */
+/**
+ * 모임 상태
+ */
+@RequiredArgsConstructor
+@Getter
 public enum EnMeetingStatus {
 
-  // 1. 모집 전, 2. 모집 중, 3. 모집 마감, 4. 활동 중, 5. 활동 종료
-  /** 시작 전 */
-  BEFORE_START(0),
+    BEFORE_RECRUITMENT("모집 전"),
 
-  /** 지원 가능 */
-  APPLY_ABLE(1),
+    RECRUITING("모집 중"),
 
-  /** 모집 완료 */
-  RECRUITMENT_COMPLETE(2);
+    CLOSE_RECRUITMENT("모집 마감"),
 
-  private final int value;
+    ACTIVE("활동 중"),
 
-  EnMeetingStatus(int value) {
-    this.value = value;
-  }
+    ACTIVITY_END("활동 종료");
 
-  public static EnMeetingStatus ofValue(int dbData) {
-    return Arrays.stream(EnMeetingStatus.values()).filter(v -> v.getValue() == (dbData)).findFirst()
-        .orElseThrow(() -> new BadRequestException(
-            String.format("EnMeetingStatus 클래스에 value = [%s] 값을 가진 enum 객체가 없습니다.", dbData)));
-  }
+    private final String value;
 
-  public int getValue() {
-    return value;
-  }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -20,6 +20,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingRe
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingByIdResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -71,4 +72,9 @@ public interface MeetingV2Api {
     ResponseEntity<MeetingGetApplyListResponseDto> findApplyList(@PathVariable Integer meetingId,
                                                                  @ModelAttribute MeetingGetApplyListCommand queryCommand,
                                                                  Principal principal);
+
+    @Operation(summary = "모임 상세 조회", description = "모임 상세 조회")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "모임 상세 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "모임이 없습니다.", content = @Content),})
+    ResponseEntity<MeetingV2GetMeetingByIdResponseDto> getMeetingById(@PathVariable Integer meetingId, Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -3,18 +3,28 @@ package org.sopt.makers.crew.main.meeting.v2;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import java.security.Principal;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.crew.main.common.util.UserUtil;
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
+import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplicantDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingCreatorDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingByIdResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.service.MeetingV2Service;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -91,5 +101,26 @@ public class MeetingV2Controller implements MeetingV2Api {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(meetingV2Service.findApplyList(queryCommand, meetingId, userId));
+    }
+
+    @Override
+    @GetMapping("/{meetingId}")
+    public ResponseEntity<MeetingV2GetMeetingByIdResponseDto> getMeetingById(@PathVariable Integer meetingId,
+                                                                             Principal principal) {
+
+        ApplyInfoDto applyInfoDto = new ApplyInfoDto(1, "지원할래요", LocalDateTime.of(2024, 5, 18, 00, 00),
+                EnApplyStatus.APPROVE,
+                new ApplicantDto(158, "송민규", 258, List.of(new UserActivityVO("서버", 33)), "프로필 사진 링크", "010-1234-5678"));
+
+        MeetingJoinablePart[] m = {MeetingJoinablePart.SERVER};
+
+        MeetingV2GetMeetingByIdResponseDto dto = MeetingV2GetMeetingByIdResponseDto.of(163, "모임제목", "스터디",
+                List.of(new ImageUrlVO(0,
+                        "https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/05/19/e927fa61-8782-4c94-9024-7b832853facb.png")),
+                LocalDateTime.of(2024, 5, 18, 00, 00), LocalDateTime.of(2024, 5, 20, 23, 59),
+                20, "모임 설명", "진행방식 설명", LocalDateTime.of(2024, 6, 18, 00, 00), LocalDateTime.of(2024, 6, 24, 00, 00),
+                "스터디장 소개", "타겟설명", "비고", true, true, 34, 34, m, EnMeetingStatus.APPLY_ABLE, 2, false, true,
+                true, MeetingCreatorDto.of(134, "송민규", 258), List.of(applyInfoDto));
+        return ResponseEntity.ok(dto);
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -3,22 +3,13 @@ package org.sopt.makers.crew.main.meeting.v2;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import java.security.Principal;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.crew.main.common.util.UserUtil;
-import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
-import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
-import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
-import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
-import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
-import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplicantDto;
-import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDto;
-import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingCreatorDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
@@ -35,7 +26,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -107,20 +97,8 @@ public class MeetingV2Controller implements MeetingV2Api {
     @GetMapping("/{meetingId}")
     public ResponseEntity<MeetingV2GetMeetingByIdResponseDto> getMeetingById(@PathVariable Integer meetingId,
                                                                              Principal principal) {
+        Integer userId = UserUtil.getUserId(principal);
 
-        ApplyInfoDto applyInfoDto = new ApplyInfoDto(1, "지원할래요", LocalDateTime.of(2024, 5, 18, 00, 00),
-                EnApplyStatus.APPROVE,
-                new ApplicantDto(158, "송민규", 258, List.of(new UserActivityVO("서버", 33)), "프로필 사진 링크", "010-1234-5678"));
-
-        MeetingJoinablePart[] m = {MeetingJoinablePart.SERVER};
-
-        MeetingV2GetMeetingByIdResponseDto dto = MeetingV2GetMeetingByIdResponseDto.of(163, "모임제목", "스터디",
-                List.of(new ImageUrlVO(0,
-                        "https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/05/19/e927fa61-8782-4c94-9024-7b832853facb.png")),
-                LocalDateTime.of(2024, 5, 18, 00, 00), LocalDateTime.of(2024, 5, 20, 23, 59),
-                20, "모임 설명", "진행방식 설명", LocalDateTime.of(2024, 6, 18, 00, 00), LocalDateTime.of(2024, 6, 24, 00, 00),
-                "스터디장 소개", "타겟설명", "비고", true, true, 34, 34, m, EnMeetingStatus.APPLY_ABLE, 2, false, true,
-                true, MeetingCreatorDto.of(134, "송민규", 258), List.of(applyInfoDto));
-        return ResponseEntity.ok(dto);
+        return ResponseEntity.ok(meetingV2Service.getMeetingById(meetingId, userId));
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/MeetingMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/MeetingMapper.java
@@ -26,8 +26,8 @@ public interface MeetingMapper {
     @Mapping(source = "requestBody.endDate", target = "endDate", qualifiedByName = "getEndDate")
     @Mapping(source = "requestBody.mStartDate", target = "mStartDate", qualifiedByName = "getStartDate")
     @Mapping(source = "requestBody.mEndDate", target = "mEndDate", qualifiedByName = "getEndDate")
-    Meeting toMeetingEntity(MeetingV2CreateMeetingBodyDto requestBody, Integer targetActiveGeneration,
-                            Integer createdGeneration, User user, Integer userId);
+    Meeting toMeeting(MeetingV2CreateMeetingBodyDto requestBody, Integer targetActiveGeneration,
+                      Integer createdGeneration, User user, Integer userId);
 
     @Named("getImageURL")
     static List<ImageUrlVO> getImageURL(List<String> files) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplicantDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplicantDto.java
@@ -1,7 +1,6 @@
 package org.sopt.makers.crew.main.meeting.v2.dto.response;
 
 import com.querydsl.core.annotations.QueryProjection;
-import java.util.Comparator;
 import java.util.List;
 import lombok.Getter;
 import org.sopt.makers.crew.main.common.util.UserUtil;

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingCreatorDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingCreatorDto.java
@@ -1,0 +1,14 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class MeetingCreatorDto {
+    Integer id;
+    String name;
+    Integer orgId;
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingCreatorDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingCreatorDto.java
@@ -7,8 +7,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor(staticName = "of")
 public class MeetingCreatorDto {
-    Integer id;
-    String name;
-    Integer orgId;
+    private final Integer id;
+    private final String name;
+    private final Integer orgId;
+    private final String profileImage;
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingBannerResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingBannerResponseDto.java
@@ -3,6 +3,7 @@ package org.sopt.makers.crew.main.meeting.v2.dto.response;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
@@ -53,6 +54,6 @@ public class MeetingV2GetMeetingBannerResponseDto {
     private Integer approvedUserCount;
     /** 개설자 정보 */
     private Optional<MeetingV2GetMeetingBannerResponseUserDto> user;
-    /** 미팅 상태 */
-    private Integer status;
+    /** 모임 상태 */
+    private EnMeetingStatus status;
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
@@ -1,0 +1,46 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+@Schema(description = "모임 상세 조회 dto")
+public class MeetingV2GetMeetingByIdResponseDto {
+    Integer meetingId;
+    String title;
+    String category;
+    List<ImageUrlVO> imageURLs;
+    LocalDateTime applyStartDate;
+    LocalDateTime applyEndDate;
+    int capacity;
+    String desc;
+    String processDesc;
+    LocalDateTime activityStartDate;
+    LocalDateTime activityEndDate;
+    String leaderDesc;
+    String targetDesc;
+    String note;
+    Boolean isMentorNeeded;
+    Boolean canJoinOnlyActiveGeneration;
+    Integer createdGeneration;
+    Integer targetActiveGeneration;
+    MeetingJoinablePart[] joinableParts;
+
+    EnMeetingStatus status;
+    Integer approvedApplyCount;
+    Boolean host;
+    Boolean apply;
+    Boolean approved;
+
+    MeetingCreatorDto meetingCreator;
+
+    List<ApplyInfoDto> appliedInfo;
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
@@ -3,44 +3,59 @@ package org.sopt.makers.crew.main.meeting.v2.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 
 @Getter
-@AllArgsConstructor(staticName = "of")
+@RequiredArgsConstructor
 @Schema(description = "모임 상세 조회 dto")
 public class MeetingV2GetMeetingByIdResponseDto {
-    Integer meetingId;
-    String title;
-    String category;
-    List<ImageUrlVO> imageURLs;
-    LocalDateTime applyStartDate;
-    LocalDateTime applyEndDate;
-    int capacity;
-    String desc;
-    String processDesc;
-    LocalDateTime activityStartDate;
-    LocalDateTime activityEndDate;
-    String leaderDesc;
-    String targetDesc;
-    String note;
-    Boolean isMentorNeeded;
-    Boolean canJoinOnlyActiveGeneration;
-    Integer createdGeneration;
-    Integer targetActiveGeneration;
-    MeetingJoinablePart[] joinableParts;
+    private final Integer meetingId;
+    private final String title;
+    private final String category;
+    private final List<ImageUrlVO> imageURLs;
+    private final LocalDateTime startDate;
+    private final LocalDateTime endDate;
+    private final int capacity;
+    private final String desc;
+    private final String processDesc;
+    private final LocalDateTime activityStartDate;
+    private final LocalDateTime activityEndDate;
+    private final String leaderDesc;
+    private final String targetDesc;
+    private final String note;
+    private final Boolean isMentorNeeded;
+    private final Boolean canJoinOnlyActiveGeneration;
+    private final Integer createdGeneration;
+    private final Integer targetActiveGeneration;
+    private final MeetingJoinablePart[] joinableParts;
 
-    EnMeetingStatus status;
-    Integer approvedApplyCount;
-    Boolean host;
-    Boolean apply;
-    Boolean approved;
+    private final EnMeetingStatus status;
+    private final long approvedApplyCount;
+    private final Boolean host;
+    private final Boolean apply;
+    private final Boolean approved;
 
-    MeetingCreatorDto meetingCreator;
+    private final MeetingCreatorDto meetingCreator;
 
-    List<ApplyInfoDto> appliedInfo;
+    private final List<SimpleApplyInfoResponseDto> appliedInfo;
 
+    public static MeetingV2GetMeetingByIdResponseDto of(Meeting meeting, long approvedCount, Boolean isHost, Boolean isApply,
+                                                        Boolean isApproved, MeetingCreatorDto meetingCreator,
+                                                        List<SimpleApplyInfoResponseDto> appliedInfo, LocalDateTime now) {
+
+        EnMeetingStatus meetingStatus = meeting.getMeetingStatus(now);
+
+        return new MeetingV2GetMeetingByIdResponseDto(meeting.getId(), meeting.getTitle(),
+                meeting.getCategory().getValue(), meeting.getImageURL(), meeting.getStartDate(), meeting.getEndDate(),
+                meeting.getCapacity(), meeting.getDesc(), meeting.getProcessDesc(), meeting.getMStartDate(),
+                meeting.getMEndDate(), meeting.getLeaderDesc(), meeting.getTargetDesc(), meeting.getNote(),
+                meeting.getIsMentorNeeded(), meeting.getCanJoinOnlyActiveGeneration(), meeting.getCreatedGeneration(),
+                meeting.getTargetActiveGeneration(), meeting.getJoinableParts(), meetingStatus,
+                approvedCount, isHost, isApply, isApproved, meetingCreator, appliedInfo);
+    }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/SimpleApplyInfoResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/SimpleApplyInfoResponseDto.java
@@ -1,0 +1,17 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class SimpleApplyInfoResponseDto {
+    private final String name;
+    private final EnApplyStatus status;
+    private final String profileImage;
+
+    public static SimpleApplyInfoResponseDto of(String name, EnApplyStatus status, String profileImage) {
+        return new SimpleApplyInfoResponseDto(name, status, profileImage);
+    }
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -10,6 +10,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingRe
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingByIdResponseDto;
 
 public interface MeetingV2Service {
 
@@ -26,4 +27,6 @@ public interface MeetingV2Service {
 
     MeetingGetApplyListResponseDto findApplyList(MeetingGetApplyListCommand queryCommand, Integer meetingId,
                                                  Integer userId);
+
+    MeetingV2GetMeetingByIdResponseDto getMeetingById(Integer meetingId, Integer userId);
 }

--- a/main/src/test/java/org/sopt/makers/crew/main/entity/apply/ApplyGroupsTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/entity/apply/ApplyGroupsTest.java
@@ -1,0 +1,219 @@
+package org.sopt.makers.crew.main.entity.apply;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyType;
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
+
+public class ApplyGroupsTest {
+
+    @Test
+    void 승인된_신청자_수_조회(){
+        // given
+        User host = User.builder().name("김철수")
+                .orgId(1)
+                .activities(List.of(new UserActivityVO("웹", 31)))
+                .profileImage(null)
+                .phone("010-2222-2222")
+                .build();
+
+        Meeting meeting = Meeting.builder()
+                .user(host)
+                .title("모임 제목입니다")
+                .category(MeetingCategory.EVENT)
+                .startDate(LocalDateTime.of(2024,4,24,0,0,0))
+                .endDate(LocalDateTime.of(2024,4,29,23,59,59))
+                .capacity(20)
+                .desc("모임 소개입니다")
+                .processDesc("진행방식 소개입니다")
+                .mStartDate(LocalDateTime.of(2024,5,24,0,0,0))
+                .mEndDate(LocalDateTime.of(2024,6,24,0,0,0))
+                .leaderDesc("스장 소개입니다")
+                .targetDesc("모집 대상입니다")
+                .isMentorNeeded(true)
+                .canJoinOnlyActiveGeneration(false)
+                .createdGeneration(34)
+                .targetActiveGeneration(null)
+                .joinableParts(MeetingJoinablePart.values())
+                .build();
+
+        User applicant1 = User.builder().name("홍길동")
+                .orgId(2)
+                .activities(List.of(new UserActivityVO("서버", 33)))
+                .profileImage(null)
+                .phone("010-1234-5678")
+                .build();
+
+        User applicant2 = User.builder().name("김삼순")
+                .orgId(3)
+                .activities(List.of(new UserActivityVO("디자인", 34)))
+                .profileImage(null)
+                .phone("010-1111-1111")
+                .build();
+
+        Apply apply1 = Apply.builder()
+                .type(EnApplyType.APPLY)
+                .user(applicant1)
+                .userId(2)
+                .content("지원동기입니다1")
+                .meeting(meeting)
+                .meetingId(1)
+                .build();
+
+        Apply apply2 = Apply.builder()
+                .type(EnApplyType.APPLY)
+                .user(applicant2)
+                .userId(3)
+                .content("지원동기입니다2")
+                .meeting(meeting)
+                .meetingId(1)
+                .build();
+        apply2.updateApplyStatus(EnApplyStatus.APPROVE);
+
+        ApplyGroups applyGroups = new ApplyGroups(List.of(apply1, apply2));
+
+        // when
+        long approvedCount = applyGroups.getApprovedCount();
+
+        // then
+        Assertions.assertThat(approvedCount).isEqualTo(1L);
+    }
+
+    @Test
+    void 특정_사용자가_신청했는지_조회(){
+        // given
+        User host = User.builder().name("김철수")
+                .orgId(1)
+                .activities(List.of(new UserActivityVO("웹", 31)))
+                .profileImage(null)
+                .phone("010-2222-2222")
+                .build();
+
+        Meeting meeting = Meeting.builder()
+                .user(host)
+                .title("모임 제목입니다")
+                .category(MeetingCategory.EVENT)
+                .startDate(LocalDateTime.of(2024,4,24,0,0,0))
+                .endDate(LocalDateTime.of(2024,4,29,23,59,59))
+                .capacity(20)
+                .desc("모임 소개입니다")
+                .processDesc("진행방식 소개입니다")
+                .mStartDate(LocalDateTime.of(2024,5,24,0,0,0))
+                .mEndDate(LocalDateTime.of(2024,6,24,0,0,0))
+                .leaderDesc("스장 소개입니다")
+                .targetDesc("모집 대상입니다")
+                .isMentorNeeded(true)
+                .canJoinOnlyActiveGeneration(false)
+                .createdGeneration(34)
+                .targetActiveGeneration(null)
+                .joinableParts(MeetingJoinablePart.values())
+                .build();
+
+        User applicant1 = User.builder().name("홍길동")
+                .orgId(2)
+                .activities(List.of(new UserActivityVO("서버", 33)))
+                .profileImage(null)
+                .phone("010-1234-5678")
+                .build();
+
+        Apply apply1 = Apply.builder()
+                .type(EnApplyType.APPLY)
+                .user(applicant1)
+                .userId(2)
+                .content("지원동기입니다1")
+                .meeting(meeting)
+                .meetingId(1)
+                .build();
+
+        ApplyGroups applyGroups = new ApplyGroups(List.of(apply1));
+
+        // when
+        Boolean isApply1 = applyGroups.isApply(2);
+        Boolean isApply2 = applyGroups.isApply(3);
+
+        // then
+        Assertions.assertThat(isApply1).isEqualTo(true);
+        Assertions.assertThat(isApply2).isEqualTo(false);
+    }
+
+    @Test
+    void 특정_사용자가_승인되었는지_조회(){
+        // given
+        User host = User.builder().name("김철수")
+                .orgId(1)
+                .activities(List.of(new UserActivityVO("웹", 31)))
+                .profileImage(null)
+                .phone("010-2222-2222")
+                .build();
+
+        Meeting meeting = Meeting.builder()
+                .user(host)
+                .title("모임 제목입니다")
+                .category(MeetingCategory.EVENT)
+                .startDate(LocalDateTime.of(2024,4,24,0,0,0))
+                .endDate(LocalDateTime.of(2024,4,29,23,59,59))
+                .capacity(20)
+                .desc("모임 소개입니다")
+                .processDesc("진행방식 소개입니다")
+                .mStartDate(LocalDateTime.of(2024,5,24,0,0,0))
+                .mEndDate(LocalDateTime.of(2024,6,24,0,0,0))
+                .leaderDesc("스장 소개입니다")
+                .targetDesc("모집 대상입니다")
+                .isMentorNeeded(true)
+                .canJoinOnlyActiveGeneration(false)
+                .createdGeneration(34)
+                .targetActiveGeneration(null)
+                .joinableParts(MeetingJoinablePart.values())
+                .build();
+
+        User applicant1 = User.builder().name("홍길동")
+                .orgId(2)
+                .activities(List.of(new UserActivityVO("서버", 33)))
+                .profileImage(null)
+                .phone("010-1234-5678")
+                .build();
+
+        User applicant2 = User.builder().name("김삼순")
+                .orgId(3)
+                .activities(List.of(new UserActivityVO("디자인", 34)))
+                .profileImage(null)
+                .phone("010-1111-1111")
+                .build();
+
+        Apply apply1 = Apply.builder()
+                .type(EnApplyType.APPLY)
+                .user(applicant1)
+                .userId(2)
+                .content("지원동기입니다1")
+                .meeting(meeting)
+                .meetingId(1)
+                .build();
+
+        Apply apply2 = Apply.builder()
+                .type(EnApplyType.APPLY)
+                .user(applicant2)
+                .userId(3)
+                .content("지원동기입니다2")
+                .meeting(meeting)
+                .meetingId(1)
+                .build();
+        apply2.updateApplyStatus(EnApplyStatus.APPROVE);
+
+        ApplyGroups applyGroups = new ApplyGroups(List.of(apply1, apply2));
+
+        // when
+        Boolean isApproved1 = applyGroups.isApproved(2);
+        Boolean isApproved2 = applyGroups.isApproved(3);
+
+        // then
+        Assertions.assertThat(isApproved1).isEqualTo(false);
+        Assertions.assertThat(isApproved2).isEqualTo(true);
+    }
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/entity/common/StubTime.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/entity/common/StubTime.java
@@ -1,0 +1,14 @@
+package org.sopt.makers.crew.main.entity.common;
+
+import java.time.LocalDateTime;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("test")
+public class StubTime implements Time {
+    @Override
+    public LocalDateTime now() {
+        return LocalDateTime.of(2024, 4, 24, 23, 59);
+    }
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/entity/meeting/MeetingTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/entity/meeting/MeetingTest.java
@@ -1,0 +1,103 @@
+package org.sopt.makers.crew.main.entity.meeting;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
+
+public class MeetingTest {
+
+    @Test
+    void 스터디장인지_확인(){
+        // given
+        User host = User.builder().name("김철수")
+                .orgId(1)
+                .activities(List.of(new UserActivityVO("웹", 31)))
+                .profileImage(null)
+                .phone("010-2222-2222")
+                .build();
+
+        Meeting meeting = Meeting.builder()
+                .user(host)
+                .userId(1)
+                .title("모임 제목입니다")
+                .category(MeetingCategory.EVENT)
+                .startDate(LocalDateTime.of(2024,4,24,0,0,0))
+                .endDate(LocalDateTime.of(2024,4,29,23,59,59))
+                .capacity(20)
+                .desc("모임 소개입니다")
+                .processDesc("진행방식 소개입니다")
+                .mStartDate(LocalDateTime.of(2024,5,24,0,0,0))
+                .mEndDate(LocalDateTime.of(2024,6,24,0,0,0))
+                .leaderDesc("스장 소개입니다")
+                .targetDesc("모집 대상입니다")
+                .isMentorNeeded(true)
+                .canJoinOnlyActiveGeneration(false)
+                .createdGeneration(34)
+                .targetActiveGeneration(null)
+                .joinableParts(MeetingJoinablePart.values())
+                .build();
+
+        // when
+        Boolean isHost1 = meeting.isHost(1);
+        Boolean isHost2 = meeting.isHost(2);
+
+        // then
+        Assertions.assertThat(isHost1).isEqualTo(true);
+        Assertions.assertThat(isHost2).isEqualTo(false);
+    }
+
+    @Test
+    void 신청기간_이전에_모임_모집상태_확인(){
+        // given
+        User host = User.builder().name("김철수")
+                .orgId(1)
+                .activities(List.of(new UserActivityVO("웹", 31)))
+                .profileImage(null)
+                .phone("010-2222-2222")
+                .build();
+
+        Meeting meeting = Meeting.builder()
+                .user(host)
+                .userId(1)
+                .title("모임 제목입니다")
+                .category(MeetingCategory.EVENT)
+                .startDate(LocalDateTime.of(2024,4,24,0,0,0))
+                .endDate(LocalDateTime.of(2024,4,29,23,59,59))
+                .capacity(20)
+                .desc("모임 소개입니다")
+                .processDesc("진행방식 소개입니다")
+                .mStartDate(LocalDateTime.of(2024,5,24,0,0,0))
+                .mEndDate(LocalDateTime.of(2024,6,24,0,0,0))
+                .leaderDesc("스장 소개입니다")
+                .targetDesc("모집 대상입니다")
+                .isMentorNeeded(true)
+                .canJoinOnlyActiveGeneration(false)
+                .createdGeneration(34)
+                .targetActiveGeneration(null)
+                .joinableParts(MeetingJoinablePart.values())
+                .build();
+
+        // when
+        EnMeetingStatus beforeRecruitment = meeting.getMeetingStatus(LocalDateTime.of(2024, 4, 23, 23, 59, 59));
+        EnMeetingStatus recruiting = meeting.getMeetingStatus(LocalDateTime.of(2024, 4, 24, 0, 0, 0));
+        EnMeetingStatus closeRecruitment = meeting.getMeetingStatus(LocalDateTime.of(2024, 4, 30, 0, 0, 0));
+        EnMeetingStatus active = meeting.getMeetingStatus(LocalDateTime.of(2024, 5, 24, 0, 0, 0));
+        EnMeetingStatus activityEnd = meeting.getMeetingStatus(LocalDateTime.of(2024, 6, 24, 0, 0, 1));
+
+
+        // then
+        Assertions.assertThat(beforeRecruitment).isEqualTo(EnMeetingStatus.BEFORE_RECRUITMENT);
+        Assertions.assertThat(recruiting).isEqualTo(EnMeetingStatus.RECRUITING);
+        Assertions.assertThat(closeRecruitment).isEqualTo(EnMeetingStatus.CLOSE_RECRUITMENT);
+        Assertions.assertThat(active).isEqualTo(EnMeetingStatus.ACTIVE);
+        Assertions.assertThat(activityEnd).isEqualTo(EnMeetingStatus.ACTIVITY_END);
+
+    }
+
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/entity/meeting/MeetingTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/entity/meeting/MeetingTest.java
@@ -55,15 +55,10 @@ public class MeetingTest {
     @Test
     void 신청기간_이전에_모임_모집상태_확인(){
         // given
-        User host = User.builder().name("김철수")
-                .orgId(1)
-                .activities(List.of(new UserActivityVO("웹", 31)))
-                .profileImage(null)
-                .phone("010-2222-2222")
-                .build();
+        User hostFixture = createHostFixture();
 
         Meeting meeting = Meeting.builder()
-                .user(host)
+                .user(hostFixture)
                 .userId(1)
                 .title("모임 제목입니다")
                 .category(MeetingCategory.EVENT)
@@ -98,6 +93,15 @@ public class MeetingTest {
         Assertions.assertThat(active).isEqualTo(EnMeetingStatus.ACTIVE);
         Assertions.assertThat(activityEnd).isEqualTo(EnMeetingStatus.ACTIVITY_END);
 
+    }
+
+    private User createHostFixture(){
+        return User.builder().name("김철수")
+                .orgId(1)
+                .activities(List.of(new UserActivityVO("웹", 31)))
+                .profileImage(null)
+                .phone("010-2222-2222")
+                .build();
     }
 
 }

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceMockingTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceMockingTest.java
@@ -1,0 +1,223 @@
+package org.sopt.makers.crew.main.meeting.v2.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.FULL_MEETING_CAPACITY;
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.NOT_IN_APPLY_PERIOD;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.makers.crew.main.common.exception.BadRequestException;
+import org.sopt.makers.crew.main.entity.apply.Apply;
+import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.UserFixture;
+import org.sopt.makers.crew.main.entity.user.UserRepository;
+import org.sopt.makers.crew.main.entity.user.enums.UserPart;
+import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
+import org.sopt.makers.crew.main.meeting.v2.dto.ApplyMapper;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
+
+@ExtendWith(MockitoExtension.class)
+public class MeetingV2ServiceMockingTest {
+    @InjectMocks
+    private MeetingV2ServiceImpl meetingV2Service;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private ApplyRepository applyRepository;
+    @Mock
+    private MeetingRepository meetingRepository;
+    @Mock
+    private ApplyMapper applyMapper;
+
+
+    private List<Apply> applies;
+
+    private User ownerUser;
+
+    private User applyUser;
+
+    private Meeting meeting;
+
+    @BeforeEach
+    void init() {
+        List<UserActivityVO> activityVOS = new ArrayList<>();
+        activityVOS.add(new UserActivityVO(UserPart.SERVER.getValue(), 33));
+
+        ownerUser = User.builder()
+                .name("송민규")
+                .orgId(1)
+                .activities(activityVOS)
+                .phone("010-9472-6796")
+                .build();
+        ownerUser.setUserIdForTest(1);
+
+        applyUser = User.builder()
+                .name("홍길동")
+                .orgId(2)
+                .activities(activityVOS)
+                .phone("010-1234-5678")
+                .build();
+        applyUser.setUserIdForTest(2);
+
+        ImageUrlVO imageUrlVO = new ImageUrlVO(1, "www.~~");
+
+        meeting = Meeting.builder()
+                .user(ownerUser)
+                .userId(ownerUser.getId())
+                .title("사람 구해요")
+                .category(MeetingCategory.STUDY)
+                .imageURL(List.of(imageUrlVO))
+                .startDate(LocalDateTime.of(2024, Month.MARCH, 17, 0, 0))
+                .endDate(LocalDateTime.of(2024, Month.MARCH, 20, 23, 59))
+                .capacity(10)
+                .desc("열정 많은 사람 구해요")
+                .processDesc("이렇게 할거에여")
+                .mStartDate(LocalDateTime.of(2024, Month.APRIL, 1, 0, 0))
+                .mEndDate(LocalDateTime.of(2030, Month.APRIL, 20, 0, 0))
+                .leaderDesc("저는 이런 사람이에요.")
+                .targetDesc("이런 사람이 왔으면 좋겠어요")
+                .note("유의사항은 이거에요")
+                .isMentorNeeded(true)
+                .canJoinOnlyActiveGeneration(true)
+                .createdGeneration(33)
+                .targetActiveGeneration(33)
+                .joinableParts(MeetingJoinablePart.values())
+                .appliedInfo(new ArrayList<>())
+                .build();
+
+        Apply apply = Apply.builder()
+                .meeting(meeting)
+                .meetingId(1)
+                .user(applyUser)
+                .userId(2)
+                .content("제 지원동기는요")
+                .build();
+
+        meeting.addApply(apply);
+        apply.updateApplyStatus(EnApplyStatus.APPROVE);
+
+        applies = new ArrayList<>();
+        applies.add(apply);
+    }
+
+    // TODO : Mocking 개선 필요
+    @Test
+    void 내모임조회_성공() {
+        // given
+        User user = UserFixture.createStaticUser();
+        doReturn(Optional.of(user)).when(userRepository).findByOrgId(any());
+        doReturn(applies).when(applyRepository).findAllByUserIdAndStatus(any(), any());
+
+        MeetingV2GetAllMeetingByOrgUserQueryDto dto = new MeetingV2GetAllMeetingByOrgUserQueryDto(
+                applyUser.getOrgId(), 1, 12);
+
+        // when
+        MeetingV2GetAllMeetingByOrgUserDto myMeetings = meetingV2Service.getAllMeetingByOrgUser(dto);
+
+        // then
+        Assertions.assertThat(myMeetings.getMeetings().get(0))
+                .extracting("isMeetingLeader", "title", "category", "mStartDate", "mEndDate", "isActiveMeeting")
+                .containsExactly(false, meeting.getTitle(), meeting.getCategory().getValue(), meeting.getMStartDate(),
+                        meeting.getMEndDate(), true);
+    }
+
+    // TODO : Mocking 개선 필요
+    @Test
+    public void 모임신청시_정원이찼을때_예외발생() {
+        // given
+        for (int i = 0; i < meeting.getCapacity(); i++) {
+            User tempUser = User.builder()
+                    .name("user" + i)
+                    .orgId(2 + i)
+                    .phone("010-0000-000" + i)
+                    .build();
+            tempUser.setUserIdForTest(3 + i); // 3부터 시작하는 userId 설정
+
+            Apply apply = Apply.builder()
+                    .meeting(meeting)
+                    .meetingId(meeting.getId())
+                    .user(tempUser)
+                    .userId(tempUser.getId())
+                    .content("꼭 하고 싶어요" + i)
+                    .build();
+
+            apply.updateApplyStatus(EnApplyStatus.APPROVE); // 승인 상태로 변경
+        }
+        applies = new ArrayList<>(meeting.getAppliedInfo());
+        MeetingV2ApplyMeetingDto requestBody = new MeetingV2ApplyMeetingDto(meeting.getId(), "열심히 하겠습니다.");
+
+        doReturn(meeting).when(meetingRepository).findByIdOrThrow(requestBody.getMeetingId());
+        doReturn(applyUser).when(userRepository).findByIdOrThrow(applyUser.getId());
+
+        // when & then
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+            meetingV2Service.applyMeeting(requestBody, applyUser.getId());
+        });
+
+        assertEquals(FULL_MEETING_CAPACITY.getErrorCode(), exception.getMessage());
+    }
+
+    // TODO : Mocking 개선 필요
+    @Test
+    public void 모집시작시간이전_모임지원시_예외발생() {
+        // given
+        LocalDateTime oneMinuteAfterNow = LocalDateTime.now().plusMinutes(1);
+
+        meeting = Meeting.builder()
+                .user(ownerUser)
+                .userId(ownerUser.getId())
+                .title("사람 구해요")
+                .category(MeetingCategory.STUDY)
+                .startDate(oneMinuteAfterNow) // 모집 시작 시간을 현재 시간으로부터 1분 후로 설정
+                .endDate(oneMinuteAfterNow.plusDays(1))
+                .capacity(10)
+                .desc("열정 많은 사람 구해요")
+                .processDesc("이렇게 할거에여")
+                .mStartDate(LocalDateTime.of(2028, Month.APRIL, 20, 0, 0))
+                .mEndDate(LocalDateTime.of(2030, Month.APRIL, 20, 0, 0))
+                .leaderDesc("저는 이런 사람이에요.")
+                .targetDesc("이런 사람이 왔으면 좋겠어요")
+                .note("유의사항은 이거에요")
+                .isMentorNeeded(true)
+                .canJoinOnlyActiveGeneration(true)
+                .createdGeneration(33)
+                .targetActiveGeneration(33)
+                .joinableParts(MeetingJoinablePart.values())
+                .appliedInfo(new ArrayList<>())
+                .build();
+
+        MeetingV2ApplyMeetingDto requestBody = new MeetingV2ApplyMeetingDto(meeting.getId(), "열심히 하겠습니다.");
+
+        doReturn(meeting).when(meetingRepository).findByIdOrThrow(requestBody.getMeetingId());
+        doReturn(applyUser).when(userRepository).findByIdOrThrow(applyUser.getId());
+
+        // when & then
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+            meetingV2Service.applyMeeting(requestBody, applyUser.getId());
+        });
+
+        assertEquals(NOT_IN_APPLY_PERIOD.getErrorCode(), exception.getMessage());
+    }
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceMockingTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceMockingTest.java
@@ -184,29 +184,8 @@ public class MeetingV2ServiceMockingTest {
     public void 모집시작시간이전_모임지원시_예외발생() {
         // given
         LocalDateTime oneMinuteAfterNow = LocalDateTime.now().plusMinutes(1);
-
-        meeting = Meeting.builder()
-                .user(ownerUser)
-                .userId(ownerUser.getId())
-                .title("사람 구해요")
-                .category(MeetingCategory.STUDY)
-                .startDate(oneMinuteAfterNow) // 모집 시작 시간을 현재 시간으로부터 1분 후로 설정
-                .endDate(oneMinuteAfterNow.plusDays(1))
-                .capacity(10)
-                .desc("열정 많은 사람 구해요")
-                .processDesc("이렇게 할거에여")
-                .mStartDate(LocalDateTime.of(2028, Month.APRIL, 20, 0, 0))
-                .mEndDate(LocalDateTime.of(2030, Month.APRIL, 20, 0, 0))
-                .leaderDesc("저는 이런 사람이에요.")
-                .targetDesc("이런 사람이 왔으면 좋겠어요")
-                .note("유의사항은 이거에요")
-                .isMentorNeeded(true)
-                .canJoinOnlyActiveGeneration(true)
-                .createdGeneration(33)
-                .targetActiveGeneration(33)
-                .joinableParts(MeetingJoinablePart.values())
-                .appliedInfo(new ArrayList<>())
-                .build();
+        Meeting meeting = createMeetingFixture(ownerUser, oneMinuteAfterNow, oneMinuteAfterNow.plusDays(1),
+                LocalDateTime.of(2028, Month.APRIL, 20, 0, 0), LocalDateTime.of(2030, Month.APRIL, 20, 0, 0));
 
         MeetingV2ApplyMeetingDto requestBody = new MeetingV2ApplyMeetingDto(meeting.getId(), "열심히 하겠습니다.");
 
@@ -219,5 +198,32 @@ public class MeetingV2ServiceMockingTest {
         });
 
         assertEquals(NOT_IN_APPLY_PERIOD.getErrorCode(), exception.getMessage());
+    }
+
+    private Meeting createMeetingFixture(User ownerUser, LocalDateTime startDate, LocalDateTime endDate,
+                                         LocalDateTime mStartDate, LocalDateTime mEndDate) {
+        return Meeting.builder()
+                .user(ownerUser)
+                .userId(ownerUser.getId())
+                .title("사람 구해요")
+                .category(MeetingCategory.STUDY)
+                .startDate(startDate) // 모집 시작 시간을 현재 시간으로부터 1분 후로 설정
+                .endDate(endDate)
+                .capacity(10)
+                .desc("열정 많은 사람 구해요")
+                .processDesc("이렇게 할거에여")
+                .mStartDate(mStartDate)
+                .mEndDate(mEndDate)
+                .leaderDesc("저는 이런 사람이에요.")
+                .targetDesc("이런 사람이 왔으면 좋겠어요")
+                .note("유의사항은 이거에요")
+                .isMentorNeeded(true)
+                .canJoinOnlyActiveGeneration(true)
+                .createdGeneration(33)
+                .targetActiveGeneration(33)
+                .joinableParts(MeetingJoinablePart.values())
+                .appliedInfo(new ArrayList<>())
+                .build();
+
     }
 }


### PR DESCRIPTION
## 👩‍💻 Contents
- 모임 상세 조회 API 마이그레이션했습니다.

## 📝 Review Note
### 일급컬렉션
- List<Apply> 부분을 ApplyGroups 라는 일급컬렉션을 만들어 관련 로직을 해당 클래스 내에 넣었습니다. 개인적으로 이런식으로 하는게 객체지향적이다 싶어서 추가해봤는데요! 변수명부터 시작해서 더 좋은 의견있으시면 말씀주세요!
- 참고링크 : https://jojoldu.tistory.com/412

### 서비스레이어에 Time 클래스 추가
- `now()` 라는 값이 Testability 를 많이 낮춘다고 생각했습니다!
- 그래서 의존성 주입으로 풀어내봤습니다. 테스트 코드 작성시에는 `MockTime` 클래스를 만들어서 테스트 코드 작성해볼 예정입니다!
- 참고링크 : https://jojoldu.tistory.com/676?category=1036934

### API 응답값
- 기존 API 응답값에서 필요없는 데이터들이 너무 많다는 생각이 들었습니다. 그래서 디버깅도 복잡하고, 오버페칭하고 있다는 생각이 들었는데요..! 이와 관련해서는 FE분들과 논의중에 있습니다! 다른 의견 있으시면 편하게 말씀주세요 :)

### 양방향 연관관계
* **논의하게된 계기**
    - 서비스 레이어쪽 테스트코드를 작성하려고 했었는데 알 수 없는 쿼리가 계속 발생하고, 이로 인해 테스트가 자꾸 실패했습니다..! 
    - 조회임에도 불구하고 계속 user쪽에서 update문이 발생하고, 이로 인해 충돌이 발생하더라고요..
    - 원인찾는게 어려울것 같아서 일단 제외하고 PR 올렸는데요! 개인적인 생각으론 양방향 매핑이 문제라는 생각이 들더라고요..!
* 제안
    - 그래서 앞으로 연관관계 사용을 지양하고, 제가 필요하지 않는 연관관계 끊는 작업을 해도 괜찮을지 여쭤보고 싶었습니다!
    - 예를 들어, `User` 엔티티의 `@OneToMany` 는 모두 다 필요하지 않다고 생각했습니다!
    - 사실 테스트 코드를 떠나서 저는 양방향 매핑을 지양하자는 주의여서 말씀드린 맥락이기도 합니다...!
    - 참고 링크1 : https://www.youtube.com/watch?v=vgNHW_nb2mg
    - 참고 링크2 : https://www.youtube.com/watch?v=dJ5C4qRqAgA&t=1398s (8분 1초)

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #203

## ✅ 점검사항

- [x] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [x] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [x] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?