### PR TITLE
[FEAT] 대댓글 기능 구현

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/CommentV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/CommentV2Api.java
@@ -62,7 +62,7 @@ public interface CommentV2Api {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "성공"),
 	})
-	ResponseEntity<Void> mentionUserInCom현ment(
+	ResponseEntity<Void> mentionUserInComment(
 		@Valid @RequestBody CommentV2MentionUserInCommentRequestDto requestBody,
 		Principal principal);
 

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/CommentV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/CommentV2Api.java
@@ -7,14 +7,17 @@ import jakarta.validation.Valid;
 
 import java.security.Principal;
 
+import org.sopt.makers.crew.main.comment.v2.dto.query.CommentV2GetCommentsQueryDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2CreateCommentBodyDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2MentionUserInCommentRequestDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2UpdateCommentBodyDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2CreateCommentResponseDto;
+import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2GetCommentsResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2ReportCommentResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2UpdateCommentResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -59,7 +62,14 @@ public interface CommentV2Api {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "성공"),
 	})
-	ResponseEntity<Void> mentionUserInComment(
+	ResponseEntity<Void> mentionUserInCom현ment(
 		@Valid @RequestBody CommentV2MentionUserInCommentRequestDto requestBody,
 		Principal principal);
+
+	@Operation(summary = "모임 게시글 댓글 리스트 조회")
+	@ResponseStatus(HttpStatus.OK)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "성공"),
+	})
+	ResponseEntity<CommentV2GetCommentsResponseDto> getComments(@Valid @ModelAttribute CommentV2GetCommentsQueryDto requestBody, Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/CommentV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/CommentV2Controller.java
@@ -7,17 +7,20 @@ import java.security.Principal;
 
 import lombok.RequiredArgsConstructor;
 
+import org.sopt.makers.crew.main.comment.v2.dto.query.CommentV2GetCommentsQueryDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2CreateCommentBodyDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2MentionUserInCommentRequestDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2UpdateCommentBodyDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2CreateCommentResponseDto;
+import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2GetCommentsResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2ReportCommentResponseDto;
-import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2UpdateCommentResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2UpdateCommentResponseDto;
 import org.sopt.makers.crew.main.comment.v2.service.CommentV2Service;
 import org.sopt.makers.crew.main.common.util.UserUtil;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -81,5 +84,18 @@ public class CommentV2Controller implements CommentV2Api {
 		Integer userId = UserUtil.getUserId(principal);
 		commentV2Service.mentionUserInComment(requestBody, userId);
 		return ResponseEntity.status(HttpStatus.OK).build();
+	}
+
+	@Override
+	@GetMapping
+	public ResponseEntity<CommentV2GetCommentsResponseDto> getComments(
+		@Valid @ModelAttribute CommentV2GetCommentsQueryDto requestBody,
+		Principal principal) {
+
+		Integer userId = UserUtil.getUserId(principal);
+		CommentV2GetCommentsResponseDto commentDtos = commentV2Service.getComments(requestBody.getPostId(),
+			requestBody.getPage(), requestBody.getTake(), userId);
+
+		return ResponseEntity.status(HttpStatus.OK).body(commentDtos);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/query/CommentV2GetCommentsQueryDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/query/CommentV2GetCommentsQueryDto.java
@@ -1,0 +1,20 @@
+package org.sopt.makers.crew.main.comment.v2.dto.query;
+
+import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentV2GetCommentsQueryDto extends PageOptionsDto {
+
+	@NotNull
+	private final Integer postId;
+
+	@Builder
+	public CommentV2GetCommentsQueryDto(Integer page, Integer take, Integer postId) {
+		super(page, take);
+		this.postId = postId;
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/request/CommentV2CreateCommentBodyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/request/CommentV2CreateCommentBodyDto.java
@@ -11,12 +11,18 @@ import lombok.Getter;
 @Schema(description = "댓글 생성 request body dto")
 public class CommentV2CreateCommentBodyDto {
 
-  @Schema(example = "1", required = true, description = "게시글 ID")
-  @NotNull
-  private Integer postId;
+	@Schema(example = "1", required = true, description = "게시글 ID")
+	@NotNull
+	private Integer postId;
 
-  @Schema(example = "알고보면 쓸데있는 개발 프로세스", required = true, description = "댓글 내용")
-  @NotEmpty
-  private String contents;
+	@Schema(example = "알고보면 쓸데있는 개발 프로세스", required = true, description = "댓글 내용")
+	@NotEmpty
+	private String contents;
+
+	@Schema(example = "댓글/대댓글 여부", required = true, description = "true")
+	private boolean isParent;
+
+	@Schema(example = "대댓글인 경우, 댓글의 id", required = true, description = "1")
+	private Integer parentCommentId;
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/response/CommentDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/response/CommentDto.java
@@ -1,0 +1,33 @@
+package org.sopt.makers.crew.main.comment.v2.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.Getter;
+
+@Getter
+public class CommentDto {
+	private final Integer id;
+	private final String contents;
+	private final CommentWriterDto user;
+	private final LocalDateTime updatedDate;
+	private final int likeCount;
+	private final boolean isLiked;
+	private final boolean isWriter;
+	private final List<CommentDto> replies;
+
+	@QueryProjection
+	public CommentDto(Integer id, String contents, CommentWriterDto user, LocalDateTime updatedDate, int likeCount,
+		boolean isLiked, boolean isWriter, List<CommentDto> replies) {
+		this.id = id;
+		this.contents = contents;
+		this.user = user;
+		this.updatedDate = updatedDate;
+		this.likeCount = likeCount;
+		this.isLiked = isLiked;
+		this.isWriter = isWriter;
+		this.replies = replies;
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/response/CommentV2GetCommentsResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/response/CommentV2GetCommentsResponseDto.java
@@ -1,0 +1,15 @@
+package org.sopt.makers.crew.main.comment.v2.dto.response;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.common.pagination.dto.PageMetaDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class CommentV2GetCommentsResponseDto {
+	private final List<CommentDto> comments;
+	private final PageMetaDto meta;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/response/CommentWriterDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/response/CommentWriterDto.java
@@ -1,0 +1,19 @@
+package org.sopt.makers.crew.main.comment.v2.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.Getter;
+
+@Getter
+public class CommentWriterDto {
+	private final Integer id;
+	private final String name;
+	private final String profileImage;
+
+	@QueryProjection
+	public CommentWriterDto(Integer id, String name, String profileImage) {
+		this.id = id;
+		this.name = name;
+		this.profileImage = profileImage;
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2Service.java
@@ -3,6 +3,7 @@ package org.sopt.makers.crew.main.comment.v2.service;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2CreateCommentBodyDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2MentionUserInCommentRequestDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2CreateCommentResponseDto;
+import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2GetCommentsResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2ReportCommentResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2UpdateCommentResponseDto;
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
@@ -22,4 +23,6 @@ public interface CommentV2Service {
 
 	CommentV2UpdateCommentResponseDto updateComment(Integer commentId, String contents,
 		Integer userId);
+
+	CommentV2GetCommentsResponseDto getComments(Integer postId, Integer page, Integer take, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
@@ -2,21 +2,33 @@ package org.sopt.makers.crew.main.comment.v2.service;
 
 import static org.sopt.makers.crew.main.internal.notification.PushNotificationEnums.*;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2CreateCommentBodyDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2MentionUserInCommentRequestDto;
+import org.sopt.makers.crew.main.comment.v2.dto.response.CommentDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2CreateCommentResponseDto;
+import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2GetCommentsResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2UpdateCommentResponseDto;
+import org.sopt.makers.crew.main.comment.v2.dto.response.CommentWriterDto;
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.common.exception.ForbiddenException;
+import org.sopt.makers.crew.main.common.pagination.dto.PageMetaDto;
+import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
 import org.sopt.makers.crew.main.common.response.ErrorStatus;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2ReportCommentResponseDto;
 import org.sopt.makers.crew.main.common.util.Time;
 import org.sopt.makers.crew.main.entity.comment.Comment;
 import org.sopt.makers.crew.main.entity.comment.CommentRepository;
+import org.sopt.makers.crew.main.entity.like.Like;
+import org.sopt.makers.crew.main.entity.like.LikeRepository;
+import org.sopt.makers.crew.main.entity.like.MyLikes;
 import org.sopt.makers.crew.main.entity.post.Post;
 import org.sopt.makers.crew.main.entity.post.PostRepository;
 import org.sopt.makers.crew.main.entity.report.Report;
@@ -26,6 +38,8 @@ import org.sopt.makers.crew.main.entity.user.UserRepository;
 import org.sopt.makers.crew.main.internal.notification.PushNotificationService;
 import org.sopt.makers.crew.main.internal.notification.dto.PushNotificationRequestDto;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +47,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CommentV2ServiceImpl implements CommentV2Service {
+	private static final int IS_PARENT_COMMENT = 0;
 	private static final int IS_REPLY_COMMENT = 1;
 	private static final String DELETE_COMMENT_CONTENT = "삭제된 댓글입니다.";
 
@@ -40,6 +55,8 @@ public class CommentV2ServiceImpl implements CommentV2Service {
 	private final UserRepository userRepository;
 	private final CommentRepository commentRepository;
 	private final ReportRepository reportRepository;
+	private final LikeRepository likeRepository;
+
 	private final PushNotificationService pushNotificationService;
 
 	@Value("${push-notification.web-url}")
@@ -68,8 +85,8 @@ public class CommentV2ServiceImpl implements CommentV2Service {
 		if (isReplyComment) {
 			validateParentCommentId(requestBody);
 			depth = 1;
-			order = getOrder(parentId);
 			parentId = requestBody.getParentCommentId();
+			order = getOrder(parentId);
 		}
 
 		Comment comment = getComment(requestBody, post, writer, depth, order, parentId);
@@ -136,7 +153,7 @@ public class CommentV2ServiceImpl implements CommentV2Service {
 		Comment comment = commentRepository.findByIdOrThrow(commentId);
 
 		// 2. comment의 user_id와 userId가 같은지 확인한다.
-		comment.isWriter(userId);
+		comment.validateWriter(userId);
 
 		// 3. comment의 contents를 수정한다.
 		comment.updateContents(contents, time.now());
@@ -144,6 +161,45 @@ public class CommentV2ServiceImpl implements CommentV2Service {
 		// 4. 수정된 comment의 id, contents, updatedDate를 반환한다.
 		return CommentV2UpdateCommentResponseDto.of(comment.getId(), comment.getContents(),
 			String.valueOf(comment.getUpdatedDate()));
+	}
+
+	@Override
+	public CommentV2GetCommentsResponseDto getComments(Integer postId, Integer page, Integer take, Integer userId) {
+		Page<Comment> allComments = commentRepository.findAllByPostIdPagination(postId, IS_PARENT_COMMENT,
+			PageRequest.of(page - 1, take));
+		List<Comment> parentComments = allComments.stream()
+			.filter(comment -> comment.getDepth() == IS_PARENT_COMMENT)
+			.toList();
+		List<Comment> childComments = allComments.stream()
+			.filter(comment -> comment.getDepth() == IS_REPLY_COMMENT)
+			.toList();
+
+		MyLikes myLikes = new MyLikes(likeRepository.findAllByUserIdAndPostIdNotNull(userId));
+
+		List<CommentDto> commentDtos = getCommentDtos(userId, parentComments, childComments, myLikes);
+
+		PageOptionsDto pageOptionsDto = new PageOptionsDto(page, take);
+		PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, (int)allComments.getTotalElements());
+
+		return CommentV2GetCommentsResponseDto.of(commentDtos, pageMetaDto);
+	}
+
+	private List<CommentDto> getCommentDtos(Integer userId, List<Comment> parentComments, List<Comment> childComments,
+		MyLikes myLikes) {
+
+		Map<Integer, List<CommentDto>> replyMap = new HashMap<>();
+		childComments.forEach(comment -> replyMap.computeIfAbsent(comment.getParentId(), k -> new ArrayList<>())
+			.add(new CommentDto(comment.getId(), comment.getContents(),
+				new CommentWriterDto(comment.getUser().getId(), comment.getUser().getName(),
+					comment.getUser().getProfileImage()), comment.getUpdatedDate(), comment.getLikeCount(),
+				myLikes.isLikeComment(comment.getId()), comment.isWriter(userId), null)));
+
+		return parentComments.stream()
+			.map(comment -> new CommentDto(comment.getId(), comment.getContents(),
+				new CommentWriterDto(comment.getUser().getId(), comment.getUser().getName(),
+					comment.getUser().getProfileImage()), comment.getUpdatedDate(), comment.getLikeCount(),
+				myLikes.isLikeComment(comment.getId()), comment.isWriter(userId), replyMap.get(comment.getId())))
+			.toList();
 	}
 
 	/**

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
@@ -252,13 +252,15 @@ public class CommentV2ServiceImpl implements CommentV2Service {
 		Post post = postRepository.findByIdOrThrow(comment.getPostId());
 		post.decreaseCommentCount();
 
-		if (comment.getDepth() == IS_REPLY_COMMENT) {
+		Optional<Comment> childComment = commentRepository.findFirstByParentIdOrderByOrderDesc(
+			comment.getId());
+
+		if (comment.getDepth() == IS_REPLY_COMMENT || childComment.isEmpty()) {
 			commentRepository.delete(comment);
 			return;
 		}
 
 		comment.deleteParentComment(DELETE_COMMENT_CONTENT, null, null);
-
 	}
 
 	@Override

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
@@ -33,6 +33,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CommentV2ServiceImpl implements CommentV2Service {
+	private static final int IS_REPLY_COMMENT = 1;
+	private static final String DELETE_COMMENT_CONTENT = "삭제된 댓글입니다.";
 
 	private final PostRepository postRepository;
 	private final UserRepository userRepository;
@@ -193,7 +195,14 @@ public class CommentV2ServiceImpl implements CommentV2Service {
 
 		Post post = postRepository.findByIdOrThrow(comment.getPostId());
 		post.decreaseCommentCount();
-		commentRepository.delete(comment);
+
+		if (comment.getDepth() == IS_REPLY_COMMENT) {
+			commentRepository.delete(comment);
+			return;
+		}
+
+		comment.deleteParentComment(DELETE_COMMENT_CONTENT, null, null);
+
 	}
 
 	@Override

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/Apply.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/Apply.java
@@ -104,7 +104,6 @@ public class Apply {
         this.content = content;
         this.appliedDate = LocalDateTime.now();
         this.status = EnApplyStatus.WAITING;
-        this.meeting.addApply(this);
     }
 
     public void updateApplyStatus(EnApplyStatus status) {

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
@@ -20,6 +20,8 @@ public interface ApplyRepository extends JpaRepository<Apply, Integer>, ApplySea
 
     List<Apply> findAllByMeetingIdAndStatus(Integer meetingId, EnApplyStatus statusValue);
 
+    List<Apply> findAllByMeetingId(Integer meetingId);
+
     boolean existsByMeetingIdAndUserId(Integer meetingId, Integer userId);
 
     @Transactional

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepository.java
@@ -1,12 +1,12 @@
 package org.sopt.makers.crew.main.entity.apply;
 
-import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 
 public interface ApplySearchRepository {
-    Page<ApplyInfoDto> findApplyList(MeetingGetApplyListCommand queryCommand, Pageable pageable, Integer meetingId,
+    Page<ApplyInfoDto> findApplyList(MeetingGetAppliesQueryDto queryCommand, Pageable pageable, Integer meetingId,
                                      Integer meetingCreatorId, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepositoryImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepositoryImpl.java
@@ -9,7 +9,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.QApplicantDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.QApplyInfoDto;
@@ -25,7 +25,7 @@ public class ApplySearchRepositoryImpl implements ApplySearchRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<ApplyInfoDto> findApplyList(MeetingGetApplyListCommand queryCommand, Pageable pageable, Integer meetingId, Integer meetingCreatorId, Integer userId) {
+    public Page<ApplyInfoDto> findApplyList(MeetingGetAppliesQueryDto queryCommand, Pageable pageable, Integer meetingId, Integer meetingCreatorId, Integer userId) {
         List<ApplyInfoDto> content = getContent(queryCommand, pageable, meetingId, meetingCreatorId, userId);
         JPAQuery<Long> countQuery = getCount(queryCommand, meetingId);
 
@@ -33,7 +33,7 @@ public class ApplySearchRepositoryImpl implements ApplySearchRepository {
                 PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()), countQuery::fetchFirst);
     }
 
-    private List<ApplyInfoDto> getContent(MeetingGetApplyListCommand queryCommand, Pageable pageable, Integer meetingId, Integer meetingCreatorId, Integer userId) {
+    private List<ApplyInfoDto> getContent(MeetingGetAppliesQueryDto queryCommand, Pageable pageable, Integer meetingId, Integer meetingCreatorId, Integer userId) {
         boolean isStudyCreator = Objects.equals(meetingCreatorId, userId);
         return queryFactory
                 .select(new QApplyInfoDto(
@@ -53,7 +53,7 @@ public class ApplySearchRepositoryImpl implements ApplySearchRepository {
                 .fetch();
     }
 
-    private JPAQuery<Long> getCount(MeetingGetApplyListCommand queryCommand, Integer meetingId) {
+    private JPAQuery<Long> getCount(MeetingGetAppliesQueryDto queryCommand, Integer meetingId) {
         return queryFactory
                 .select(apply.count())
                 .from(apply)

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
@@ -48,13 +48,13 @@ public class Comment {
 	private String contents;
 
 	/**
-	 * 댓글 깊이
+	 * 댓글/대댓글 구분자 (0 = 댓글, 1 = 대댓글)
 	 */
 	@Column(nullable = false, columnDefinition = "int default 0")
 	private int depth;
 
 	/**
-	 * 댓글 순서
+	 * 댓글 순서 (댓글일 경우 0, 대댓글은 1부터 시작)
 	 */
 	@Column(nullable = false, columnDefinition = "int default 0")
 	private int order;
@@ -106,29 +106,26 @@ public class Comment {
 	private int likeCount;
 
 	/**
-	 * 부모 댓글 정보
-	 */
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "parentId")
-	private Comment parent;
-
-	/**
 	 * 부모 댓글의 고유 식별자
 	 */
 	@Column(insertable = false, updatable = false)
 	private Integer parentId;
 
 	@Builder
-	public Comment(String contents, User user, Post post, Comment parent) {
+	public Comment(String contents, int depth, int order, LocalDateTime createdDate, LocalDateTime updatedDate,
+		User user,
+		Integer userId, Post post, Integer postId, int likeCount, Integer parentId) {
 		this.contents = contents;
+		this.depth = depth;
+		this.order = order;
+		this.createdDate = createdDate;
+		this.updatedDate = updatedDate;
 		this.user = user;
-		this.userId = user.getId();
+		this.userId = userId;
 		this.post = post;
-		this.parent = parent;
-		this.depth = 0;
-		this.order = 0;
-		this.likeCount = 0;
-		this.post.addComment(this);
+		this.postId = postId;
+		this.likeCount = likeCount;
+		this.parentId = parentId;
 	}
 
 	public void updateContents(String contents, LocalDateTime updatedDate) {

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
@@ -108,7 +108,7 @@ public class Comment {
 	/**
 	 * 부모 댓글의 고유 식별자
 	 */
-	@Column(insertable = false, updatable = false)
+	@Column(updatable = false)
 	private Integer parentId;
 
 	@Builder
@@ -138,11 +138,13 @@ public class Comment {
 		this.userId = userId;
 	}
 
-	public void isWriter(Integer userId) {
-		boolean isWriter = this.userId.equals(userId);
-		if (!isWriter) {
+	public void validateWriter(Integer userId) {
+		if (!isWriter(userId)) {
 			throw new ForbiddenException(FORBIDDEN_EXCEPTION.getErrorCode());
 		}
 	}
 
+	public boolean isWriter(Integer userId){
+		return this.userId.equals(userId);
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
@@ -77,7 +77,7 @@ public class Comment {
 	 * 작성자 정보
 	 */
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "userId", nullable = false)
+	@JoinColumn(name = "userId")
 	private User user;
 
 	/**
@@ -113,8 +113,7 @@ public class Comment {
 
 	@Builder
 	public Comment(String contents, int depth, int order, LocalDateTime createdDate, LocalDateTime updatedDate,
-		User user,
-		Integer userId, Post post, Integer postId, int likeCount, Integer parentId) {
+		User user, Integer userId, Post post, Integer postId, int likeCount, Integer parentId) {
 		this.contents = contents;
 		this.depth = depth;
 		this.order = order;
@@ -131,6 +130,12 @@ public class Comment {
 	public void updateContents(String contents, LocalDateTime updatedDate) {
 		this.contents = contents;
 		this.updatedDate = updatedDate;
+	}
+
+	public void deleteParentComment(String contents, User user, Integer userId) {
+		this.contents = contents;
+		this.user = user;
+		this.userId = userId;
 	}
 
 	public void isWriter(Integer userId) {

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
@@ -12,7 +12,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+
 import java.time.LocalDateTime;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,114 +34,113 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(name = "comment")
 public class Comment {
 
-  /**
-   * 댓글의 고유 식별자
-   */
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Integer id;
+	/**
+	 * 댓글의 고유 식별자
+	 */
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
 
-  /**
-   * 댓글 내용
-   */
-  @Column(nullable = false)
-  private String contents;
+	/**
+	 * 댓글 내용
+	 */
+	@Column(nullable = false)
+	private String contents;
 
-  /**
-   * 댓글 깊이
-   */
-  @Column(nullable = false, columnDefinition = "int default 0")
-  private int depth;
+	/**
+	 * 댓글 깊이
+	 */
+	@Column(nullable = false, columnDefinition = "int default 0")
+	private int depth;
 
-  /**
-   * 댓글 순서
-   */
-  @Column(nullable = false, columnDefinition = "int default 0")
-  private int order;
+	/**
+	 * 댓글 순서
+	 */
+	@Column(nullable = false, columnDefinition = "int default 0")
+	private int order;
 
-  /**
-   * 작성일
-   */
-  @Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
-  @CreatedDate
-  private LocalDateTime createdDate;
+	/**
+	 * 작성일
+	 */
+	@Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
+	@CreatedDate
+	private LocalDateTime createdDate;
 
-  /**
-   * 수정일
-   */
-  @Column(name = "updatedDate", nullable = false, columnDefinition = "TIMESTAMP")
-  @LastModifiedDate
-  private LocalDateTime updatedDate;
+	/**
+	 * 수정일
+	 */
+	@Column(name = "updatedDate", nullable = false, columnDefinition = "TIMESTAMP")
+	@LastModifiedDate
+	private LocalDateTime updatedDate;
 
-  /**
-   * 작성자 정보
-   */
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "userId", nullable = false)
-  private User user;
+	/**
+	 * 작성자 정보
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "userId", nullable = false)
+	private User user;
 
-  /**
-   * 작성자의 고유 식별자
-   */
-  @Column(insertable = false, updatable = false)
-  private Integer userId;
+	/**
+	 * 작성자의 고유 식별자
+	 */
+	@Column(insertable = false, updatable = false)
+	private Integer userId;
 
-  /**
-   * 댓글이 속한 게시글 정보
-   */
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "postId", nullable = false)
-  private Post post;
+	/**
+	 * 댓글이 속한 게시글 정보
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "postId", nullable = false)
+	private Post post;
 
-  /**
-   * 댓글이 속한 게시글의 고유 식별자
-   */
-  @Column(insertable = false, updatable = false)
-  private Integer postId;
+	/**
+	 * 댓글이 속한 게시글의 고유 식별자
+	 */
+	@Column(insertable = false, updatable = false)
+	private Integer postId;
 
-  /**
-   * 댓글에 대한 좋아요 수
-   */
-  @Column(nullable = false, columnDefinition = "int default 0")
-  private int likeCount;
+	/**
+	 * 댓글에 대한 좋아요 수
+	 */
+	@Column(nullable = false, columnDefinition = "int default 0")
+	private int likeCount;
 
-  /**
-   * 부모 댓글 정보
-   */
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "parentId")
-  private Comment parent;
+	/**
+	 * 부모 댓글 정보
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "parentId")
+	private Comment parent;
 
-  /**
-   * 부모 댓글의 고유 식별자
-   */
-  @Column(insertable = false, updatable = false)
-  private Integer parentId;
+	/**
+	 * 부모 댓글의 고유 식별자
+	 */
+	@Column(insertable = false, updatable = false)
+	private Integer parentId;
 
+	@Builder
+	public Comment(String contents, User user, Post post, Comment parent) {
+		this.contents = contents;
+		this.user = user;
+		this.userId = user.getId();
+		this.post = post;
+		this.parent = parent;
+		this.depth = 0;
+		this.order = 0;
+		this.likeCount = 0;
+		this.post.addComment(this);
+	}
 
-  @Builder
-  public Comment(String contents, User user, Post post, Comment parent) {
-    this.contents = contents;
-    this.user = user;
-    this.userId = user.getId();
-    this.post = post;
-    this.parent = parent;
-    this.depth = 0;
-    this.order = 0;
-    this.likeCount = 0;
-    this.post.addComment(this);
-  }
+	public void updateContents(String contents, LocalDateTime updatedDate) {
+		this.contents = contents;
+		this.updatedDate = updatedDate;
+	}
 
-  public void updateContents(String contents,LocalDateTime updatedDate) {
-    this.contents = contents;
-    this.updatedDate = updatedDate;
-  }
-
-  public void isWriter(Integer userId){
-    boolean isWriter = this.userId.equals(userId);
-    if (!isWriter) {
-      throw new ForbiddenException(FORBIDDEN_EXCEPTION.getErrorCode());
-    }
-  }
+	public void isWriter(Integer userId) {
+		boolean isWriter = this.userId.equals(userId);
+		if (!isWriter) {
+			throw new ForbiddenException(FORBIDDEN_EXCEPTION.getErrorCode());
+		}
+	}
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentRepository.java
@@ -1,13 +1,24 @@
 package org.sopt.makers.crew.main.entity.comment;
 
+import java.util.Optional;
+
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.common.response.ErrorStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Integer> {
 
-  default Comment findByIdOrThrow(Integer commentId) {
-    return findById(commentId)
-        .orElseThrow(() -> new BadRequestException(ErrorStatus.NOT_FOUND_COMMENT.getErrorCode()));
-  }
+	default Comment findByIdOrThrow(Integer commentId) {
+		return findById(commentId)
+			.orElseThrow(() -> new BadRequestException(ErrorStatus.NOT_FOUND_COMMENT.getErrorCode()));
+	}
+
+	Optional<Comment> findFirstByParentIdOrderByOrderDesc(Integer parentId);
+
+	Optional<Comment> findByIdAndPostId(Integer id, Integer postId);
+
+	default Comment findByIdAndPostIdOrThrow(Integer id, Integer postId){
+		return findByIdAndPostId(id, postId)
+			.orElseThrow(() -> new BadRequestException(ErrorStatus.NOT_FOUND_COMMENT.getErrorCode()));
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentRepository.java
@@ -6,7 +6,7 @@ import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.common.response.ErrorStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentRepository extends JpaRepository<Comment, Integer> {
+public interface CommentRepository extends JpaRepository<Comment, Integer>, CommentSearchRepository {
 
 	default Comment findByIdOrThrow(Integer commentId) {
 		return findById(commentId)

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentSearchRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentSearchRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.makers.crew.main.entity.comment;
+
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CommentSearchRepository {
+	Page<Comment> findAllByPostIdPagination(Integer postId, int depth, Pageable pageable);
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentSearchRepositoryImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentSearchRepositoryImpl.java
@@ -1,0 +1,49 @@
+package org.sopt.makers.crew.main.entity.comment;
+
+import static org.sopt.makers.crew.main.entity.comment.QComment.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentSearchRepositoryImpl implements CommentSearchRepository {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Page<Comment> findAllByPostIdPagination(Integer postId, int depth, Pageable pageable) {
+		QComment parentComment = new QComment("parentComment");
+		QComment childComment = new QComment("childComment");
+
+		List<Comment> content = queryFactory
+			.selectFrom(parentComment)
+			.leftJoin(childComment).on(childComment.parentId.eq(parentComment.id))
+			.where(parentComment.postId.eq(postId))
+			.orderBy(parentComment.createdDate.asc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		JPAQuery<Long> countQuery = getCount(postId);
+
+		return PageableExecutionUtils.getPage(content, PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()), countQuery::fetchFirst);
+	}
+
+	private JPAQuery<Long> getCount(Integer postId) {
+		return queryFactory
+			.select(comment.count())
+			.from(comment)
+			.where(comment.postId.eq(postId));
+
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
@@ -1,6 +1,10 @@
 package org.sopt.makers.crew.main.entity.like;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Integer> {
+
+	List<Like> findAllByUserIdAndPostIdNotNull(Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/like/MyLikes.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/like/MyLikes.java
@@ -1,0 +1,17 @@
+package org.sopt.makers.crew.main.entity.like;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class MyLikes {
+	private final List<Like> myLikes;
+
+	public boolean isLikeComment(Integer commentId){
+		return myLikes.stream()
+			.anyMatch(like -> like.getCommentId().equals(commentId));
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -14,15 +14,16 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
 import org.sopt.makers.crew.main.entity.apply.Apply;
@@ -31,7 +32,6 @@ import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
-import org.sopt.makers.crew.main.entity.post.Post;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -42,200 +42,179 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(name = "meeting")
 public class Meeting {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
 
-    /**
-     * 개설한 유저
-     */
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userId", nullable = false)
-    private User user;
+	/**
+	 * 개설한 유저
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "userId", nullable = false)
+	private User user;
 
-    /**
-     * 유저 id
-     */
-    @Column(insertable = false, updatable = false)
-    private Integer userId;
+	/**
+	 * 유저 id
+	 */
+	@Column(insertable = false, updatable = false)
+	private Integer userId;
 
-    /**
-     * 지원 or 초대 정보
-     */
-    @OneToMany(mappedBy = "meeting", cascade = CascadeType.REMOVE)
-    private List<Apply> appliedInfo;
+	/**
+	 * 모임 제목
+	 */
+	@Column(nullable = false)
+	private String title;
 
-    /**
-     * 모임 제목
-     */
-    @Column(nullable = false)
-    private String title;
+	/**
+	 * 모임 카테고리
+	 */
+	@Column(name = "category", nullable = false)
+	@Convert(converter = MeetingCategoryConverter.class)
+	private MeetingCategory category;
 
-    /**
-     * 모임 카테고리
-     */
-    @Column(name = "category", nullable = false)
-    @Convert(converter = MeetingCategoryConverter.class)
-    private MeetingCategory category;
+	/**
+	 * 이미지
+	 */
+	@Column(name = "imageURL", columnDefinition = "jsonb")
+	@Type(JsonBinaryType.class)
+	//@JdbcTypeCode(SqlTypes.JSON)
+	private List<ImageUrlVO> imageURL;
 
-    /**
-     * 이미지
-     */
-    @Column(name = "imageURL", columnDefinition = "jsonb")
-    @Type(JsonBinaryType.class)
-    //@JdbcTypeCode(SqlTypes.JSON)
-    private List<ImageUrlVO> imageURL;
+	/**
+	 * 모집 시작 기간
+	 */
+	@Column(name = "startDate", nullable = false, columnDefinition = "TIMESTAMP")
+	private LocalDateTime startDate;
 
-    /**
-     * 모집 시작 기간
-     */
-    @Column(name = "startDate", nullable = false, columnDefinition = "TIMESTAMP")
-    private LocalDateTime startDate;
+	/**
+	 * 모집 마감 기간
+	 */
+	@Column(name = "endDate", nullable = false, columnDefinition = "TIMESTAMP")
+	private LocalDateTime endDate;
 
-    /**
-     * 모집 마감 기간
-     */
-    @Column(name = "endDate", nullable = false, columnDefinition = "TIMESTAMP")
-    private LocalDateTime endDate;
+	/**
+	 * 모집 인원
+	 */
+	@Column(name = "capacity", nullable = false)
+	private Integer capacity;
 
-    /**
-     * 모집 인원
-     */
-    @Column(name = "capacity", nullable = false)
-    private Integer capacity;
+	/**
+	 * 모임 소개
+	 */
+	@Column(name = "desc", nullable = false)
+	private String desc;
 
-    /**
-     * 모임 소개
-     */
-    @Column(name = "desc", nullable = false)
-    private String desc;
+	/**
+	 * 진행방식 소개
+	 */
+	@Column(name = "processDesc", nullable = false)
+	private String processDesc;
 
-    /**
-     * 진행방식 소개
-     */
-    @Column(name = "processDesc", nullable = false)
-    private String processDesc;
+	/**
+	 * 모임 시작 기간
+	 */
+	@Column(name = "mStartDate", nullable = false, columnDefinition = "TIMESTAMP")
+	private LocalDateTime mStartDate;
 
-    /**
-     * 모임 시작 기간
-     */
-    @Column(name = "mStartDate", nullable = false, columnDefinition = "TIMESTAMP")
-    private LocalDateTime mStartDate;
+	/**
+	 * 모임 마감 기간
+	 */
+	@Column(name = "mEndDate", nullable = false, columnDefinition = "TIMESTAMP")
+	private LocalDateTime mEndDate;
 
-    /**
-     * 모임 마감 기간
-     */
-    @Column(name = "mEndDate", nullable = false, columnDefinition = "TIMESTAMP")
-    private LocalDateTime mEndDate;
+	/**
+	 * 개설자 소개
+	 */
+	@Column(name = "leaderDesc", nullable = false)
+	private String leaderDesc;
 
-    /**
-     * 개설자 소개
-     */
-    @Column(name = "leaderDesc", nullable = false)
-    private String leaderDesc;
+	/**
+	 * 모집 대상
+	 */
+	@Column(name = "targetDesc", nullable = false)
+	private String targetDesc;
 
-    /**
-     * 모집 대상
-     */
-    @Column(name = "targetDesc", nullable = false)
-    private String targetDesc;
+	/**
+	 * 유의 사항
+	 */
+	@Column(name = "note")
+	private String note;
 
-    /**
-     * 유의 사항
-     */
-    @Column(name = "note")
-    private String note;
+	/**
+	 * 멘토 필요 여부
+	 */
+	@Column(name = "isMentorNeeded", nullable = false)
+	private Boolean isMentorNeeded;
 
-    /**
-     * 멘토 필요 여부
-     */
-    @Column(name = "isMentorNeeded", nullable = false)
-    private Boolean isMentorNeeded;
+	/**
+	 * 활동 기수만 참여 가능한지 여부
+	 */
+	@Column(name = "canJoinOnlyActiveGeneration", nullable = false)
+	private Boolean canJoinOnlyActiveGeneration;
 
-    /**
-     * 활동 기수만 참여 가능한지 여부
-     */
-    @Column(name = "canJoinOnlyActiveGeneration", nullable = false)
-    private Boolean canJoinOnlyActiveGeneration;
+	/**
+	 * 모임 기수
+	 */
+	@Column(name = "createdGeneration", nullable = false)
+	private Integer createdGeneration;
 
-    /**
-     * 모임 기수
-     */
-    @Column(name = "createdGeneration", nullable = false)
-    private Integer createdGeneration;
+	/**
+	 * 대상 활동 기수
+	 */
+	@Column(name = "targetActiveGeneration")
+	private Integer targetActiveGeneration;
 
-    /**
-     * 대상 활동 기수
-     */
-    @Column(name = "targetActiveGeneration")
-    private Integer targetActiveGeneration;
+	/**
+	 * 모임 참여 가능한 파트
+	 */
+	@Type(value = EnumArrayType.class,
+		parameters = @Parameter(name = AbstractArrayType.SQL_ARRAY_TYPE,
+			value = "meeting_joinableparts_enum"))
+	@Column(name = "joinableParts", columnDefinition = "meeting_joinableparts_enum[]")
+	private MeetingJoinablePart[] joinableParts;
 
-    /**
-     * 모임 참여 가능한 파트
-     */
-    @Type(value = EnumArrayType.class,
-            parameters = @Parameter(name = AbstractArrayType.SQL_ARRAY_TYPE,
-                    value = "meeting_joinableparts_enum"))
-    @Column(name = "joinableParts", columnDefinition = "meeting_joinableparts_enum[]")
-    private MeetingJoinablePart[] joinableParts;
+	@Builder
+	public Meeting(User user, Integer userId, List<Apply> appliedInfo, String title, MeetingCategory category,
+		List<ImageUrlVO> imageURL, LocalDateTime startDate, LocalDateTime endDate, Integer capacity,
+		String desc, String processDesc, LocalDateTime mStartDate, LocalDateTime mEndDate,
+		String leaderDesc, String targetDesc, String note, Boolean isMentorNeeded,
+		Boolean canJoinOnlyActiveGeneration, Integer createdGeneration,
+		Integer targetActiveGeneration, MeetingJoinablePart[] joinableParts) {
+		this.user = user;
+		this.userId = userId;
+		this.title = title;
+		this.category = category;
+		this.imageURL = imageURL;
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.capacity = capacity;
+		this.desc = desc;
+		this.processDesc = processDesc;
+		this.mStartDate = mStartDate;
+		this.mEndDate = mEndDate;
+		this.leaderDesc = leaderDesc;
+		this.targetDesc = targetDesc;
+		this.note = note;
+		this.isMentorNeeded = isMentorNeeded;
+		this.canJoinOnlyActiveGeneration = canJoinOnlyActiveGeneration;
+		this.createdGeneration = createdGeneration;
+		this.targetActiveGeneration = targetActiveGeneration;
+		this.joinableParts = joinableParts;
+	}
 
-    /**
-     * 게시글 리스트
-     */
-    @OneToMany(mappedBy = "meeting", cascade = CascadeType.REMOVE)
-    private List<Post> posts;
-
-    @Builder
-    public Meeting(User user, Integer userId, List<Apply> appliedInfo, String title, MeetingCategory category,
-                   List<ImageUrlVO> imageURL, LocalDateTime startDate, LocalDateTime endDate, Integer capacity,
-                   String desc, String processDesc, LocalDateTime mStartDate, LocalDateTime mEndDate,
-                   String leaderDesc, String targetDesc, String note, Boolean isMentorNeeded,
-                   Boolean canJoinOnlyActiveGeneration, Integer createdGeneration,
-                   Integer targetActiveGeneration, MeetingJoinablePart[] joinableParts) {
-        this.user = user;
-        this.userId = userId;
-        this.appliedInfo = appliedInfo != null ? appliedInfo : new ArrayList<>();
-        this.title = title;
-        this.category = category;
-        this.imageURL = imageURL;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.capacity = capacity;
-        this.desc = desc;
-        this.processDesc = processDesc;
-        this.mStartDate = mStartDate;
-        this.mEndDate = mEndDate;
-        this.leaderDesc = leaderDesc;
-        this.targetDesc = targetDesc;
-        this.note = note;
-        this.isMentorNeeded = isMentorNeeded;
-        this.canJoinOnlyActiveGeneration = canJoinOnlyActiveGeneration;
-        this.createdGeneration = createdGeneration;
-        this.targetActiveGeneration = targetActiveGeneration;
-        this.joinableParts = joinableParts;
-    }
-
-    public void addApply(Apply apply) {
-        appliedInfo.add(apply);
-    }
-
-    public void addPost(Post post) {
-        posts.add(post);
-    }
-
-    /**
-     * 모임 모집상태 확인
-     *
-     * @return 모임 모집상태
-     */
-    public Integer getMeetingStatus() {
-        LocalDateTime now = LocalDateTime.now();
-        if (now.isBefore(startDate)) {
-            return EnMeetingStatus.BEFORE_START.getValue();
-        } else if (now.isBefore(endDate)) {
-            return EnMeetingStatus.APPLY_ABLE.getValue();
-        } else {
-            return EnMeetingStatus.RECRUITMENT_COMPLETE.getValue();
-        }
-    }
+	/**
+	 * 모임 모집상태 확인
+	 *
+	 * @return 모임 모집상태
+	 */
+	public Integer getMeetingStatus() {
+		LocalDateTime now = LocalDateTime.now();
+		if (now.isBefore(startDate)) {
+			return EnMeetingStatus.BEFORE_START.getValue();
+		} else if (now.isBefore(endDate)) {
+			return EnMeetingStatus.APPLY_ABLE.getValue();
+		} else {
+			return EnMeetingStatus.RECRUITMENT_COMPLETE.getValue();
+		}
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/post/Post.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/post/Post.java
@@ -11,19 +11,18 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import org.hibernate.annotations.Type;
 import org.sopt.makers.crew.main.entity.comment.Comment;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
-import org.sopt.makers.crew.main.entity.report.Report;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -36,124 +35,108 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(name = "post")
 public class Post {
 
-    /**
-     * 게시글의 고유 식별자
-     */
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+	/**
+	 * 게시글의 고유 식별자
+	 */
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
 
-    /**
-     * 게시글 제목
-     */
-    @Column(nullable = false)
-    private String title;
+	/**
+	 * 게시글 제목
+	 */
+	@Column(nullable = false)
+	private String title;
 
-    /**
-     * 게시글 내용
-     */
-    @Column(nullable = false, columnDefinition = "TEXT")
-    private String contents;
+	/**
+	 * 게시글 내용
+	 */
+	@Column(nullable = false, columnDefinition = "TEXT")
+	private String contents;
 
-    /**
-     * 게시글 작성일
-     */
-    @Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
-    @CreatedDate
-    private LocalDateTime createdDate;
+	/**
+	 * 게시글 작성일
+	 */
+	@Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
+	@CreatedDate
+	private LocalDateTime createdDate;
 
-    /**
-     * 게시글 수정일
-     */
-    @Column(name = "updatedDate", nullable = false, columnDefinition = "TIMESTAMP")
-    @LastModifiedDate
-    private LocalDateTime updatedDate;
+	/**
+	 * 게시글 수정일
+	 */
+	@Column(name = "updatedDate", nullable = false, columnDefinition = "TIMESTAMP")
+	@LastModifiedDate
+	private LocalDateTime updatedDate;
 
-    /**
-     * 조회수
-     */
-    @Column(nullable = false, columnDefinition = "int default 0")
-    private int viewCount;
+	/**
+	 * 조회수
+	 */
+	@Column(nullable = false, columnDefinition = "int default 0")
+	private int viewCount;
 
-    /**
-     * 이미지 리스트
-     */
-    @Column(name = "images", columnDefinition = "text[]")
-    @Type(StringArrayType.class)
-    private String[] images;
+	/**
+	 * 이미지 리스트
+	 */
+	@Column(name = "images", columnDefinition = "text[]")
+	@Type(StringArrayType.class)
+	private String[] images;
 
-    /**
-     * 작성자 정보
-     */
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userId", nullable = false)
-    private User user;
+	/**
+	 * 작성자 정보
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "userId", nullable = false)
+	private User user;
 
-    /**
-     * 작성자의 고유 식별자
-     */
-    @Column(insertable = false, updatable = false)
-    private Integer userId;
+	/**
+	 * 작성자의 고유 식별자
+	 */
+	@Column(insertable = false, updatable = false)
+	private Integer userId;
 
-    /**
-     * 게시글이 속한 미팅 정보
-     */
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "meetingId", nullable = false)
-    private Meeting meeting;
+	/**
+	 * 게시글이 속한 미팅 정보
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "meetingId", nullable = false)
+	private Meeting meeting;
 
-    /**
-     * 게시글이 속한 미팅의 고유 식별자
-     */
-    @Column(insertable = false, updatable = false)
-    private Integer meetingId;
+	/**
+	 * 게시글이 속한 미팅의 고유 식별자
+	 */
+	@Column(insertable = false, updatable = false)
+	private Integer meetingId;
 
-    /**
-     * 게시글에 달린 댓글 목록
-     */
-    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
-    private List<Comment> comments = new ArrayList<>();
+	/**
+	 * 게시글에 달린 댓글 수
+	 */
+	@Column(nullable = false, columnDefinition = "int default 0")
+	private int commentCount;
 
-    /**
-     * 게시글에 달린 댓글 수
-     */
-    @Column(nullable = false, columnDefinition = "int default 0")
-    private int commentCount;
+	/**
+	 * 게시글에 대한 좋아요 수
+	 */
+	@Column(nullable = false, columnDefinition = "int default 0")
+	private int likeCount;
 
-    /**
-     * 게시글에 대한 좋아요 수
-     */
-    @Column(nullable = false, columnDefinition = "int default 0")
-    private int likeCount;
+	@Builder
+	public Post(String title, String contents, String[] images, User user, Meeting meeting) {
+		this.title = title;
+		this.contents = contents;
+		this.viewCount = 0;
+		this.images = images;
+		this.user = user;
+		this.meeting = meeting;
+		this.commentCount = 0;
+		this.likeCount = 0;
+	}
 
-    /**
-     * 게시글에 대한 신고 목록
-     */
-    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
-    private List<Report> reports;
+	public void addComment(Comment comment) {
+		//this.comments.add(comment);
+		this.commentCount++;
+	}
 
-    @Builder
-    public Post(String title, String contents, String[] images, User user, Meeting meeting) {
-        this.title = title;
-        this.contents = contents;
-        this.viewCount = 0;
-        this.images = images;
-        this.user = user;
-        this.meeting = meeting;
-        this.commentCount = 0;
-        this.likeCount = 0;
-    }
-
-    public void addComment(Comment comment) {
-        this.comments.add(comment);
-        this.commentCount++;
-    }
-
-  public void addReport(Report report) {
-    this.reports.add(report);
-  }
-
-  public void decreaseCommentCount() {
-    this.commentCount--;
-  }
+	public void decreaseCommentCount() {
+		this.commentCount--;
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostRepository.java
@@ -14,4 +14,6 @@ public interface PostRepository extends JpaRepository<Post, Integer>, PostSearch
         return findById(postId)
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_POST.getErrorCode()));
     }
+
+    Optional<Post> findFirstByMeetingIdOrderByIdDesc(Integer meetingId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
@@ -3,30 +3,20 @@ package org.sopt.makers.crew.main.entity.user;
 import static org.sopt.makers.crew.main.common.response.ErrorStatus.*;
 
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Type;
 import org.sopt.makers.crew.main.common.exception.ServerException;
-import org.sopt.makers.crew.main.common.response.ErrorStatus;
-import org.sopt.makers.crew.main.entity.apply.Apply;
-import org.sopt.makers.crew.main.entity.meeting.Meeting;
-import org.sopt.makers.crew.main.entity.post.Post;
-import org.sopt.makers.crew.main.entity.report.Report;
 import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
 
 @Entity
@@ -74,50 +64,14 @@ public class User {
     @Column(name = "phone")
     private String phone;
 
-    /**
-     * 내가 생성한 모임
-     */
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
-    private Set<Meeting> meetings = new HashSet<>();
-
-    /**
-     * 내가 지원한 내역
-     */
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
-    private List<Apply> applies = new ArrayList<>();
-
-    /**
-     * 작성한 게시글
-     */
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
-    private List<Post> posts = new ArrayList<>();
-
-    /**
-     * 신고 내역
-     */
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
-    private List<Report> reports = new ArrayList<>();
-
     @Builder
-    public User(String name, int orgId, List<UserActivityVO> activities, String profileImage,
+    public User(String name, Integer orgId, List<UserActivityVO> activities, String profileImage,
                 String phone) {
         this.name = name;
         this.orgId = orgId;
         this.activities = activities;
         this.profileImage = profileImage;
         this.phone = phone;
-    }
-
-    public void addMeeting(Meeting meeting) {
-        this.meetings.add(meeting);
-    }
-
-    public void addApply(Apply apply) {
-        this.applies.add(apply);
-    }
-
-    public void addReport(Report report) {
-        this.reports.add(report);
     }
 
     public void setUserIdForTest(Integer userId) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.List;
-import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
@@ -69,6 +69,6 @@ public interface MeetingV2Api {
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "모임 지원자/참여자 조회 성공"),
             @ApiResponse(responseCode = "400", description = "모임이 없습니다.", content = @Content),})
     ResponseEntity<MeetingGetApplyListResponseDto> findApplyList(@PathVariable Integer meetingId,
-                                                                 @ModelAttribute MeetingGetApplyListCommand queryCommand,
+                                                                 @ModelAttribute MeetingGetAppliesQueryDto queryCommand,
                                                                  Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -6,7 +6,7 @@ import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.crew.main.common.util.UserUtil;
-import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
@@ -25,7 +25,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -84,7 +83,7 @@ public class MeetingV2Controller implements MeetingV2Api {
     @Override
     @GetMapping("/{meetingId}/list")
     public ResponseEntity<MeetingGetApplyListResponseDto> findApplyList(@PathVariable Integer meetingId,
-                                                                        @ModelAttribute MeetingGetApplyListCommand queryCommand,
+                                                                        @ModelAttribute MeetingGetAppliesQueryDto queryCommand,
                                                                         Principal principal) {
 
         Integer userId = UserUtil.getUserId(principal);

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/query/MeetingGetAppliesQueryDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/query/MeetingGetAppliesQueryDto.java
@@ -10,13 +10,13 @@ import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
 
 @Getter
 @Setter
-public class MeetingGetApplyListCommand extends PageOptionsDto {
+public class MeetingGetAppliesQueryDto extends PageOptionsDto {
 
     private List<EnApplyStatus> status;
     private String date;
 
     @Builder
-    public MeetingGetApplyListCommand(int page, int take, List<EnApplyStatus> status, String date) {
+    public MeetingGetAppliesQueryDto(int page, int take, List<EnApplyStatus> status, String date) {
         super(page, take);
         this.status = (status == null || status.isEmpty()) ?
                 Arrays.asList(EnApplyStatus.WAITING, EnApplyStatus.APPROVE, EnApplyStatus.REJECT) : status;

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingBannerResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingBannerResponseDto.java
@@ -52,7 +52,7 @@ public class MeetingV2GetMeetingBannerResponseDto {
     /** 가입된 지원자 수 */
     private Integer approvedUserCount;
     /** 개설자 정보 */
-    private Optional<MeetingV2GetMeetingBannerResponseUserDto> user;
+    private MeetingV2GetMeetingBannerResponseUserDto user;
     /** 미팅 상태 */
     private Integer status;
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -1,7 +1,7 @@
 package org.sopt.makers.crew.main.meeting.v2.service;
 
 import java.util.List;
-import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
@@ -24,6 +24,6 @@ public interface MeetingV2Service {
 
     void applyMeetingCancel(Integer meetingId, Integer userId);
 
-    MeetingGetApplyListResponseDto findApplyList(MeetingGetApplyListCommand queryCommand, Integer meetingId,
+    MeetingGetApplyListResponseDto findApplyList(MeetingGetAppliesQueryDto queryCommand, Integer meetingId,
                                                  Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -18,7 +18,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import lombok.RequiredArgsConstructor;
+
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.common.pagination.dto.PageMetaDto;
 import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
@@ -31,6 +33,7 @@ import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.post.Post;
+import org.sopt.makers.crew.main.entity.post.PostRepository;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.entity.user.UserRepository;
 import org.sopt.makers.crew.main.entity.user.enums.UserPart;
@@ -59,234 +62,236 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MeetingV2ServiceImpl implements MeetingV2Service {
 
-    private final static int ZERO = 0;
+	private final static int ZERO = 0;
 
-    private final UserRepository userRepository;
-    private final ApplyRepository applyRepository;
-    private final MeetingRepository meetingRepository;
+	private final UserRepository userRepository;
+	private final ApplyRepository applyRepository;
+	private final MeetingRepository meetingRepository;
+	private final PostRepository postRepository;
 
-    private final MeetingMapper meetingMapper;
-    private final ApplyMapper applyMapper;
+	private final MeetingMapper meetingMapper;
+	private final ApplyMapper applyMapper;
 
-    @Override
-    public MeetingV2GetAllMeetingByOrgUserDto getAllMeetingByOrgUser(
-            MeetingV2GetAllMeetingByOrgUserQueryDto queryDto) {
-        int page = queryDto.getPage();
-        int take = queryDto.getTake();
+	@Override
+	public MeetingV2GetAllMeetingByOrgUserDto getAllMeetingByOrgUser(
+		MeetingV2GetAllMeetingByOrgUserQueryDto queryDto) {
+		int page = queryDto.getPage();
+		int take = queryDto.getTake();
 
-        Optional<User> user = userRepository.findByOrgId(queryDto.getOrgUserId());
-        List<MeetingV2GetAllMeetingByOrgUserMeetingDto> userJoinedList = new ArrayList<>();
+		Optional<User> user = userRepository.findByOrgId(queryDto.getOrgUserId());
+		List<MeetingV2GetAllMeetingByOrgUserMeetingDto> userJoinedList = new ArrayList<>();
 
-        if (!user.isEmpty()) {
-            User existUser = user.get();
-            userJoinedList = Stream
-                    .concat(existUser.getMeetings().stream(),
-                            applyRepository.findAllByUserIdAndStatus(existUser.getId(), EnApplyStatus.APPROVE)
-                                    .stream().map(apply -> apply.getMeeting()))
-                    .map(meeting -> MeetingV2GetAllMeetingByOrgUserMeetingDto.of(meeting.getId(),
-                            checkMeetingLeader(meeting, existUser.getId()), meeting.getTitle(),
-                            meeting.getImageURL().get(0).getUrl(), meeting.getCategory().getValue(),
-                            meeting.getMStartDate(), meeting.getMEndDate(), checkActivityStatus(meeting)))
-                    .sorted(Comparator.comparing(MeetingV2GetAllMeetingByOrgUserMeetingDto::getId).reversed())
-                    .collect(Collectors.toList());
-        }
+		if (!user.isEmpty()) {
+			User existUser = user.get();
+			List<Meeting> myMeetings = meetingRepository.findAllByUserId(existUser.getId());
 
-        List<MeetingV2GetAllMeetingByOrgUserMeetingDto> pagedUserJoinedList =
-                userJoinedList.stream().skip((long) (page - 1) * take) // 스킵할 아이템 수 계산
-                        .limit(take) // 페이지당 아이템 수 제한
-                        .collect(Collectors.toList());
-        PageOptionsDto pageOptionsDto = new PageOptionsDto(page, take);
-        PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, userJoinedList.size());
-        return MeetingV2GetAllMeetingByOrgUserDto.of(pagedUserJoinedList, pageMetaDto);
-    }
+			userJoinedList = Stream
+				.concat(myMeetings.stream(),
+					applyRepository.findAllByUserIdAndStatus(existUser.getId(), EnApplyStatus.APPROVE)
+						.stream().map(apply -> apply.getMeeting()))
+				.map(meeting -> MeetingV2GetAllMeetingByOrgUserMeetingDto.of(meeting.getId(),
+					checkMeetingLeader(meeting, existUser.getId()), meeting.getTitle(),
+					meeting.getImageURL().get(0).getUrl(), meeting.getCategory().getValue(),
+					meeting.getMStartDate(), meeting.getMEndDate(), checkActivityStatus(meeting)))
+				.sorted(Comparator.comparing(MeetingV2GetAllMeetingByOrgUserMeetingDto::getId).reversed())
+				.collect(Collectors.toList());
+		}
 
-    @Override
-    public List<MeetingV2GetMeetingBannerResponseDto> getMeetingBanner() {
-        List<MeetingV2GetMeetingBannerResponseDto> meetingBanners = this.meetingRepository.findAll()
-                .stream().sorted(Comparator.comparing(Meeting::getId).reversed()).limit(20).map(meeting -> {
-                    List<Post> post = meeting.getPosts().stream()
-                            .sorted(Comparator.comparing(Post::getId).reversed()).limit(1).toList();
-                    List<Apply> applies = meeting.getAppliedInfo();
+		List<MeetingV2GetAllMeetingByOrgUserMeetingDto> pagedUserJoinedList =
+			userJoinedList.stream().skip((long)(page - 1) * take) // 스킵할 아이템 수 계산
+				.limit(take) // 페이지당 아이템 수 제한
+				.collect(Collectors.toList());
+		PageOptionsDto pageOptionsDto = new PageOptionsDto(page, take);
+		PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, userJoinedList.size());
+		return MeetingV2GetAllMeetingByOrgUserDto.of(pagedUserJoinedList, pageMetaDto);
+	}
 
-                    Integer applicantCount = applies.size();
-                    Integer appliedUserCount = applies.stream()
-                            .filter(apply -> apply.getStatus().equals(EnApplyStatus.APPROVE)).toList().size();
+	@Override
+	public List<MeetingV2GetMeetingBannerResponseDto> getMeetingBanner() {
+		return meetingRepository.findAll()
+			.stream()
+			.sorted(Comparator.comparing(Meeting::getId).reversed())
+			.limit(20)
+			.map(meeting -> {
+				Optional<Post> recentPost = postRepository.findFirstByMeetingIdOrderByIdDesc(meeting.getId());
+				Optional<LocalDateTime> recentActivityDate = recentPost.map(Post::getCreatedDate);
 
-                    Optional<LocalDateTime> recentActivityDate =
-                            post.isEmpty() ? Optional.empty() : Optional.of(post.get(0).getCreatedDate());
+				List<Apply> applies = applyRepository.findAllByMeetingId(meeting.getId());
+				Integer applicantCount = applies.size();
+				Integer appliedUserCount = applies.stream()
+					.filter(apply -> apply.getStatus().equals(EnApplyStatus.APPROVE)).toList().size();
 
-                    Optional<MeetingV2GetMeetingBannerResponseUserDto> meetingLeader = userRepository
-                            .findById(meeting.getUserId()).map(user -> MeetingV2GetMeetingBannerResponseUserDto
-                                    .of(user.getId(), user.getName(), user.getOrgId(), user.getProfileImage()));
+				User meetingLeader = userRepository.findByIdOrThrow(meeting.getUserId());
+				MeetingV2GetMeetingBannerResponseUserDto meetingLeaderDto = MeetingV2GetMeetingBannerResponseUserDto
+					.of(meetingLeader.getId(), meetingLeader.getName(), meetingLeader.getOrgId(),
+						meetingLeader.getProfileImage());
 
-                    return MeetingV2GetMeetingBannerResponseDto.of(meeting.getId(), meeting.getUserId(),
-                            meeting.getTitle(), meeting.getCategory(), meeting.getImageURL(),
-                            meeting.getMStartDate(), meeting.getMEndDate(), meeting.getStartDate(),
-                            meeting.getEndDate(),
-                            meeting.getCapacity(), recentActivityDate, meeting.getTargetActiveGeneration(),
-                            meeting.getJoinableParts(), applicantCount, appliedUserCount, meetingLeader,
-                            meeting.getMeetingStatus());
-                }).toList();
+				return MeetingV2GetMeetingBannerResponseDto.of(meeting.getId(), meeting.getUserId(),
+					meeting.getTitle(), meeting.getCategory(), meeting.getImageURL(),
+					meeting.getMStartDate(), meeting.getMEndDate(), meeting.getStartDate(),
+					meeting.getEndDate(),
+					meeting.getCapacity(), recentActivityDate, meeting.getTargetActiveGeneration(),
+					meeting.getJoinableParts(), applicantCount, appliedUserCount, meetingLeaderDto,
+					meeting.getMeetingStatus());
+			}).toList();
+	}
 
-        return meetingBanners;
-    }
+	@Override
+	@Transactional
+	public MeetingV2CreateMeetingResponseDto createMeeting(MeetingV2CreateMeetingBodyDto requestBody, Integer userId) {
+		User user = userRepository.findByIdOrThrow(userId);
 
+		if (user.getActivities() == null) {
+			throw new BadRequestException(VALIDATION_EXCEPTION.getErrorCode());
+		}
 
-    @Override
-    @Transactional
-    public MeetingV2CreateMeetingResponseDto createMeeting(MeetingV2CreateMeetingBodyDto requestBody, Integer userId) {
-        User user = userRepository.findByIdOrThrow(userId);
+		if (requestBody.getFiles().size() == ZERO || requestBody.getJoinableParts().length == ZERO) {
+			throw new BadRequestException(VALIDATION_EXCEPTION.getErrorCode());
+		}
 
-        if (user.getActivities() == null) {
-            throw new BadRequestException(VALIDATION_EXCEPTION.getErrorCode());
-        }
+		Meeting meeting = meetingMapper.toMeetingEntity(requestBody,
+			getTargetActiveGeneration(requestBody.getCanJoinOnlyActiveGeneration()), ACTIVE_GENERATION, user,
+			user.getId());
 
-        if (requestBody.getFiles().size() == ZERO || requestBody.getJoinableParts().length == ZERO) {
-            throw new BadRequestException(VALIDATION_EXCEPTION.getErrorCode());
-        }
+		Meeting savedMeeting = meetingRepository.save(meeting);
+		return MeetingV2CreateMeetingResponseDto.of(savedMeeting.getId());
+	}
 
-        Meeting meeting = meetingMapper.toMeetingEntity(requestBody,
-                getTargetActiveGeneration(requestBody.getCanJoinOnlyActiveGeneration()), ACTIVE_GENERATION, user,
-                user.getId());
+	@Override
+	@Transactional
+	public MeetingV2ApplyMeetingResponseDto applyMeeting(MeetingV2ApplyMeetingDto requestBody, Integer userId) {
+		Meeting meeting = meetingRepository.findByIdOrThrow(requestBody.getMeetingId());
+		User user = userRepository.findByIdOrThrow(userId);
 
-        Meeting savedMeeting = meetingRepository.save(meeting);
-        return MeetingV2CreateMeetingResponseDto.of(savedMeeting.getId());
-    }
+		List<Apply> applies = applyRepository.findAllByMeetingId(meeting.getId());
 
-    @Override
-    @Transactional
-    public MeetingV2ApplyMeetingResponseDto applyMeeting(MeetingV2ApplyMeetingDto requestBody, Integer userId) {
-        Meeting meeting = meetingRepository.findByIdOrThrow(requestBody.getMeetingId());
-        User user = userRepository.findByIdOrThrow(userId);
+		validateMeetingCapacity(meeting, applies);
+		validateUserAlreadyApplied(userId, applies);
+		validateApplyPeriod(meeting);
+		validateUserActivities(user);
+		validateUserJoinableParts(user, meeting);
 
-        validateMeetingCapacity(meeting);
-        validateUserAlreadyApplied(meeting, userId);
-        validateApplyPeriod(meeting);
-        validateUserActivities(user);
-        validateUserJoinableParts(user, meeting);
+		Apply apply = applyMapper.toApplyEntity(requestBody, EnApplyType.APPLY, meeting, user,
+			userId);
+		Apply savedApply = applyRepository.save(apply);
+		return MeetingV2ApplyMeetingResponseDto.of(savedApply.getId());
+	}
 
-        Apply apply = applyMapper.toApplyEntity(requestBody, EnApplyType.APPLY, meeting, user,
-                userId);
-        Apply savedApply = applyRepository.save(apply);
-        return MeetingV2ApplyMeetingResponseDto.of(savedApply.getId());
-    }
+	@Override
+	@Transactional
+	public void applyMeetingCancel(Integer meetingId, Integer userId) {
+		boolean exists = applyRepository.existsByMeetingIdAndUserId(meetingId, userId);
 
-    @Override
-    @Transactional
-    public void applyMeetingCancel(Integer meetingId, Integer userId) {
-        boolean exists = applyRepository.existsByMeetingIdAndUserId(meetingId, userId);
+		if (!exists) {
+			throw new BadRequestException(NOT_FOUND_APPLY.getErrorCode());
+		}
 
-        if (!exists) {
-            throw new BadRequestException(NOT_FOUND_APPLY.getErrorCode());
-        }
+		applyRepository.deleteByMeetingIdAndUserId(meetingId, userId);
+	}
 
-        applyRepository.deleteByMeetingIdAndUserId(meetingId, userId);
-    }
+	@Override
+	@Transactional(readOnly = true)
+	public MeetingGetApplyListResponseDto findApplyList(MeetingGetApplyListCommand queryCommand,
+		Integer meetingId,
+		Integer userId) {
+		Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
+		Page<ApplyInfoDto> applyInfoDtos = applyRepository.findApplyList(queryCommand,
+			PageRequest.of(queryCommand.getPage() - 1, queryCommand.getTake()),
+			meetingId, meeting.getUserId(), userId);
+		PageOptionsDto pageOptionsDto = new PageOptionsDto(queryCommand.getPage(), queryCommand.getTake());
+		PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, (int)applyInfoDtos.getTotalElements());
 
-    @Override
-    @Transactional(readOnly = true)
-    public MeetingGetApplyListResponseDto findApplyList(MeetingGetApplyListCommand queryCommand,
-                                                        Integer meetingId,
-                                                        Integer userId) {
-        Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
-        Page<ApplyInfoDto> applyInfoDtos = applyRepository.findApplyList(queryCommand,
-                PageRequest.of(queryCommand.getPage() - 1, queryCommand.getTake()),
-                meetingId, meeting.getUserId(), userId);
-        PageOptionsDto pageOptionsDto = new PageOptionsDto(queryCommand.getPage(), queryCommand.getTake());
-        PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, (int) applyInfoDtos.getTotalElements());
+		return MeetingGetApplyListResponseDto.of(applyInfoDtos.getContent(), pageMetaDto);
+	}
 
-        return MeetingGetApplyListResponseDto.of(applyInfoDtos.getContent(), pageMetaDto);
-    }
+	private Boolean checkMeetingLeader(Meeting meeting, Integer userId) {
+		return meeting.getUserId().equals(userId);
+	}
 
+	private Boolean checkActivityStatus(Meeting meeting) {
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime mStartDate = meeting.getMStartDate();
+		LocalDateTime mEndDate = meeting.getMEndDate();
+		return now.isEqual(mStartDate) || (now.isAfter(mStartDate) && now.isBefore(mEndDate));
+	}
 
-    private Boolean checkMeetingLeader(Meeting meeting, Integer userId) {
-        return meeting.getUserId().equals(userId);
-    }
+	private Integer getTargetActiveGeneration(Boolean canJoinOnlyActiveGeneration) {
+		return canJoinOnlyActiveGeneration ? ACTIVE_GENERATION : null;
+	}
 
-    private Boolean checkActivityStatus(Meeting meeting) {
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime mStartDate = meeting.getMStartDate();
-        LocalDateTime mEndDate = meeting.getMEndDate();
-        return now.isEqual(mStartDate) || (now.isAfter(mStartDate) && now.isBefore(mEndDate));
-    }
+	private List<UserActivityVO> filterUserActivities(User user, Meeting meeting) {
+		// 현재 활동기수만 지원 가능할 경우 -> 현재 활동 기수에 해당하는 파트만 필터링
+		if (meeting.getTargetActiveGeneration() == ACTIVE_GENERATION && meeting.getCanJoinOnlyActiveGeneration()) {
+			List<UserActivityVO> filteredActivities = user.getActivities().stream()
+				.filter(activity -> activity.getGeneration() == ACTIVE_GENERATION)
+				.collect(Collectors.toList());
 
-    private Integer getTargetActiveGeneration(Boolean canJoinOnlyActiveGeneration) {
-        return canJoinOnlyActiveGeneration ? ACTIVE_GENERATION : null;
-    }
+			// 활동 기수가 아닌 경우 예외 처리
+			if (filteredActivities.isEmpty()) {
+				throw new BadRequestException(NOT_ACTIVE_GENERATION.getErrorCode());
+			}
 
-    private List<UserActivityVO> filterUserActivities(User user, Meeting meeting) {
-        // 현재 활동기수만 지원 가능할 경우 -> 현재 활동 기수에 해당하는 파트만 필터링
-        if (meeting.getTargetActiveGeneration() == ACTIVE_GENERATION && meeting.getCanJoinOnlyActiveGeneration()) {
-            List<UserActivityVO> filteredActivities = user.getActivities().stream()
-                    .filter(activity -> activity.getGeneration() == ACTIVE_GENERATION)
-                    .collect(Collectors.toList());
+			return filteredActivities;
+		}
+		return user.getActivities();
+	}
 
-            // 활동 기수가 아닌 경우 예외 처리
-            if (filteredActivities.isEmpty()) {
-                throw new BadRequestException(NOT_ACTIVE_GENERATION.getErrorCode());
-            }
+	private void validateMeetingCapacity(Meeting meeting, List<Apply> applies) {
+		List<Apply> approvedApplies = applies.stream()
+			.filter(apply -> EnApplyStatus.APPROVE.equals(apply.getStatus()))
+			.toList();
 
-            return filteredActivities;
-        }
-        return user.getActivities();
-    }
+		if (approvedApplies.size() >= meeting.getCapacity()) {
+			throw new BadRequestException(FULL_MEETING_CAPACITY.getErrorCode());
+		}
+	}
 
-    private void validateMeetingCapacity(Meeting meeting) {
-        List<Apply> approvedApplies = meeting.getAppliedInfo().stream()
-                .filter(apply -> EnApplyStatus.APPROVE.equals(apply.getStatus()))
-                .collect(Collectors.toList());
+	private void validateUserAlreadyApplied(Integer userId, List<Apply> applies) {
+		boolean hasApplied = applies.stream()
+			.anyMatch(appliedInfo -> appliedInfo.getUser().getId().equals(userId));
 
-        if (approvedApplies.size() >= meeting.getCapacity()) {
-            throw new BadRequestException(FULL_MEETING_CAPACITY.getErrorCode());
-        }
-    }
+		if (hasApplied) {
+			throw new BadRequestException(ALREADY_APPLIED_MEETING.getErrorCode());
+		}
+	}
 
-    private void validateUserAlreadyApplied(Meeting meeting, Integer userId) {
-        boolean hasApplied = meeting.getAppliedInfo().stream()
-                .anyMatch(appliedInfo -> appliedInfo.getUser().getId().equals(userId));
+	private void validateApplyPeriod(Meeting meeting) {
+		LocalDateTime now = LocalDateTime.now();
+		if (now.isAfter(meeting.getEndDate()) || now.isBefore(meeting.getStartDate())) {
+			throw new BadRequestException(NOT_IN_APPLY_PERIOD.getErrorCode());
+		}
+	}
 
-        if (hasApplied) {
-            throw new BadRequestException(ALREADY_APPLIED_MEETING.getErrorCode());
-        }
-    }
+	private void validateUserActivities(User user) {
+		if (user.getActivities().isEmpty()) {
+			throw new BadRequestException(MISSING_GENERATION_PART.getErrorCode());
+		}
+	}
 
-    private void validateApplyPeriod(Meeting meeting) {
-        LocalDateTime now = LocalDateTime.now();
-        if (now.isAfter(meeting.getEndDate()) || now.isBefore(meeting.getStartDate())) {
-            throw new BadRequestException(NOT_IN_APPLY_PERIOD.getErrorCode());
-        }
-    }
+	private void validateUserJoinableParts(User user, Meeting meeting) {
+		if (meeting.getJoinableParts().length == 0) {
+			return;
+		}
 
-    private void validateUserActivities(User user) {
-        if (user.getActivities().isEmpty()) {
-            throw new BadRequestException(MISSING_GENERATION_PART.getErrorCode());
-        }
-    }
+		List<UserActivityVO> userActivities = filterUserActivities(user, meeting);
+		List<String> userJoinableParts = userActivities.stream()
+			.map(UserActivityVO::getPart)
+			.filter(part -> {
+				MeetingJoinablePart meetingJoinablePart = UserPartUtil.getMeetingJoinablePart(
+					UserPart.ofValue(part));
 
-    private void validateUserJoinableParts(User user, Meeting meeting) {
-        if (meeting.getJoinableParts().length == 0) {
-            return;
-        }
+				// 임원진이라면 패스
+				if (meetingJoinablePart == null) {
+					return true;
+				}
 
-        List<UserActivityVO> userActivities = filterUserActivities(user, meeting);
-        List<String> userJoinableParts = userActivities.stream()
-                .map(UserActivityVO::getPart)
-                .filter(part -> {
-                    MeetingJoinablePart meetingJoinablePart = UserPartUtil.getMeetingJoinablePart(
-                            UserPart.ofValue(part));
+				return Arrays.stream(meeting.getJoinableParts())
+					.anyMatch(joinablePart -> joinablePart == meetingJoinablePart);
+			})
+			.collect(Collectors.toList());
 
-                    // 임원진이라면 패스
-                    if (meetingJoinablePart == null) {
-                        return true;
-                    }
-
-                    return Arrays.stream(meeting.getJoinableParts())
-                            .anyMatch(joinablePart -> joinablePart == meetingJoinablePart);
-                })
-                .collect(Collectors.toList());
-
-        if (userJoinableParts.isEmpty()) {
-            throw new BadRequestException(NOT_TARGET_PART.getErrorCode());
-        }
-    }
+		if (userJoinableParts.isEmpty()) {
+			throw new BadRequestException(NOT_TARGET_PART.getErrorCode());
+		}
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -40,7 +40,7 @@ import org.sopt.makers.crew.main.entity.user.enums.UserPart;
 import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
 import org.sopt.makers.crew.main.meeting.v2.dto.ApplyMapper;
 import org.sopt.makers.crew.main.meeting.v2.dto.MeetingMapper;
-import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
@@ -191,7 +191,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
 	@Override
 	@Transactional(readOnly = true)
-	public MeetingGetApplyListResponseDto findApplyList(MeetingGetApplyListCommand queryCommand,
+	public MeetingGetApplyListResponseDto findApplyList(MeetingGetAppliesQueryDto queryCommand,
 		Integer meetingId,
 		Integer userId) {
 		Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.makers.crew.main.common.exception.ForbiddenException;
 import org.sopt.makers.crew.main.common.pagination.dto.PageMetaDto;
 import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
+import org.sopt.makers.crew.main.entity.apply.Apply;
 import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
@@ -62,7 +63,9 @@ public class PostV2ServiceImpl implements PostV2Service {
 		Meeting meeting = meetingRepository.findByIdOrThrow(requestBody.getMeetingId());
 		User user = userRepository.findByIdOrThrow(userId);
 
-		boolean isInMeeting = meeting.getAppliedInfo().stream()
+		List<Apply> applies = applyRepository.findAllById(List.of(meeting.getId()));
+
+		boolean isInMeeting = applies.stream()
 			.anyMatch(apply -> apply.getUserId().equals(userId)
 				&& apply.getStatus() == EnApplyStatus.APPROVE);
 

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
@@ -4,10 +4,14 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import lombok.RequiredArgsConstructor;
+
 import org.sopt.makers.crew.main.common.exception.BaseException;
 import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.entity.user.UserRepository;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMeetingByUserMeetingDto;
@@ -21,45 +25,48 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class UserV2ServiceImpl implements UserV2Service {
 
-    private final UserRepository userRepository;
-    private final ApplyRepository applyRepository;
+	private final UserRepository userRepository;
+	private final ApplyRepository applyRepository;
+	private final MeetingRepository meetingRepository;
 
-    @Override
-    public List<UserV2GetAllMeetingByUserMeetingDto> getAllMeetingByUser(Integer userId) {
-        User user = userRepository.findByIdOrThrow(userId);
+	@Override
+	public List<UserV2GetAllMeetingByUserMeetingDto> getAllMeetingByUser(Integer userId) {
+		User user = userRepository.findByIdOrThrow(userId);
 
-        List<UserV2GetAllMeetingByUserMeetingDto> userJoinedList = Stream.concat(
-                        user.getMeetings().stream(),
-                        applyRepository.findAllByUserIdAndStatus(userId, EnApplyStatus.APPROVE)
-                                .stream()
-                                .map(apply -> apply.getMeeting())
-                )
-                .map(meeting -> UserV2GetAllMeetingByUserMeetingDto.of(
-                        meeting.getId(),
-                        meeting.getTitle(),
-                        meeting.getDesc(),
-                        meeting.getImageURL().get(0).getUrl(),
-                        meeting.getCategory().getValue()
-                ))
-                .sorted(Comparator.comparing(UserV2GetAllMeetingByUserMeetingDto::getId).reversed())
-                .collect(Collectors.toList());
+		List<Meeting> myMeetings = meetingRepository.findAllByUserId(user.getId());
 
-        if (userJoinedList.isEmpty()) {
-            throw new BaseException(HttpStatus.NO_CONTENT);
-        }
-        return userJoinedList;
-    }
+		List<UserV2GetAllMeetingByUserMeetingDto> userJoinedList = Stream.concat(
+				myMeetings.stream(),
+				applyRepository.findAllByUserIdAndStatus(userId, EnApplyStatus.APPROVE)
+					.stream()
+					.map(apply -> apply.getMeeting())
+			)
+			.map(meeting -> UserV2GetAllMeetingByUserMeetingDto.of(
+				meeting.getId(),
+				meeting.getTitle(),
+				meeting.getDesc(),
+				meeting.getImageURL().get(0).getUrl(),
+				meeting.getCategory().getValue()
+			))
+			.sorted(Comparator.comparing(UserV2GetAllMeetingByUserMeetingDto::getId).reversed())
+			.collect(Collectors.toList());
 
-    @Override
-    public List<UserV2GetAllMentionUserDto> getAllMentionUser() {
+		if (userJoinedList.isEmpty()) {
+			throw new BaseException(HttpStatus.NO_CONTENT);
+		}
+		return userJoinedList;
+	}
 
-        List<User> users = userRepository.findAll();
+	@Override
+	public List<UserV2GetAllMentionUserDto> getAllMentionUser() {
 
-        return users.stream()
-                .filter(user -> user.getActivities() != null)
-                .map(user -> UserV2GetAllMentionUserDto.of(user.getId(), user.getName(),
-                        user.getRecentActivityVO().getPart(), user.getRecentActivityVO().getGeneration(),
-                        user.getProfileImage()))
-                .toList();
-    }
+		List<User> users = userRepository.findAll();
+
+		return users.stream()
+			.filter(user -> user.getActivities() != null)
+			.map(user -> UserV2GetAllMentionUserDto.of(user.getId(), user.getName(),
+				user.getRecentActivityVO().getPart(), user.getRecentActivityVO().getGeneration(),
+				user.getProfileImage()))
+			.toList();
+	}
 }

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/repository/ApplyRepositoryTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/repository/ApplyRepositoryTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.sopt.makers.crew.main.common.config.TestConfig;
 import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
-import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetApplyListCommand;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -42,7 +42,7 @@ public class ApplyRepositoryTest {
         // given
         int page = 1;
         int take = 12;
-        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(page, take, List.of(EnApplyStatus.WAITING, EnApplyStatus.APPROVE, EnApplyStatus.REJECT), "desc");
+        MeetingGetAppliesQueryDto queryCommand = new MeetingGetAppliesQueryDto(page, take, List.of(EnApplyStatus.WAITING, EnApplyStatus.APPROVE, EnApplyStatus.REJECT), "desc");
         Integer meetingId = 1;
         Integer studyCreatorId = 1;
         Integer userId = 1;
@@ -96,7 +96,7 @@ public class ApplyRepositoryTest {
         // given
         int page = 1;
         int take = 12;
-        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(page, take, List.of(EnApplyStatus.WAITING, EnApplyStatus.APPROVE, EnApplyStatus.REJECT), "asc");
+        MeetingGetAppliesQueryDto queryCommand = new MeetingGetAppliesQueryDto(page, take, List.of(EnApplyStatus.WAITING, EnApplyStatus.APPROVE, EnApplyStatus.REJECT), "asc");
         Integer meetingId = 1;
         Integer studyCreatorId = 1;
         Integer userId = 1;
@@ -148,7 +148,7 @@ public class ApplyRepositoryTest {
         // given
         int page = 1;
         int take = 12;
-        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(page, take, List.of(EnApplyStatus.WAITING), "asc");
+        MeetingGetAppliesQueryDto queryCommand = new MeetingGetAppliesQueryDto(page, take, List.of(EnApplyStatus.WAITING), "asc");
         Integer meetingId = 1;
         Integer studyCreatorId = 1;
         Integer userId = 1;
@@ -180,7 +180,7 @@ public class ApplyRepositoryTest {
         // given
         int page = 1;
         int take = 12;
-        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(page, take, List.of(EnApplyStatus.APPROVE), "asc");
+        MeetingGetAppliesQueryDto queryCommand = new MeetingGetAppliesQueryDto(page, take, List.of(EnApplyStatus.APPROVE), "asc");
         Integer meetingId = 1;
         Integer studyCreatorId = 1;
         Integer userId = 1;
@@ -223,7 +223,7 @@ public class ApplyRepositoryTest {
         // given
         int page = 1;
         int take = 12;
-        MeetingGetApplyListCommand queryCommand = new MeetingGetApplyListCommand(page, take, List.of(EnApplyStatus.WAITING, EnApplyStatus.APPROVE, EnApplyStatus.REJECT), "desc");
+        MeetingGetAppliesQueryDto queryCommand = new MeetingGetAppliesQueryDto(page, take, List.of(EnApplyStatus.WAITING, EnApplyStatus.APPROVE, EnApplyStatus.REJECT), "desc");
         Integer meetingId = 1;
         Integer studyCreatorId = 1;
         Integer userId = 2;

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -115,7 +115,7 @@ public class MeetingV2ServiceTest {
                 .content("제 지원동기는요")
                 .build();
 
-        meeting.addApply(apply);
+        //meeting.addApply(apply);
         apply.updateApplyStatus(EnApplyStatus.APPROVE);
 
         applies = new ArrayList<>();
@@ -163,7 +163,7 @@ public class MeetingV2ServiceTest {
 
             apply.updateApplyStatus(EnApplyStatus.APPROVE); // 승인 상태로 변경
         }
-        applies = new ArrayList<>(meeting.getAppliedInfo());
+       // applies = new ArrayList<>(meeting.getAppliedInfo());
         MeetingV2ApplyMeetingDto requestBody = new MeetingV2ApplyMeetingDto(meeting.getId(), "열심히 하겠습니다.");
 
         doReturn(meeting).when(meetingRepository).findByIdOrThrow(requestBody.getMeetingId());

--- a/server/src/comment/v1/comment-v1.controller.ts
+++ b/server/src/comment/v1/comment-v1.controller.ts
@@ -43,6 +43,7 @@ export class CommentV1Controller {
 
   @ApiOperation({
     summary: '모임 게시글 댓글 리스트 조회',
+    deprecated: true,
   })
   @ApiOkResponseCommon(CommentV1GetCommentsResponseDto)
   @ApiResponse({


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 일단 PR 내용이 굉장히 큰 것 같아 죄송하다는 말씀드립니다,,,
- 작업 내용은 크게 아래와 같습니다!

 1. 댓글 작성 API 인터페이스 및 내부 구현 수정
 2. 댓글 삭제 API 내부 구현 수정
 3. 모임 게시글 댓글 리스트 조회 API 마이그레이션 + 인터페이스 및 내부 구현 수정

### 공통
- 일단 정말 불필요하다고 생각드는 연관관계는 모두 삭제했습니다. (연관관계 수정으로 인해 UserV2ServiceImpl.java 도 변화가 생겼습니다...!)
- 특히 CommentV2ServiceImpl.java 파일쪽 변화가 커서 확인해주시면 감사하겠습니다..!!
- 기존에 있던 변수명 중에 컨벤션에 맞지 않는 것들을 전반적으로 수정했습니다...! 이 외에도 줄간격도 맞췄습니다..!

### 댓글 작성 API 
- 여기서 핵심은 댓글인 경우와 대댓글인 경우입니다. 기존 db 변경을 최소화하고 싶어서 기존에 있던 db 컬럼을 최대로 활용했습니다!
- 댓글은 depth =0, 대댓글은 depth = 1 을 의미합니다.
- 댓글은 parentId 가 null 이고, 대댓글은 댓글의 id를 저장하고 있습니다.
- 대댓글 간의 순서가 보장되어야 하기 때문에 order 라는 컬럼을 사용했습니다. 댓글의 경우 order 가 0 이며, 대댓글은 1부터 시작합니다.
<img width="779" alt="스크린샷 2024-07-13 오전 1 41 56" src="https://github.com/user-attachments/assets/5b0097f5-8b4b-4107-ab19-7399a720ca6f">

### 댓글 삭제
- 대댓글일 경우 동일하게 삭제되지만, 댓글일 경우 대댓글이 있는 경우에 기존 데이터들을 null로 바꾸고 "삭제된 댓글입니다." 라고 저장하도록 구현했습니다. 

### 모임 게시글 댓글 리스트 조회 API
- 해당 API가 가장 까다로웠습니다...
- 일단 페이지네이션 기준을 댓글+대댓글 포함해서 개수를 선정했습니다. 그러다보니 복잡한 부분이 생겼는데요! 
- 댓글 기준으로 오래된 것 부터 보여줘야 하지만 대댓글은 댓글기준으로 보여줘야 한다는 것입니다! 
- 예를 들어 7월 1일 댓글, 7월 2일 댓글이 있을 때, 7월 1일 댓글에 대댓글이 11개가 있다면 12개를 보여줘야하는 페이지네이션의 경우 7월 2일 댓글이 조회되지 않아야 합니다! (이게 말이 정말 어려운데... 제 설명이 부족하다면 말씀주세요..!!)
- 아무튼 이런 복잡한 이슈로 인해 하나의 Comment 테이블에 동일한 Comment 테이블을 leftjoin 하여 구현했습니다...!
- 요기 로직이 정말 복잡해서.. 다른 의견있으시면 편하게 말씀주세요!! 
- CommentSearchRepositoryImpl 클래스도 한 번만 확인해주시면 감사하겠습니다!

### myLikes 일급컬렉션 추가
- 좋아요를 눌렀는지 여부를 일급컬렉션을 만들어 구현했습니다.

## 📝 Review Note


## 📣 Related Issue


- closed #247

## ✅ 점검사항

- [x] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [x] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [x] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?