### PR TITLE
[REFACTOR] 멘션 사용자 조회 API 캐시 도입

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -234,6 +234,15 @@ services:
       caddy.route_8: /notice/v2
       caddy.route_8.reverse_proxy: "{{ upstreams 4000 }}"
 
+  redis:
+    image: redis:6.2
+    container_name: redis
+    ports:
+      - 6379:6379
+    networks:
+      - caddy
+    restart: unless-stopped
+
 networks:
   caddy:
     external: true

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -71,6 +71,11 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
 }
 
 tasks.named('test') {

--- a/main/src/main/java/org/sopt/makers/crew/main/common/exception/ServerException.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/exception/ServerException.java
@@ -1,0 +1,14 @@
+package org.sopt.makers.crew.main.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ServerException extends BaseException {
+    public ServerException(HttpStatus httpStatus) {
+        super(httpStatus);
+    }
+
+    public ServerException(String responseMessage) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, responseMessage);
+    }
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
@@ -1,5 +1,7 @@
 package org.sopt.makers.crew.main.entity.user;
 
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.*;
+
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -10,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -18,6 +21,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Type;
+import org.sopt.makers.crew.main.common.exception.ServerException;
+import org.sopt.makers.crew.main.common.response.ErrorStatus;
 import org.sopt.makers.crew.main.entity.apply.Apply;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.post.Post;
@@ -117,5 +122,12 @@ public class User {
 
     public void setUserIdForTest(Integer userId) {
         this.id = userId;
+    }
+
+    public UserActivityVO getRecentActivityVO(){
+        return activities.stream()
+                .filter(userActivityVO -> userActivityVO.getPart() != null)
+                .max(Comparator.comparingInt(UserActivityVO::getGeneration))
+                .orElseThrow(() -> new ServerException(INTERNAL_SERVER_ERROR.getErrorCode()));
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/external/redis/RedisConfig.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/external/redis/RedisConfig.java
@@ -1,0 +1,63 @@
+package org.sopt.makers.crew.main.external.redis;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.cache.RedisCacheWriter;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Autowired
+    private RedisConnectionFactory redisConnectionFactory;
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+
+        // JSON 직렬화 설정
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
+        GenericJackson2JsonRedisSerializer jsonRedisSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        // Key serializer 설정
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+
+        // Value serializer 설정
+        template.setValueSerializer(jsonRedisSerializer);
+        template.setHashValueSerializer(jsonRedisSerializer);
+
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    @Bean
+    public RedisCacheManager cacheManager() {
+        RedisCacheWriter redisCacheWriter = RedisCacheWriter.nonLockingRedisCacheWriter(redisConnectionFactory);
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofHours(5L)); // 캐시 TTL 설정
+
+        return new RedisCacheManager(redisCacheWriter, redisCacheConfiguration);
+    }
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
@@ -24,7 +24,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/post/v2")
 @RequiredArgsConstructor
-@Tag(name = "게시글")
 public class PostV2Controller implements PostV2Api {
 
     private final PostV2Service postV2Service;

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserApi.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserApi.java
@@ -1,0 +1,28 @@
+package org.sopt.makers.crew.main.user.v2;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.security.Principal;
+import java.util.List;
+import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMeetingByUserMeetingDto;
+import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMentionUserDto;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "사용자")
+public interface UserApi {
+
+    @Operation(summary = "내가 속한 모임 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "204", description = "내가 속한 모임 리스트가 없는 경우", content = @Content),
+    })
+    ResponseEntity<List<UserV2GetAllMeetingByUserMeetingDto>> getAllMeetingByUser(Principal principal);
+
+    @Operation(summary = "멘션 사용자 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공")})
+    ResponseEntity<List<UserV2GetAllMentionUserDto>> getAllMentionUser(Principal principal);
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
@@ -1,15 +1,11 @@
 package org.sopt.makers.crew.main.user.v2;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.crew.main.common.util.UserUtil;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMeetingByUserMeetingDto;
+import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMentionUserDto;
 import org.sopt.makers.crew.main.user.v2.service.UserV2Service;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,21 +17,22 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/user/v2")
 @RequiredArgsConstructor
