### PR TITLE
[FIX] Open API Spec에 맞춰서 게시글 목록 조회 API 파라미터 구조 수정

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
@@ -1,6 +1,8 @@
 package org.sopt.makers.crew.main.post.v2;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -32,6 +34,9 @@ public interface PostV2Api {
             @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "400", description = "모임이 없습니다.", content = @Content),
     })
+    @Parameters({@Parameter(name = "page", description = "페이지, default = 1", example = "1"),
+            @Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50"),
+            @Parameter(name = "meetingId", description = "모임 id", example = "0")})
     ResponseEntity<PostV2GetPostsResponseDto> getPosts(
-            @ModelAttribute PostGetPostsCommand queryCommand, Principal principal);
+            @ModelAttribute @Parameter(hidden = true) PostGetPostsCommand queryCommand, Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.crew.main.post.v2;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.security.Principal;
@@ -40,8 +41,9 @@ public class PostV2Controller implements PostV2Api {
     @Override
     @GetMapping()
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<PostV2GetPostsResponseDto> getPosts(@ModelAttribute PostGetPostsCommand queryCommand,
-                                                              Principal principal) {
+    public ResponseEntity<PostV2GetPostsResponseDto> getPosts(
+            @ModelAttribute @Parameter(hidden = true) PostGetPostsCommand queryCommand,
+            Principal principal) {
         Integer userId = UserUtil.getUserId(principal);
         return ResponseEntity.ok(postV2Service.getPosts(queryCommand, userId));
     }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/query/PostGetPostsCommand.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/query/PostGetPostsCommand.java
@@ -1,7 +1,6 @@
 package org.sopt.makers.crew.main.post.v2.dto.query;
 
 import java.util.Optional;
-import lombok.Builder;
 import lombok.Getter;
 import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
 
@@ -10,7 +9,6 @@ public class PostGetPostsCommand extends PageOptionsDto {
 
     private Optional<Integer> meetingId;
 
-    @Builder
     public PostGetPostsCommand(Integer meetingId, Integer page, Integer take) {
         super(page, take);
         this.meetingId = Optional.ofNullable(meetingId);


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- Open API Spec에 맞춰서 게시글 목록 조회 API 파라미터 구조를 수정했습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #231 

## ✅ 점검사항

- [x] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [x] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [x] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?