### PR TITLE
[FIX] 댓글 작성 알림 시 비밀문자열 제거

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
@@ -1,26 +1,27 @@
 package org.sopt.makers.crew.main.comment.v2.service;
 
-import static org.sopt.makers.crew.main.internal.notification.PushNotificationEnums.*;
+import static org.sopt.makers.crew.main.internal.notification.PushNotificationEnums.NEW_COMMENT_MENTION_PUSH_NOTIFICATION_TITLE;
+import static org.sopt.makers.crew.main.internal.notification.PushNotificationEnums.NEW_COMMENT_PUSH_NOTIFICATION_TITLE;
+import static org.sopt.makers.crew.main.internal.notification.PushNotificationEnums.PUSH_NOTIFICATION_CATEGORY;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
 import lombok.RequiredArgsConstructor;
-
 import org.sopt.makers.crew.main.comment.v2.dto.CommentMapper;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2CreateCommentBodyDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2MentionUserInCommentRequestDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2CreateCommentResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2GetCommentsResponseDto;
+import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2ReportCommentResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2UpdateCommentResponseDto;
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.common.exception.ForbiddenException;
 import org.sopt.makers.crew.main.common.response.ErrorStatus;
-import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2ReportCommentResponseDto;
+import org.sopt.makers.crew.main.common.util.MentionSecretStringRemover;
 import org.sopt.makers.crew.main.common.util.Time;
 import org.sopt.makers.crew.main.entity.comment.Comment;
 import org.sopt.makers.crew.main.entity.comment.CommentRepository;
