### PR TITLE
[FEAT] 공지사항 관련 API 마이그레이션

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,6 +138,8 @@ services:
       caddy.route_6.reverse_proxy: "{{ upstreams 4000 }}"
       caddy.route_7: /comment/v2
       caddy.route_7.reverse_proxy: "{{ upstreams 4000 }}"
+      caddy.route_8: /notice/v2
+      caddy.route_8.reverse_proxy: "{{ upstreams 4000 }}"
 
   nestjs-blue:
     image: makerscrew/server:latest
@@ -229,6 +231,8 @@ services:
       caddy.route_6.reverse_proxy: "{{ upstreams 4000 }}"
       caddy.route_7: /comment/v2
       caddy.route_7.reverse_proxy: "{{ upstreams 4000 }}"
+      caddy.route_8: /notice/v2
+      caddy.route_8.reverse_proxy: "{{ upstreams 4000 }}"
 
 networks:
   caddy:

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/notice/Notice.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/notice/Notice.java
@@ -26,7 +26,7 @@ public class Notice {
      */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int id;
+    private Integer id;
 
     /**
      * 공지사항 제목

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/notice/NoticeRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/notice/NoticeRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.makers.crew.main.entity.notice;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Integer> {
+
+    List<Notice> findByExposeStartDateBeforeAndExposeEndDateAfter(LocalDateTime now1, LocalDateTime now2);
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/notice/NoticeV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/notice/NoticeV2Api.java
@@ -1,0 +1,23 @@
+package org.sopt.makers.crew.main.notice;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.sopt.makers.crew.main.notice.dto.request.NoticeV2CreateRequestDto;
+import org.sopt.makers.crew.main.notice.dto.response.NoticeV2GetResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "공지사항")
+public interface NoticeV2Api {
+
+    @Operation(summary = "공지사항 조회")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "성공")})
+    ResponseEntity<List<NoticeV2GetResponseDto>> getNotices();
+
+    @Operation(summary = "공지사항 작성")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "성공")})
+    ResponseEntity<Void> createNotice(@RequestBody NoticeV2CreateRequestDto requestDto);
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/notice/NoticeV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/notice/NoticeV2Controller.java
@@ -1,0 +1,35 @@
+package org.sopt.makers.crew.main.notice;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.makers.crew.main.notice.dto.request.NoticeV2CreateRequestDto;
+import org.sopt.makers.crew.main.notice.dto.response.NoticeV2GetResponseDto;
+import org.sopt.makers.crew.main.notice.service.NoticeV2Service;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/notice/v2")
+@RequiredArgsConstructor
+public class NoticeV2Controller implements NoticeV2Api {
+    private final NoticeV2Service noticeService;
+
+
+    @Override
+    @GetMapping
+    public ResponseEntity<List<NoticeV2GetResponseDto>> getNotices() {
+        return ResponseEntity.ok(noticeService.getNotices());
+    }
+
+    @Override
+    @PostMapping
+    public ResponseEntity<Void> createNotice(@RequestBody NoticeV2CreateRequestDto requestDto) {
+        noticeService.createNotice(requestDto);
+        return ResponseEntity.ok(null);
+    }
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/notice/dto/request/NoticeV2CreateRequestDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/notice/dto/request/NoticeV2CreateRequestDto.java
@@ -1,0 +1,16 @@
+package org.sopt.makers.crew.main.notice.dto.request;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class NoticeV2CreateRequestDto {
+    private final String title;
+    private final String subTitle;
+    private final String contents;
+    private final LocalDateTime exposeStartDate;
+    private final LocalDateTime exposeEndDate;
+    private final String noticeSecretKey;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/notice/dto/response/NoticeV2GetResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/notice/dto/response/NoticeV2GetResponseDto.java
@@ -1,0 +1,14 @@
+package org.sopt.makers.crew.main.notice.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(staticName = "of")
+public class NoticeV2GetResponseDto {
+    private final String title;
+    private final String subTitle;
+    private final String contents;
+    private final LocalDateTime createdDate;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/notice/service/NoticeV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/notice/service/NoticeV2Service.java
@@ -1,0 +1,51 @@
+package org.sopt.makers.crew.main.notice.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.makers.crew.main.common.exception.BadRequestException;
+import org.sopt.makers.crew.main.entity.notice.Notice;
+import org.sopt.makers.crew.main.entity.notice.NoticeRepository;
+import org.sopt.makers.crew.main.notice.dto.request.NoticeV2CreateRequestDto;
+import org.sopt.makers.crew.main.notice.dto.response.NoticeV2GetResponseDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeV2Service {
+    private final NoticeRepository noticeRepository;
+
+    @Value("${notice.secret-key}")
+    private String noticeSecretKey;
+
+    public List<NoticeV2GetResponseDto> getNotices() {
+        // Time 클래스로 교체 필요.
+        List<Notice> notices = noticeRepository.findByExposeStartDateBeforeAndExposeEndDateAfter(LocalDateTime.now(),
+                LocalDateTime.now());
+        return notices.stream()
+                .map(notice -> NoticeV2GetResponseDto.of(notice.getTitle(), notice.getSubTitle(), notice.getContents(),
+                        notice.getCreatedDate()))
+                .toList();
+    }
+
+    @Transactional
+    public void createNotice(NoticeV2CreateRequestDto requestDto) {
+
+        if (!requestDto.getNoticeSecretKey().equals(noticeSecretKey)) {
+            throw new BadRequestException("올바르지 않는 요청입니다.");
+        }
+
+        Notice notice = Notice.builder()
+                .title(requestDto.getTitle())
+                .subTitle(requestDto.getSubTitle())
+                .contents(requestDto.getContents())
+                .exposeStartDate(requestDto.getExposeStartDate())
+                .exposeEndDate(requestDto.getExposeEndDate())
+                .build();
+
+        noticeRepository.save(notice);
+    }
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/notice/service/NoticeV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/notice/service/NoticeV2Service.java
@@ -1,9 +1,12 @@
 package org.sopt.makers.crew.main.notice.service;
 
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.FORBIDDEN_EXCEPTION;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
+import org.sopt.makers.crew.main.common.exception.ForbiddenException;
 import org.sopt.makers.crew.main.entity.notice.Notice;
 import org.sopt.makers.crew.main.entity.notice.NoticeRepository;
 import org.sopt.makers.crew.main.notice.dto.request.NoticeV2CreateRequestDto;
@@ -35,7 +38,7 @@ public class NoticeV2Service {
     public void createNotice(NoticeV2CreateRequestDto requestDto) {
 
         if (!requestDto.getNoticeSecretKey().equals(noticeSecretKey)) {
-            throw new BadRequestException("올바르지 않는 요청입니다.");
+            throw new ForbiddenException(FORBIDDEN_EXCEPTION.getErrorCode());
         }
 
         Notice notice = Notice.builder()

--- a/main/src/main/resources/application-dev.yml
+++ b/main/src/main/resources/application-dev.yml
@@ -52,3 +52,6 @@ push-notification:
   x-api-key: ${DEV_PUSH_API_KEY}
   service: ${PUSH_NOTIFICATION_SERVICE}
   push-server-url: ${DEV_PUSH_SERVER_URL}
+
+notice:
+  secret-key : ${NOTICE_SECRET_KEY}

--- a/main/src/main/resources/application-prod.yml
+++ b/main/src/main/resources/application-prod.yml
@@ -51,3 +51,6 @@ push-notification:
   x-api-key: ${PROD_PUSH_API_KEY}
   service: ${PUSH_NOTIFICATION_SERVICE}
   push-server-url: ${PROD_PUSH_SERVER_URL}
+
+notice:
+  secret-key : ${NOTICE_SECRET_KEY}

--- a/main/src/main/resources/application-test.yml
+++ b/main/src/main/resources/application-test.yml
@@ -55,3 +55,6 @@ push-notification:
   x-api-key: ${DEV_PUSH_API_KEY}
   service: ${PUSH_NOTIFICATION_SERVICE}
   push-server-url: ${DEV_PUSH_SERVER_URL}
+
+notice:
+  secret-key : ${NOTICE_SECRET_KEY}


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 볼륨이 작아서 공지사항 작성과 조회 API를 모두 작업했습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 공지사항 관련해서 누구나 공지사항을 작성할 수 있는 것 같아서 API 요청시 시크릿값을 넣어야 하는 것으로 변경했습니다.
- 해당 파일(`application-secret.properties`) 내용은 인수인계 톡방에 공유드리겠습니다! CI 실패하는 이유는 이것 때문입니다!
- 이것과 관련해서 다른 의견 있으시면 편하게 말씀주세요!!

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #221 

## ✅ 점검사항

- [x] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [x] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [x] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?