### PR TITLE
[CHORE] 댓글 삭제 기능 수정 및 댓글 수정 로직 일부 수정

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2Service.java
@@ -17,7 +17,7 @@ public interface CommentV2Service {
 	CommentV2ReportCommentResponseDto reportComment(Integer commentId, Integer userId)
 		throws BadRequestException;
 
-	void deleteComment(Integer commentId, Integer userId) throws ForbiddenException;
+	void deleteComment(Integer commentId, Integer userId);
 
 	void mentionUserInComment(CommentV2MentionUserInCommentRequestDto requestBody, Integer userId);
 

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
@@ -7,7 +7,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
+
 import org.sopt.makers.crew.main.comment.v2.dto.CommentMapper;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2CreateCommentBodyDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2MentionUserInCommentRequestDto;
@@ -23,6 +25,7 @@ import org.sopt.makers.crew.main.common.util.MentionSecretStringRemover;
 import org.sopt.makers.crew.main.common.util.Time;
 import org.sopt.makers.crew.main.entity.comment.Comment;
 import org.sopt.makers.crew.main.entity.comment.CommentRepository;
+import org.sopt.makers.crew.main.entity.comment.Comments;
 import org.sopt.makers.crew.main.entity.like.LikeRepository;
 import org.sopt.makers.crew.main.entity.like.MyLikes;
 import org.sopt.makers.crew.main.entity.post.Post;
@@ -41,230 +44,225 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CommentV2ServiceImpl implements CommentV2Service {
+	private static final int IS_REPLY_COMMENT = 1;
 
-    private static final int IS_PARENT_COMMENT = 0;
-    private static final int IS_REPLY_COMMENT = 1;
-    private static final String DELETE_COMMENT_CONTENT = "삭제된 댓글입니다.";
+	private final PostRepository postRepository;
+	private final UserRepository userRepository;
+	private final CommentRepository commentRepository;
+	private final ReportRepository reportRepository;
+	private final LikeRepository likeRepository;
 
-    private final PostRepository postRepository;
-    private final UserRepository userRepository;
-    private final CommentRepository commentRepository;
-    private final ReportRepository reportRepository;
-    private final LikeRepository likeRepository;
+	private final PushNotificationService pushNotificationService;
 
-    private final PushNotificationService pushNotificationService;
+	private final CommentMapper commentMapper;
 
-    private final CommentMapper commentMapper;
+	@Value("${push-notification.web-url}")
+	private String pushWebUrl;
 
-    @Value("${push-notification.web-url}")
-    private String pushWebUrl;
+	private final Time time;
 
-    private final Time time;
+	/**
+	 * 모임 게시글 댓글 작성
+	 *
+	 * @throws 400 존재하지 않는 게시글일 떄
+	 * @apiNote 모임에 속한 유저만 작성 가능
+	 */
+	@Override
+	@Transactional
+	public CommentV2CreateCommentResponseDto createComment(
+		CommentV2CreateCommentBodyDto requestBody,
+		Integer userId) {
+		Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
+		User writer = userRepository.findByIdOrThrow(userId);
 
-    /**
-     * 모임 게시글 댓글 작성
-     *
-     * @throws 400 존재하지 않는 게시글일 떄
-     * @apiNote 모임에 속한 유저만 작성 가능
-     */
-    @Override
-    @Transactional
-    public CommentV2CreateCommentResponseDto createComment(
-        CommentV2CreateCommentBodyDto requestBody,
-        Integer userId) {
-        Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
-        User writer = userRepository.findByIdOrThrow(userId);
+		int depth = 0;
+		int order = 0;
+		Integer parentId = 0;
 
-        int depth = 0;
-        int order = 0;
-        Integer parentId = 0;
+		boolean isReplyComment = !requestBody.isParent();
+		if (isReplyComment) {
+			validateParentCommentId(requestBody);
+			depth = 1;
+			parentId = requestBody.getParentCommentId();
+			order = getOrder(parentId);
+		}
 
-        boolean isReplyComment = !requestBody.isParent();
-        if (isReplyComment) {
-            validateParentCommentId(requestBody);
-            depth = 1;
-            parentId = requestBody.getParentCommentId();
-            order = getOrder(parentId);
-        }
+		Comment comment = commentMapper.toComment(requestBody, post, writer, depth, order,
+			parentId);
 
-        Comment comment = commentMapper.toComment(requestBody, post, writer, depth, order,
-            parentId);
+		Comment savedComment = commentRepository.save(comment);
+		post.increaseCommentCount();
 
-        Comment savedComment = commentRepository.save(comment);
-        post.increaseCommentCount();
+		sendPushNotification(requestBody, post, writer);
 
-        sendPushNotification(requestBody, post, writer);
+		return CommentV2CreateCommentResponseDto.of(savedComment.getId());
+	}
 
-        return CommentV2CreateCommentResponseDto.of(savedComment.getId());
-    }
+	private void sendPushNotification(CommentV2CreateCommentBodyDto requestBody, Post post,
+		User user) {
+		User PostWriter = post.getUser();
+		String[] userIds = {String.valueOf(PostWriter.getOrgId())};
+		String secretStringRemovedContent = MentionSecretStringRemover.removeSecretString(
+			requestBody.getContents());
+		String pushNotificationContent = String.format("[%s의 댓글] : \"%s\"",
+			user.getName(), secretStringRemovedContent);
+		String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
 
-    private void sendPushNotification(CommentV2CreateCommentBodyDto requestBody, Post post,
-        User user) {
-        User PostWriter = post.getUser();
-        String[] userIds = {String.valueOf(PostWriter.getOrgId())};
-        String secretStringRemovedContent = MentionSecretStringRemover.removeSecretString(
-            requestBody.getContents());
-        String pushNotificationContent = String.format("[%s의 댓글] : \"%s\"",
-            user.getName(), secretStringRemovedContent);
-        String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
+		PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(userIds,
+			NEW_COMMENT_PUSH_NOTIFICATION_TITLE.getValue(),
+			pushNotificationContent,
+			PUSH_NOTIFICATION_CATEGORY.getValue(), pushNotificationWeblink);
 
-        PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(userIds,
-            NEW_COMMENT_PUSH_NOTIFICATION_TITLE.getValue(),
-            pushNotificationContent,
-            PUSH_NOTIFICATION_CATEGORY.getValue(), pushNotificationWeblink);
+		pushNotificationService.sendPushNotification(pushRequestDto);
+	}
 
-        pushNotificationService.sendPushNotification(pushRequestDto);
-    }
+	private void validateParentCommentId(CommentV2CreateCommentBodyDto requestBody) {
+		commentRepository.findByIdAndPostIdOrThrow(requestBody.getParentCommentId(),
+			requestBody.getPostId());
+	}
 
-    private void validateParentCommentId(CommentV2CreateCommentBodyDto requestBody) {
-        commentRepository.findByIdAndPostIdOrThrow(requestBody.getParentCommentId(),
-            requestBody.getPostId());
-    }
+	private int getOrder(Integer parentId) {
+		Optional<Comment> recentComment = commentRepository.findFirstByParentIdOrderByOrderDesc(
+			parentId);
+		return recentComment.map(comment -> comment.getOrder() + 1).orElse(1);
+	}
 
-    private int getOrder(Integer parentId) {
-        Optional<Comment> recentComment = commentRepository.findFirstByParentIdOrderByOrderDesc(
-            parentId);
-        return recentComment.map(comment -> comment.getOrder() + 1).orElse(1);
-    }
+	/**
+	 * 모임 게시글 댓글 수정
+	 *
+	 * @param commentId 수정할 댓글 ID
+	 * @param contents  수정할 내용
+	 * @param userId    수정하는 유저 ID
+	 * @return 수정된 댓글 정보
+	 */
+	@Override
+	@Transactional
+	public CommentV2UpdateCommentResponseDto updateComment(Integer commentId,
+		String contents, Integer userId) {
+		// 1. id를 기반으로 comment를 찾는다.
+		Comment comment = commentRepository.findByIdOrThrow(commentId);
 
-    /**
-     * 모임 게시글 댓글 수정
-     *
-     * @param commentId 수정할 댓글 ID
-     * @param contents  수정할 내용
-     * @param userId    수정하는 유저 ID
-     * @return 수정된 댓글 정보
-     */
-    @Override
-    @Transactional
-    public CommentV2UpdateCommentResponseDto updateComment(Integer commentId,
-        String contents, Integer userId) {
-        // 1. id를 기반으로 comment를 찾는다.
-        Comment comment = commentRepository.findByIdOrThrow(commentId);
+		// 2. comment의 user_id와 userId가 같은지 확인한다.
+		comment.validateWriter(userId);
 
-        // 2. comment의 user_id와 userId가 같은지 확인한다.
-        comment.validateWriter(userId);
+		// 3. comment의 contents를 수정한다.
+		comment.updateContents(contents);
 
-        // 3. comment의 contents를 수정한다.
-        comment.updateContents(contents, time.now());
+		// 4. 수정된 comment의 id, contents, updatedDate를 반환한다.
+		return CommentV2UpdateCommentResponseDto.of(comment.getId(), comment.getContents(),
+			String.valueOf(time.now()));
+	}
 
-        // 4. 수정된 comment의 id, contents, updatedDate를 반환한다.
-        return CommentV2UpdateCommentResponseDto.of(comment.getId(), comment.getContents(),
-            String.valueOf(comment.getUpdatedDate()));
-    }
+	@Override
+	public CommentV2GetCommentsResponseDto getComments(Integer postId, Integer page, Integer take,
+		Integer userId) {
+		// TODO : 페이지네이션 구현
 
-    @Override
-    public CommentV2GetCommentsResponseDto getComments(Integer postId, Integer page, Integer take,
-        Integer userId) {
-        // TODO : 페이지네이션 구현
+		List<Comment> comments = commentRepository.findAllByPostIdOrderByCreatedDate(postId);
 
-        List<Comment> comments = commentRepository.findAllByPostIdOrderByCreatedDate(postId);
+		MyLikes myLikes = new MyLikes(likeRepository.findAllByUserIdAndPostIdNotNull(userId));
 
-        MyLikes myLikes = new MyLikes(likeRepository.findAllByUserIdAndPostIdNotNull(userId));
+		Map<Integer, List<CommentDto>> replyMap = new HashMap<>();
+		comments.stream()
+			.filter(comment -> !comment.isParentComment())
+			.forEach(
+				comment -> replyMap.computeIfAbsent(comment.getParentId(), k -> new ArrayList<>())
+					.add(CommentDto.of(comment, myLikes.isLikeComment(comment.getId()),
+						comment.isWriter(userId), null)));
 
-        Map<Integer, List<CommentDto>> replyMap = new HashMap<>();
-        comments.stream()
-            .filter(comment -> !comment.isParentComment())
-            .forEach(
-                comment -> replyMap.computeIfAbsent(comment.getParentId(), k -> new ArrayList<>())
-                    .add(CommentDto.of(comment, myLikes.isLikeComment(comment.getId()),
-                        comment.isWriter(userId), null)));
+		List<CommentDto> commentDtos = comments.stream()
+			.filter(Comment::isParentComment)
+			.map(comment -> CommentDto.of(comment, myLikes.isLikeComment(comment.getId()),
+				comment.isWriter(userId),
+				replyMap.get(comment.getId())))
+			.toList();
 
-        List<CommentDto> commentDtos = comments.stream()
-            .filter(Comment::isParentComment)
-            .map(comment -> CommentDto.of(comment, myLikes.isLikeComment(comment.getId()),
-                comment.isWriter(userId),
-                replyMap.get(comment.getId())))
-            .toList();
+		return CommentV2GetCommentsResponseDto.of(commentDtos);
+	}
 
-        return CommentV2GetCommentsResponseDto.of(commentDtos);
-    }
+	/**
+	 * 댓글 신고하기
+	 *
+	 * @param commentId 댓글 신고할 댓글 id
+	 * @param userId    신고하는 유저 id
+	 * @return 신고 ID
+	 * @throws BadRequestException 이미 신고한 댓글일 때
+	 * @apiNote 댓글 신고는 한 댓글당 한번만 가능
+	 */
+	@Override
+	@Transactional
+	public CommentV2ReportCommentResponseDto reportComment(Integer commentId, Integer userId)
+		throws BadRequestException {
+		Comment comment = commentRepository.findByIdOrThrow(commentId);
+		User user = userRepository.findByIdOrThrow(userId);
 
-    /**
-     * 댓글 신고하기
-     *
-     * @param commentId 댓글 신고할 댓글 id
-     * @param userId    신고하는 유저 id
-     * @return 신고 ID
-     * @throws BadRequestException 이미 신고한 댓글일 때
-     * @apiNote 댓글 신고는 한 댓글당 한번만 가능
-     */
-    @Override
-    @Transactional
-    public CommentV2ReportCommentResponseDto reportComment(Integer commentId, Integer userId)
-        throws BadRequestException {
-        Comment comment = commentRepository.findByIdOrThrow(commentId);
-        User user = userRepository.findByIdOrThrow(userId);
+		Optional<Report> existingReport = reportRepository.findByCommentAndUser(comment, user);
 
-        Optional<Report> existingReport = reportRepository.findByCommentAndUser(comment, user);
+		if (existingReport.isPresent()) {
+			throw new BadRequestException(ErrorStatus.ALREADY_REPORTED_COMMENT.getErrorCode());
+		}
 
-        if (existingReport.isPresent()) {
-            throw new BadRequestException(ErrorStatus.ALREADY_REPORTED_COMMENT.getErrorCode());
-        }
+		Report report = Report.builder()
+			.comment(comment)
+			.user(user)
+			.build();
 
-        Report report = Report.builder()
-            .comment(comment)
-            .user(user)
-            .build();
+		Report savedReport = reportRepository.save(report);
 
-        Report savedReport = reportRepository.save(report);
+		return CommentV2ReportCommentResponseDto.of(savedReport.getId());
+	}
 
-        return CommentV2ReportCommentResponseDto.of(savedReport.getId());
-    }
+	/**
+	 * 모임 게시글 댓글 삭제
+	 *
+	 * @throws ForbiddenException 댓글 작성자가 아닐 때
+	 * @apiNote 댓글 삭제시 게시글의 댓글 수를 1 감소시킴
+	 */
+	@Override
+	@Transactional
+	public void deleteComment(Integer commentId, Integer userId) {
+		Comment comment = commentRepository.findByIdOrThrow(commentId);
+		comment.validateWriter(userId);
+		User user = comment.getUser();
 
-    /**
-     * 모임 게시글 댓글 삭제
-     *
-     * @throws ForbiddenException 댓글 작성자가 아닐 때
-     * @apiNote 댓글 삭제시 게시글의 댓글 수를 1 감소시킴
-     */
-    @Override
-    @Transactional
-    public void deleteComment(Integer commentId, Integer userId) throws ForbiddenException {
-        Comment comment = commentRepository.findByIdOrThrow(commentId);
+		Post post = postRepository.findByIdOrThrow(comment.getPostId());
+		post.decreaseCommentCount();
 
-        if (!comment.getUserId().equals(userId)) {
-            throw new ForbiddenException();
-        }
+		Comments childComments = new Comments(commentRepository.findAllByParentIdOrderByOrderDesc(comment.getId()));
 
-        Post post = postRepository.findByIdOrThrow(comment.getPostId());
-        post.decreaseCommentCount();
+		if (comment.getDepth() == IS_REPLY_COMMENT || !childComments.hasChild()) {
+			commentRepository.delete(comment);
+			return;
+		}
 
-        Optional<Comment> childComment = commentRepository.findFirstByParentIdOrderByOrderDesc(
-            comment.getId());
+		comment.deleteParentComment();
+		childComments.deleteMention(user.getName(), user.getOrgId().toString());
+	}
 
-        if (comment.getDepth() == IS_REPLY_COMMENT || childComment.isEmpty()) {
-            commentRepository.delete(comment);
-            return;
-        }
+	@Override
+	public void mentionUserInComment(CommentV2MentionUserInCommentRequestDto requestBody,
+		Integer userId) {
+		User user = userRepository.findByIdOrThrow(userId);
+		Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
 
-        comment.deleteParentComment(DELETE_COMMENT_CONTENT, null, null);
-    }
+		String pushNotificationContent = NEW_COMMENT_MENTION_PUSH_NOTIFICATION_CONTENT.getValue();
+		String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
 
-    @Override
-    public void mentionUserInComment(CommentV2MentionUserInCommentRequestDto requestBody,
-        Integer userId) {
-        User user = userRepository.findByIdOrThrow(userId);
-        Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
+		String[] userOrgIds = requestBody.getUserIds().stream()
+			.map(Object::toString)
+			.toArray(String[]::new);
 
-        String pushNotificationContent = NEW_COMMENT_MENTION_PUSH_NOTIFICATION_CONTENT.getValue();
-        String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
+		String newCommentMentionPushNotificationTitle = String.format(
+			NEW_COMMENT_MENTION_PUSH_NOTIFICATION_TITLE.getValue(), user.getName());
 
-        String[] userOrgIds = requestBody.getUserIds().stream()
-            .map(Object::toString)
-            .toArray(String[]::new);
+		PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(
+			userOrgIds,
+			newCommentMentionPushNotificationTitle,
+			pushNotificationContent,
+			PUSH_NOTIFICATION_CATEGORY.getValue(),
+			pushNotificationWeblink
+		);
 
-        String newCommentMentionPushNotificationTitle = String.format(
-            NEW_COMMENT_MENTION_PUSH_NOTIFICATION_TITLE.getValue(), user.getName());
-
-        PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(
-            userOrgIds,
-            newCommentMentionPushNotificationTitle,
-            pushNotificationContent,
-            PUSH_NOTIFICATION_CATEGORY.getValue(),
-            pushNotificationWeblink
-        );
-
-        pushNotificationService.sendPushNotification(pushRequestDto);
-    }
+		pushNotificationService.sendPushNotification(pushRequestDto);
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/common/util/MentionSecretStringRemover.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/util/MentionSecretStringRemover.java
@@ -10,6 +10,9 @@ public class MentionSecretStringRemover {
     private static final String PREFIX_PATTERN = "-~!@#";
     private static final String SUFFIX_PATTERN = "\\[\\d+\\]%\\^&\\*\\+";
 
+    private static final String DELETED_PREFIX_PATTERN = "-~!@#@";
+    private static final String DELETED_SUFFIX_PATTERN = "%^&*+";
+
     public static String removeSecretString(String content) {
         Pattern prefixPattern = Pattern.compile(PREFIX_PATTERN);
         Pattern suffixPattern = Pattern.compile(SUFFIX_PATTERN);
@@ -21,5 +24,12 @@ public class MentionSecretStringRemover {
         content = suffixMatcher.replaceAll("");
 
         return content;
+    }
+
+    public static String deleteMentionContent(String content, String mentionName, String mentionOrgId) {
+        String deletedMentionContent =
+            DELETED_PREFIX_PATTERN + mentionName + "[" + mentionOrgId + "]" + DELETED_SUFFIX_PATTERN;
+
+        return content.replace(deletedMentionContent, "@_");
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
@@ -36,6 +36,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class Comment {
 
 	private static final int PARENT_COMMENT = 0;
+	private static final String DELETE_COMMENT_CONTENT = "삭제된 댓글입니다.";
+
 
 	/**
 	 * 댓글의 고유 식별자
@@ -136,15 +138,14 @@ public class Comment {
 		this.parentId = parentId;
 	}
 
-	public void updateContents(String contents, LocalDateTime updatedDate) {
+	public void updateContents(String contents) {
 		this.contents = contents;
-		this.updatedDate = updatedDate;
 	}
 
-	public void deleteParentComment(String contents, User user, Integer userId) {
-		this.contents = contents;
-		this.user = user;
-		this.userId = userId;
+	public void deleteParentComment() {
+		this.contents = DELETE_COMMENT_CONTENT;
+		this.user = null;
+		this.userId = null;
 	}
 
 	public void validateWriter(Integer userId) {

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentRepository.java
@@ -16,6 +16,8 @@ public interface CommentRepository extends JpaRepository<Comment, Integer>, Comm
 
 	Optional<Comment> findFirstByParentIdOrderByOrderDesc(Integer parentId);
 
+	List<Comment> findAllByParentIdOrderByOrderDesc(Integer parentId);
+
 	Optional<Comment> findByIdAndPostId(Integer id, Integer postId);
 
 	default Comment findByIdAndPostIdOrThrow(Integer id, Integer postId){

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comments.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comments.java
@@ -1,0 +1,24 @@
+package org.sopt.makers.crew.main.entity.comment;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.common.util.MentionSecretStringRemover;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class Comments {
+	private final List<Comment> comments;
+
+	public void deleteMention(String mentionName, String mentionOrgId){
+		comments.forEach(comment -> {
+			String deletedMentionContent = MentionSecretStringRemover.deleteMentionContent(comment.getContents(),
+				mentionName, mentionOrgId);
+				comment.updateContents(deletedMentionContent);
+			});
+	}
+
+	public boolean hasChild(){
+		return !comments.isEmpty();
+	}
+}


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 댓글 삭제 기능 수정 : 대댓글에 댓글을 단 유저의 멘션이 있으면 멘션내용을 `@_` 로 변경하는 로직을 추가했습니다. 이에 대한 맥락은 아래 있습니다!
- https://sopt-makers.slack.com/archives/C042SGKBFK7/p1721656913922079
- 댓글 수정 로직 일부 수정 : updateDate는 알아서 업데이트가 되기에 제거했습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
<img width="683" alt="스크린샷 2024-07-23 오전 10 20 48" src="https://github.com/user-attachments/assets/06dcad2f-359f-43a8-9fc8-187a99a925a1">

<img width="693" alt="스크린샷 2024-07-23 오전 10 21 17" src="https://github.com/user-attachments/assets/61dc1438-8f22-49cf-9468-e25279ebd158">

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #259

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?