@@ -42,222 +43,232 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CommentV2ServiceImpl implements CommentV2Service {
-	private static final int IS_PARENT_COMMENT = 0;
-	private static final int IS_REPLY_COMMENT = 1;
-	private static final String DELETE_COMMENT_CONTENT = "삭제된 댓글입니다.";
 
-	private final PostRepository postRepository;
-	private final UserRepository userRepository;
-	private final CommentRepository commentRepository;
-	private final ReportRepository reportRepository;
-	private final LikeRepository likeRepository;
+    private static final int IS_PARENT_COMMENT = 0;
+    private static final int IS_REPLY_COMMENT = 1;
+    private static final String DELETE_COMMENT_CONTENT = "삭제된 댓글입니다.";
 
-	private final PushNotificationService pushNotificationService;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
+    private final ReportRepository reportRepository;
+    private final LikeRepository likeRepository;
 
-	private final CommentMapper commentMapper;
+    private final PushNotificationService pushNotificationService;
 
-	@Value("${push-notification.web-url}")
-	private String pushWebUrl;
+    private final CommentMapper commentMapper;
 
-	private final Time time;
+    @Value("${push-notification.web-url}")
+    private String pushWebUrl;
 
-	/**
-	 * 모임 게시글 댓글 작성
-	 *
-	 * @throws 400 존재하지 않는 게시글일 떄
-	 * @apiNote 모임에 속한 유저만 작성 가능
-	 */
-	@Override
-	@Transactional
-	public CommentV2CreateCommentResponseDto createComment(CommentV2CreateCommentBodyDto requestBody,
-		Integer userId) {
-		Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
-		User writer = userRepository.findByIdOrThrow(userId);
+    private final Time time;
 
-		int depth = 0;
-		int order = 0;
-		Integer parentId = 0;
+    /**
+     * 모임 게시글 댓글 작성
+     *
+     * @throws 400 존재하지 않는 게시글일 떄
+     * @apiNote 모임에 속한 유저만 작성 가능
+     */
+    @Override
+    @Transactional
+    public CommentV2CreateCommentResponseDto createComment(
+        CommentV2CreateCommentBodyDto requestBody,
+        Integer userId) {
+        Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
+        User writer = userRepository.findByIdOrThrow(userId);
 
-		boolean isReplyComment = !requestBody.isParent();
-		if (isReplyComment) {
-			validateParentCommentId(requestBody);
-			depth = 1;
-			parentId = requestBody.getParentCommentId();
-			order = getOrder(parentId);
-		}
+        int depth = 0;
+        int order = 0;
+        Integer parentId = 0;
 
-		Comment comment = commentMapper.toComment(requestBody, post, writer, depth, order, parentId);
+        boolean isReplyComment = !requestBody.isParent();
+        if (isReplyComment) {
+            validateParentCommentId(requestBody);
+            depth = 1;
+            parentId = requestBody.getParentCommentId();
+            order = getOrder(parentId);
+        }
 
-		Comment savedComment = commentRepository.save(comment);
-		post.increaseCommentCount();
+        Comment comment = commentMapper.toComment(requestBody, post, writer, depth, order,
+            parentId);
 
-		sendPushNotification(requestBody, post, writer);
+        Comment savedComment = commentRepository.save(comment);
+        post.increaseCommentCount();
 
-		return CommentV2CreateCommentResponseDto.of(savedComment.getId());
-	}
+        sendPushNotification(requestBody, post, writer);
 
-	private void sendPushNotification(CommentV2CreateCommentBodyDto requestBody, Post post, User user) {
-		User PostWriter = post.getUser();
-		String[] userIds = {String.valueOf(PostWriter.getOrgId())};
+        return CommentV2CreateCommentResponseDto.of(savedComment.getId());
+    }
 
-		String pushNotificationContent = String.format("[%s의 댓글] : \"%s\"",
-			user.getName(), requestBody.getContents());
-		String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
+    private void sendPushNotification(CommentV2CreateCommentBodyDto requestBody, Post post,
+        User user) {
+        User PostWriter = post.getUser();
+        String[] userIds = {String.valueOf(PostWriter.getOrgId())};
+        String secretStringRemovedContent = MentionSecretStringRemover.removeSecretString(
+            requestBody.getContents());
+        String pushNotificationContent = String.format("[%s의 댓글] : \"%s\"",
+            user.getName(), secretStringRemovedContent);
+        String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
 
-		PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(userIds,
-			NEW_COMMENT_PUSH_NOTIFICATION_TITLE.getValue(),
-			pushNotificationContent,
-			PUSH_NOTIFICATION_CATEGORY.getValue(), pushNotificationWeblink);
+        PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(userIds,
+            NEW_COMMENT_PUSH_NOTIFICATION_TITLE.getValue(),
+            pushNotificationContent,
+            PUSH_NOTIFICATION_CATEGORY.getValue(), pushNotificationWeblink);
 
-		pushNotificationService.sendPushNotification(pushRequestDto);
-	}
+        pushNotificationService.sendPushNotification(pushRequestDto);
+    }
 
-	private void validateParentCommentId(CommentV2CreateCommentBodyDto requestBody) {
-		commentRepository.findByIdAndPostIdOrThrow(requestBody.getParentCommentId(), requestBody.getPostId());
-	}
+    private void validateParentCommentId(CommentV2CreateCommentBodyDto requestBody) {
+        commentRepository.findByIdAndPostIdOrThrow(requestBody.getParentCommentId(),
+            requestBody.getPostId());
+    }
 
-	private int getOrder(Integer parentId) {
-		Optional<Comment> recentComment = commentRepository.findFirstByParentIdOrderByOrderDesc(
-			parentId);
-		return recentComment.map(comment -> comment.getOrder() + 1).orElse(1);
-	}
+    private int getOrder(Integer parentId) {
+        Optional<Comment> recentComment = commentRepository.findFirstByParentIdOrderByOrderDesc(
+            parentId);
+        return recentComment.map(comment -> comment.getOrder() + 1).orElse(1);
+    }
 
-	/**
-	 * 모임 게시글 댓글 수정
-	 *
-	 * @param commentId 수정할 댓글 ID
-	 * @param contents  수정할 내용
-	 * @param userId    수정하는 유저 ID
-	 * @return 수정된 댓글 정보
-	 */
-	@Override
-	@Transactional
-	public CommentV2UpdateCommentResponseDto updateComment(Integer commentId,
-		String contents, Integer userId) {
-		// 1. id를 기반으로 comment를 찾는다.
-		Comment comment = commentRepository.findByIdOrThrow(commentId);
+    /**
+     * 모임 게시글 댓글 수정
+     *
+     * @param commentId 수정할 댓글 ID
+     * @param contents  수정할 내용
+     * @param userId    수정하는 유저 ID
+     * @return 수정된 댓글 정보
+     */
+    @Override
+    @Transactional
+    public CommentV2UpdateCommentResponseDto updateComment(Integer commentId,
+        String contents, Integer userId) {
+        // 1. id를 기반으로 comment를 찾는다.
+        Comment comment = commentRepository.findByIdOrThrow(commentId);
 
-		// 2. comment의 user_id와 userId가 같은지 확인한다.
-		comment.validateWriter(userId);
+        // 2. comment의 user_id와 userId가 같은지 확인한다.
+        comment.validateWriter(userId);
 
-		// 3. comment의 contents를 수정한다.
-		comment.updateContents(contents, time.now());
+        // 3. comment의 contents를 수정한다.
+        comment.updateContents(contents, time.now());
 
-		// 4. 수정된 comment의 id, contents, updatedDate를 반환한다.
-		return CommentV2UpdateCommentResponseDto.of(comment.getId(), comment.getContents(),
-			String.valueOf(comment.getUpdatedDate()));
-	}
+        // 4. 수정된 comment의 id, contents, updatedDate를 반환한다.
+        return CommentV2UpdateCommentResponseDto.of(comment.getId(), comment.getContents(),
+            String.valueOf(comment.getUpdatedDate()));
+    }
 
-	@Override
-	public CommentV2GetCommentsResponseDto getComments(Integer postId, Integer page, Integer take, Integer userId) {
-		// TODO : 페이지네이션 구현
+    @Override
+    public CommentV2GetCommentsResponseDto getComments(Integer postId, Integer page, Integer take,
+        Integer userId) {
+        // TODO : 페이지네이션 구현
 
-		List<Comment> comments = commentRepository.findAllByPostIdOrderByCreatedDate(postId);
+        List<Comment> comments = commentRepository.findAllByPostIdOrderByCreatedDate(postId);
 
-		MyLikes myLikes = new MyLikes(likeRepository.findAllByUserIdAndPostIdNotNull(userId));
+        MyLikes myLikes = new MyLikes(likeRepository.findAllByUserIdAndPostIdNotNull(userId));
 
-		Map<Integer, List<CommentDto>> replyMap = new HashMap<>();
-		comments.stream()
-			.filter(comment -> !comment.isParentComment())
-			.forEach(comment -> replyMap.computeIfAbsent(comment.getParentId(), k -> new ArrayList<>())
-				.add(CommentDto.of(comment, myLikes.isLikeComment(comment.getId()), comment.isWriter(userId), null)));
+        Map<Integer, List<CommentDto>> replyMap = new HashMap<>();
+        comments.stream()
+            .filter(comment -> !comment.isParentComment())
+            .forEach(
+                comment -> replyMap.computeIfAbsent(comment.getParentId(), k -> new ArrayList<>())
+                    .add(CommentDto.of(comment, myLikes.isLikeComment(comment.getId()),
+                        comment.isWriter(userId), null)));
 
-		List<CommentDto> commentDtos = comments.stream()
-			.filter(Comment::isParentComment)
-			.map(comment -> CommentDto.of(comment, myLikes.isLikeComment(comment.getId()), comment.isWriter(userId),
-				replyMap.get(comment.getId())))
-			.toList();
+        List<CommentDto> commentDtos = comments.stream()
+            .filter(Comment::isParentComment)
+            .map(comment -> CommentDto.of(comment, myLikes.isLikeComment(comment.getId()),
+                comment.isWriter(userId),
+                replyMap.get(comment.getId())))
+            .toList();
 
-		return CommentV2GetCommentsResponseDto.of(commentDtos);
-	}
+        return CommentV2GetCommentsResponseDto.of(commentDtos);
+    }
 
-	/**
-	 * 댓글 신고하기
-	 *
-	 * @param commentId 댓글 신고할 댓글 id
-	 * @param userId    신고하는 유저 id
-	 * @return 신고 ID
-	 * @throws BadRequestException 이미 신고한 댓글일 때
-	 * @apiNote 댓글 신고는 한 댓글당 한번만 가능
-	 */
-	@Override
-	@Transactional
-	public CommentV2ReportCommentResponseDto reportComment(Integer commentId, Integer userId)
-		throws BadRequestException {
-		Comment comment = commentRepository.findByIdOrThrow(commentId);
-		User user = userRepository.findByIdOrThrow(userId);
+    /**
+     * 댓글 신고하기
+     *
+     * @param commentId 댓글 신고할 댓글 id
+     * @param userId    신고하는 유저 id
+     * @return 신고 ID
+     * @throws BadRequestException 이미 신고한 댓글일 때
+     * @apiNote 댓글 신고는 한 댓글당 한번만 가능
+     */
+    @Override
+    @Transactional
+    public CommentV2ReportCommentResponseDto reportComment(Integer commentId, Integer userId)
+        throws BadRequestException {
+        Comment comment = commentRepository.findByIdOrThrow(commentId);
+        User user = userRepository.findByIdOrThrow(userId);
 
-		Optional<Report> existingReport = reportRepository.findByCommentAndUser(comment, user);
+        Optional<Report> existingReport = reportRepository.findByCommentAndUser(comment, user);
 
-		if (existingReport.isPresent()) {
-			throw new BadRequestException(ErrorStatus.ALREADY_REPORTED_COMMENT.getErrorCode());
-		}
+        if (existingReport.isPresent()) {
+            throw new BadRequestException(ErrorStatus.ALREADY_REPORTED_COMMENT.getErrorCode());
+        }
 
-		Report report = Report.builder()
-			.comment(comment)
-			.user(user)
-			.build();
+        Report report = Report.builder()
+            .comment(comment)
+            .user(user)
+            .build();
 
-		Report savedReport = reportRepository.save(report);
+        Report savedReport = reportRepository.save(report);
 
-		return CommentV2ReportCommentResponseDto.of(savedReport.getId());
-	}
+        return CommentV2ReportCommentResponseDto.of(savedReport.getId());
+    }
 
-	/**
-	 * 모임 게시글 댓글 삭제
-	 *
-	 * @throws ForbiddenException 댓글 작성자가 아닐 때
-	 * @apiNote 댓글 삭제시 게시글의 댓글 수를 1 감소시킴
-	 */
-	@Override
-	@Transactional
-	public void deleteComment(Integer commentId, Integer userId) throws ForbiddenException {
-		Comment comment = commentRepository.findByIdOrThrow(commentId);
+    /**
+     * 모임 게시글 댓글 삭제
+     *
+     * @throws ForbiddenException 댓글 작성자가 아닐 때
+     * @apiNote 댓글 삭제시 게시글의 댓글 수를 1 감소시킴
+     */
+    @Override
+    @Transactional
+    public void deleteComment(Integer commentId, Integer userId) throws ForbiddenException {
+        Comment comment = commentRepository.findByIdOrThrow(commentId);
 
-		if (!comment.getUserId().equals(userId)) {
-			throw new ForbiddenException();
-		}
+        if (!comment.getUserId().equals(userId)) {
+            throw new ForbiddenException();
+        }
 
-		Post post = postRepository.findByIdOrThrow(comment.getPostId());
-		post.decreaseCommentCount();
+        Post post = postRepository.findByIdOrThrow(comment.getPostId());
+        post.decreaseCommentCount();
 
-		Optional<Comment> childComment = commentRepository.findFirstByParentIdOrderByOrderDesc(
-			comment.getId());
+        Optional<Comment> childComment = commentRepository.findFirstByParentIdOrderByOrderDesc(
+            comment.getId());
 
-		if (comment.getDepth() == IS_REPLY_COMMENT || childComment.isEmpty()) {
-			commentRepository.delete(comment);
-			return;
-		}
+        if (comment.getDepth() == IS_REPLY_COMMENT || childComment.isEmpty()) {
+            commentRepository.delete(comment);
+            return;
+        }
 
-		comment.deleteParentComment(DELETE_COMMENT_CONTENT, null, null);
-	}
+        comment.deleteParentComment(DELETE_COMMENT_CONTENT, null, null);
+    }
 
-	@Override
-	public void mentionUserInComment(CommentV2MentionUserInCommentRequestDto requestBody,
-		Integer userId) {
-		User user = userRepository.findByIdOrThrow(userId);
-		Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
+    @Override
+    public void mentionUserInComment(CommentV2MentionUserInCommentRequestDto requestBody,
+        Integer userId) {
+        User user = userRepository.findByIdOrThrow(userId);
+        Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
 
-		String pushNotificationContent = String.format("[%s님이 회원님을 언급했어요.] : \"%s\"",
-			user.getName(), requestBody.getContent());
-		String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
+        String pushNotificationContent = String.format("[%s님이 회원님을 언급했어요.] : \"%s\"",
+            user.getName(), requestBody.getContent());
+        String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
 
-		String[] userOrgIds = userRepository.findByIdIn(requestBody.getUserIds())
-			.stream()
-			.map(mentionedUser -> String.valueOf(mentionedUser.getOrgId()))
-			.toArray(String[]::new);
+        String[] userOrgIds = userRepository.findByIdIn(requestBody.getUserIds())
+            .stream()
+            .map(mentionedUser -> String.valueOf(mentionedUser.getOrgId()))
+            .toArray(String[]::new);
 
-		String newCommentMentionPushNotificationTitle = String.format(
-			NEW_COMMENT_MENTION_PUSH_NOTIFICATION_TITLE.getValue(), user.getName());
+        String newCommentMentionPushNotificationTitle = String.format(
+            NEW_COMMENT_MENTION_PUSH_NOTIFICATION_TITLE.getValue(), user.getName());
 
-		PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(
-			userOrgIds,
-			newCommentMentionPushNotificationTitle,
-			pushNotificationContent,
-			PUSH_NOTIFICATION_CATEGORY.getValue(),
-			pushNotificationWeblink
-		);
+        PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(
+            userOrgIds,
+            newCommentMentionPushNotificationTitle,
+            pushNotificationContent,
+            PUSH_NOTIFICATION_CATEGORY.getValue(),
+            pushNotificationWeblink
+        );
 
-		pushNotificationService.sendPushNotification(pushRequestDto);
-	}
+        pushNotificationService.sendPushNotification(pushRequestDto);
+    }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/common/util/MentionSecretStringRemover.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/util/MentionSecretStringRemover.java
@@ -1,0 +1,25 @@
+package org.sopt.makers.crew.main.common.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class MentionSecretStringRemover {
+
+    private static final String PREFIX_PATTERN = "-!@#";
+    private static final String SUFFIX_PATTERN = "\\[\\d+\\]%\\^&\\+";
+
+    public static String removeSecretString(String content) {
+        Pattern prefixPattern = Pattern.compile(PREFIX_PATTERN);
+        Pattern suffixPattern = Pattern.compile(SUFFIX_PATTERN);
+
+        Matcher prefixMatcher = prefixPattern.matcher(content);
+        content = prefixMatcher.replaceAll("");
+
+        Matcher suffixMatcher = suffixPattern.matcher(content);
+        content = suffixMatcher.replaceAll("");
+
+        return content;
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
- 내가 쓴 글에 댓글이 달렸다는 알림을 보낼 때 비밀문자열 제거


## 📣 Related Issue
- #249

## ✅ 점검사항
- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?