-@Tag(name = "사용자")
-public class UserV2Controller {
+public class UserV2Controller implements UserApi {
 
-  private final UserV2Service userV2Service;
+    private final UserV2Service userV2Service;
 
-  @Operation(summary = "내가 속한 모임 조회")
-  @GetMapping("/meeting/all")
-  @ResponseStatus(HttpStatus.OK)
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "204", description = "내가 속한 모임 리스트가 없는 경우", content = @Content),
-  })
-  public ResponseEntity<List<UserV2GetAllMeetingByUserMeetingDto>> getAllMeetingByUser(
-      Principal principal) {
-    Integer userId = UserUtil.getUserId(principal);
-    return ResponseEntity.ok(userV2Service.getAllMeetingByUser(userId));
-  }
+    @GetMapping("/meeting/all")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<List<UserV2GetAllMeetingByUserMeetingDto>> getAllMeetingByUser(
+            Principal principal) {
+        Integer userId = UserUtil.getUserId(principal);
+        return ResponseEntity.ok(userV2Service.getAllMeetingByUser(userId));
+    }
+
+    @GetMapping("/mention")
+    public ResponseEntity<List<UserV2GetAllMentionUserDto>> getAllMentionUser(
+            Principal principal) {
+        Integer userId = UserUtil.getUserId(principal);
+        return ResponseEntity.ok(userV2Service.getAllMentionUser(userId));
+    }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
@@ -33,6 +33,6 @@ public class UserV2Controller implements UserApi {
     public ResponseEntity<List<UserV2GetAllMentionUserDto>> getAllMentionUser(
             Principal principal) {
         UserUtil.getUserId(principal);
-        return ResponseEntity.ok(userV2Service.getAllMentionUser());
+        return ResponseEntity.ok(userV2Service.getAllMentionUser().getUserDtos());
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
@@ -32,7 +32,7 @@ public class UserV2Controller implements UserApi {
     @GetMapping("/mention")
     public ResponseEntity<List<UserV2GetAllMentionUserDto>> getAllMentionUser(
             Principal principal) {
-        Integer userId = UserUtil.getUserId(principal);
-        return ResponseEntity.ok(userV2Service.getAllMentionUser(userId));
+        UserUtil.getUserId(principal);
+        return ResponseEntity.ok(userV2Service.getAllMentionUser());
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/UserV2GetAllMentionUserDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/UserV2GetAllMentionUserDto.java
@@ -2,14 +2,20 @@ package org.sopt.makers.crew.main.user.v2.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor(staticName = "of")
+@AllArgsConstructor
+@NoArgsConstructor
 public class UserV2GetAllMentionUserDto {
     private Integer userId;
     private String userName;
     private String recentPart;
     private int recentGeneration;
     private String profileImageUrl;
+
+    public static UserV2GetAllMentionUserDto of(Integer userId, String userName, String recentPart, int recentGeneration, String profileImageUrl) {
+        return new UserV2GetAllMentionUserDto(userId, userName, recentPart, recentGeneration, profileImageUrl);
+    }
 }
 

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/UserV2GetAllMentionUserDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/UserV2GetAllMentionUserDto.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public class UserV2GetAllMentionUserDto {
     private Integer userId;
     private String userName;
-    private String part;
+    private String recentPart;
     private int recentGeneration;
     private String profileImageUrl;
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/UserV2GetAllMentionUserDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/UserV2GetAllMentionUserDto.java
@@ -1,0 +1,15 @@
+package org.sopt.makers.crew.main.user.v2.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class UserV2GetAllMentionUserDto {
+    private Integer userId;
+    private String userName;
+    private String part;
+    private int recentGeneration;
+    private String profileImageUrl;
+}
+

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2Service.java
@@ -2,11 +2,10 @@ package org.sopt.makers.crew.main.user.v2.service;
 
 import java.util.List;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMeetingByUserMeetingDto;
-import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMentionUserDto;
 
 public interface UserV2Service {
 
   List<UserV2GetAllMeetingByUserMeetingDto> getAllMeetingByUser(Integer userId);
 
-  List<UserV2GetAllMentionUserDto> getAllMentionUser();
+  Users getAllMentionUser();
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2Service.java
@@ -8,5 +8,5 @@ public interface UserV2Service {
 
   List<UserV2GetAllMeetingByUserMeetingDto> getAllMeetingByUser(Integer userId);
 
-  List<UserV2GetAllMentionUserDto> getAllMentionUser(Integer userId);
+  List<UserV2GetAllMentionUserDto> getAllMentionUser();
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2Service.java
@@ -2,9 +2,11 @@ package org.sopt.makers.crew.main.user.v2.service;
 
 import java.util.List;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMeetingByUserMeetingDto;
+import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMentionUserDto;
 
 public interface UserV2Service {
 
   List<UserV2GetAllMeetingByUserMeetingDto> getAllMeetingByUser(Integer userId);
 
+  List<UserV2GetAllMentionUserDto> getAllMentionUser(Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
@@ -51,7 +51,7 @@ public class UserV2ServiceImpl implements UserV2Service {
     }
 
     @Override
-    public List<UserV2GetAllMentionUserDto> getAllMentionUser(Integer userId) {
+    public List<UserV2GetAllMentionUserDto> getAllMentionUser() {
 
         List<User> users = userRepository.findAll();
 

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
@@ -12,6 +12,7 @@ import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.entity.user.UserRepository;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMeetingByUserMeetingDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMentionUserDto;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserV2ServiceImpl implements UserV2Service {
+    private final static String CACHE_NAME = "mention-user";
+
 
     private final UserRepository userRepository;
     private final ApplyRepository applyRepository;
@@ -51,15 +54,17 @@ public class UserV2ServiceImpl implements UserV2Service {
     }
 
     @Override
-    public List<UserV2GetAllMentionUserDto> getAllMentionUser() {
+    @Cacheable(cacheNames = CACHE_NAME, key = "'allMentionUsers'")
+    public Users getAllMentionUser() {
 
         List<User> users = userRepository.findAll();
-
-        return users.stream()
+        List<UserV2GetAllMentionUserDto> list = users.stream()
                 .filter(user -> user.getActivities() != null)
                 .map(user -> UserV2GetAllMentionUserDto.of(user.getId(), user.getName(),
                         user.getRecentActivityVO().getPart(), user.getRecentActivityVO().getGeneration(),
                         user.getProfileImage()))
                 .toList();
+
+        return new Users(list);
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/Users.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/Users.java
@@ -1,0 +1,17 @@
+package org.sopt.makers.crew.main.user.v2.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMentionUserDto;
+
+@Getter
+@NoArgsConstructor
+public class Users {
+    private List<UserV2GetAllMentionUserDto> userDtos = new ArrayList<>();
+
+    public Users(List<UserV2GetAllMentionUserDto> userDtos) {
+        this.userDtos = userDtos;
+    }
+}

--- a/main/src/main/resources/application-dev.yml
+++ b/main/src/main/resources/application-dev.yml
@@ -22,6 +22,10 @@ spring:
         format_sql: ture
       dialect: org.hibernate.dialect.PostgreSQLDialect
       storage_engine: innodb
+  data:
+    redis:
+      host: localhost
+      port : 6379
 
 jwt:
   header: Authorization

--- a/main/src/main/resources/application-prod.yml
+++ b/main/src/main/resources/application-prod.yml
@@ -21,6 +21,10 @@ spring:
         format_sql: ture
       dialect: org.hibernate.dialect.PostgreSQLDialect
       storage_engine: innodb
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 jwt:
   header: Authorization

--- a/main/src/test/java/org/sopt/makers/crew/main/common/annotation/IntegratedTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/common/annotation/IntegratedTest.java
@@ -1,0 +1,21 @@
+package org.sopt.makers.crew.main.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest
+@Transactional
+@Testcontainers
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public @interface IntegratedTest {
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/entity/user/UserEntityTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/entity/user/UserEntityTest.java
@@ -1,0 +1,51 @@
+package org.sopt.makers.crew.main.entity.user;
+
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
+
+public class UserEntityTest {
+
+
+    @Test
+    void 최근_기수_조회(){
+        // given
+        User user = User.builder()
+                .name("홍길동")
+                .orgId(1)
+                .activities(List.of(new UserActivityVO("서버", 33), new UserActivityVO("iOS", 34)))
+                .profileImage("image-url")
+                .phone("010-1234-5678")
+                .build();
+
+        // when
+        UserActivityVO recentActivityVO = user.getRecentActivityVO();
+
+        // then
+
+        Assertions.assertThat(recentActivityVO.getGeneration()).isEqualTo(34);
+        Assertions.assertThat(recentActivityVO.getPart()).isEqualTo("iOS");
+
+    }
+
+    @Test
+    void 최근_기수_조회_잘못된_데이터가_저장된_경우_해당_데이터는_무시한다(){
+        // given
+        User user = User.builder()
+                .name("홍길동")
+                .orgId(1)
+                .activities(List.of(new UserActivityVO(null, 34), new UserActivityVO("서버", 33)))
+                .profileImage("image-url")
+                .phone("010-1234-5678")
+                .build();
+
+        // when
+        UserActivityVO recentActivityVO = user.getRecentActivityVO();
+
+        // then
+
+        Assertions.assertThat(recentActivityVO.getGeneration()).isEqualTo(33);
+        Assertions.assertThat(recentActivityVO.getPart()).isEqualTo("서버");
+    }
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/user/v2/UserServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/user/v2/UserServiceTest.java
@@ -1,0 +1,123 @@
+package org.sopt.makers.crew.main.user.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sopt.makers.crew.main.common.annotation.IntegratedTest;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.UserRepository;
+import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
+import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMentionUserDto;
+import org.sopt.makers.crew.main.user.v2.service.UserV2Service;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@IntegratedTest
+public class UserServiceTest {
+
+    @Autowired
+    private UserV2Service userV2Service;
+
+    @Autowired
+    private UserRepository userRepository;
+
+
+    @Test
+    void 멘션_사용자_조회(){
+        // given
+        User user1 = User.builder()
+                .name("홍길동")
+                .orgId(1)
+                .activities(List.of(new UserActivityVO("서버", 33), new UserActivityVO("iOS", 34)))
+                .profileImage("image-url1")
+                .phone("010-1234-5678")
+                .build();
+        User user2 = User.builder()
+                .name("김철수")
+                .orgId(2)
+                .activities(List.of(new UserActivityVO("iOS", 30), new UserActivityVO("안드로이드", 33)))
+                .profileImage("image-url2")
+                .phone("010-1111-2222")
+                .build();
+        userRepository.saveAll(List.of(user1, user2));
+
+        // when
+        List<UserV2GetAllMentionUserDto> allMentionUsers = userV2Service.getAllMentionUser();
+
+        // then
+        assertThat(allMentionUsers).hasSize(2);
+        assertThat(allMentionUsers.get(0))
+                .extracting( "userName", "recentPart", "recentGeneration", "profileImageUrl")
+                .containsExactly( "홍길동", "iOS", 34, "image-url1");
+        assertThat(allMentionUsers.get(1))
+                .extracting("userName", "recentPart", "recentGeneration", "profileImageUrl")
+                .containsExactly("김철수", "안드로이드", 33, "image-url2");
+
+    }
+
+    @Test
+    void 멘션_사용자_조회시_db에_null_저장된_경우(){
+        // given
+        User user1 = User.builder()
+                .name("홍길동")
+                .orgId(1)
+                .activities(null)
+                .profileImage("image-url1")
+                .phone("010-1234-5678")
+                .build();
+        User user2 = User.builder()
+                .name("김철수")
+                .orgId(2)
+                .activities(List.of(new UserActivityVO("iOS", 30), new UserActivityVO("안드로이드", 33)))
+                .profileImage("image-url2")
+                .phone("010-1111-2222")
+                .build();
+        userRepository.saveAll(List.of(user1, user2));
+
+        // when
+        List<UserV2GetAllMentionUserDto> allMentionUsers = userV2Service.getAllMentionUser();
+
+        // then
+        assertThat(allMentionUsers).hasSize(1);
+        assertThat(allMentionUsers.get(0))
+                .extracting( "userName", "recentPart", "recentGeneration", "profileImageUrl")
+                .containsExactly("김철수", "안드로이드", 33, "image-url2");
+    }
+
+    @Test
+    void 멘션_사용자_조회시_db에_올바르지_않은_데이터_저장된_경우(){
+        // given
+        User user1 = User.builder()
+                .name("홍길동")
+                .orgId(1)
+                .activities(List.of(new UserActivityVO("서버", 33), new UserActivityVO("iOS", 34)))
+                .profileImage("image-url1")
+                .phone("010-1234-5678")
+                .build();
+        User user2 = User.builder()
+                .name("김철수")
+                .orgId(2)
+                .activities(List.of(new UserActivityVO(null, 30), new UserActivityVO("", 34)))
+                .profileImage("image-url2")
+                .phone("010-1111-2222")
+                .build();
+        userRepository.saveAll(List.of(user1, user2));
+
+        // when
+        List<UserV2GetAllMentionUserDto> allMentionUsers = userV2Service.getAllMentionUser();
+
+        // then
+        assertThat(allMentionUsers).hasSize(2);
+        assertThat(allMentionUsers.get(0))
+                .extracting("userName", "recentPart", "recentGeneration", "profileImageUrl")
+                .containsExactly("홍길동", "iOS", 34, "image-url1");
+        assertThat(allMentionUsers.get(1))
+                .extracting("userName", "recentPart", "recentGeneration", "profileImageUrl")
+                .containsExactly("김철수", "", 34, "image-url2");
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 멘션 사용자 조회 API에 캐시 도입했습니다.
- 한 기수동안 수정이 거의 일어나지 않기 때문에 캐시 히트율이 매우 높다고 생각했습니다.
- 하지만 성능 이슈가 발생하면 도입할 예정이고, 일단 PR만 올려보고자 했습니다!
- 캐시는 5시간마다 업데이트하도록 일단 설정해뒀고, 이후에는 새 회원이 등록될 때마다 캐시를 업데이트 하는 방식으로 변경하고자 합니다!
- 아래 성능을 보면 평균응답시간이 확실히 빨라진 것을 확인할 수 있습니다!
<img width="580" alt="스크린샷 2024-07-09 오후 1 52 45" src="https://github.com/sopt-makers/sopt-crew-backend/assets/100754581/7655a1fb-ff9e-4806-884a-da606506fec8">

<img width="593" alt="스크린샷 2024-07-09 오후 1 53 17" src="https://github.com/sopt-makers/sopt-crew-backend/assets/100754581/4ef94aeb-e0b1-4ecc-9cac-080f953338ea">


## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #225

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?