### PR TITLE
[FIX] Open API Spec에 맞춰서 쿼리 파라미터 타입 지정

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -34,9 +35,10 @@ public interface PostV2Api {
             @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "400", description = "모임이 없습니다.", content = @Content),
     })
-    @Parameters({@Parameter(name = "page", description = "페이지, default = 1", example = "1"),
-            @Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50"),
-            @Parameter(name = "meetingId", description = "모임 id", example = "0")})
+    @Parameters({
+            @Parameter(name = "page", description = "페이지, default = 1", example = "1", schema = @Schema(type = "integer", format = "int32")),
+            @Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50", schema = @Schema(type = "integer", format = "int32")),
+            @Parameter(name = "meetingId", description = "모임 id", example = "0", schema = @Schema(type = "integer", format = "int32"))})
     ResponseEntity<PostV2GetPostsResponseDto> getPosts(
             @ModelAttribute @Parameter(hidden = true) PostGetPostsCommand queryCommand, Principal principal);
 }


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- Open API Spec에 맞춰서 쿼리 파라미터 타입을 string -> integer로 지정해줬습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #233 

## ✅ 점검사항

- [x] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [x] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [x] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?