### PR TITLE
[FEAT] 모임 게시글 단일 조회 및 모임 게시글 개수 조회 V2 API 구현

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
@@ -1,10 +1,11 @@
 package org.sopt.makers.crew.main.entity.like;
 
 import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Integer> {
 
-	List<Like> findAllByUserIdAndPostIdNotNull(Integer userId);
+    List<Like> findAllByUserIdAndPostIdNotNull(Integer userId);
+
+    boolean existsByUserIdAndPostId(Integer userId, Integer postId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostRepository.java
@@ -16,4 +16,6 @@ public interface PostRepository extends JpaRepository<Post, Integer>, PostSearch
     }
 
     Optional<Post> findFirstByMeetingIdOrderByIdDesc(Integer meetingId);
+
+    Integer countByMeetingId(Integer meetingId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostSearchRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostSearchRepository.java
@@ -1,10 +1,13 @@
 package org.sopt.makers.crew.main.entity.post;
 
 import org.sopt.makers.crew.main.post.v2.dto.query.PostGetPostsCommand;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailBaseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface PostSearchRepository {
     Page<PostDetailResponseDto> findPostList(PostGetPostsCommand queryCommand, Pageable pageable, Integer userId);
+
+    PostDetailBaseDto findPost(Integer userId, Integer postId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
@@ -15,11 +15,13 @@ import org.sopt.makers.crew.main.post.v2.dto.request.PostV2CreatePostBodyDto;
 import org.sopt.makers.crew.main.post.v2.dto.request.PostV2MentionUserInPostRequestDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailBaseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2CreatePostResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostCountResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "게시글")
 public interface PostV2Api {
@@ -59,4 +61,11 @@ public interface PostV2Api {
             @ApiResponse(responseCode = "400", description = "모임이 없습니다", content = @Content)
     })
     ResponseEntity<PostDetailBaseDto> getPost(@PathVariable Integer postId, Principal principal);
+
+    @Operation(summary = "모임 게시글 개수 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "모임이 없습니다", content = @Content)
+    })
+    ResponseEntity<PostV2GetPostCountResponseDto> getPostCount(@RequestParam Integer meetingId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
@@ -9,48 +9,54 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-
 import java.security.Principal;
-
 import org.sopt.makers.crew.main.post.v2.dto.query.PostGetPostsCommand;
 import org.sopt.makers.crew.main.post.v2.dto.request.PostV2CreatePostBodyDto;
 import org.sopt.makers.crew.main.post.v2.dto.request.PostV2MentionUserInPostRequestDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailBaseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2CreatePostResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "게시글")
 public interface PostV2Api {
 
-	@Operation(summary = "모임 게시글 작성")
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "201", description = "성공"),
-		@ApiResponse(responseCode = "400", description = "모임이 없습니다.", content = @Content),
-		@ApiResponse(responseCode = "403", description = "권한이 없습니다.", content = @Content),
-	})
-	ResponseEntity<PostV2CreatePostResponseDto> createPost(
-		@Valid @RequestBody PostV2CreatePostBodyDto requestBody, Principal principal);
+    @Operation(summary = "모임 게시글 작성")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "모임이 없습니다.", content = @Content),
+            @ApiResponse(responseCode = "403", description = "권한이 없습니다.", content = @Content),
+    })
+    ResponseEntity<PostV2CreatePostResponseDto> createPost(
+            @Valid @RequestBody PostV2CreatePostBodyDto requestBody, Principal principal);
 
-	@Operation(summary = "모임 게시글 목록 조회")
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "성공"),
-		@ApiResponse(responseCode = "400", description = "모임이 없습니다.", content = @Content),
-	})
-	@Parameters({
-		@Parameter(name = "page", description = "페이지, default = 1", example = "1", schema = @Schema(type = "integer", format = "int32")),
-		@Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50", schema = @Schema(type = "integer", format = "int32")),
-		@Parameter(name = "meetingId", description = "모임 id", example = "0", schema = @Schema(type = "integer", format = "int32"))})
-	ResponseEntity<PostV2GetPostsResponseDto> getPosts(
-		@ModelAttribute @Parameter(hidden = true) PostGetPostsCommand queryCommand,
-		Principal principal);
+    @Operation(summary = "모임 게시글 목록 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "모임이 없습니다.", content = @Content),
+    })
+    @Parameters({
+            @Parameter(name = "page", description = "페이지, default = 1", example = "1", schema = @Schema(type = "integer", format = "int32")),
+            @Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50", schema = @Schema(type = "integer", format = "int32")),
+            @Parameter(name = "meetingId", description = "모임 id", example = "0", schema = @Schema(type = "integer", format = "int32"))})
+    ResponseEntity<PostV2GetPostsResponseDto> getPosts(
+            @ModelAttribute @Parameter(hidden = true) PostGetPostsCommand queryCommand,
+            Principal principal);
 
-	@Operation(summary = "게시글에서 멘션하기")
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "성공"),
-	})
-	ResponseEntity<Void> mentionUserInPost(
-		@Valid @RequestBody PostV2MentionUserInPostRequestDto requestBody, Principal principal);
+    @Operation(summary = "게시글에서 멘션하기")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
+    ResponseEntity<Void> mentionUserInPost(
+            @Valid @RequestBody PostV2MentionUserInPostRequestDto requestBody, Principal principal);
 
+    @Operation(summary = "모임 게시글 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "모임이 없습니다", content = @Content)
+    })
+    ResponseEntity<PostDetailBaseDto> getPost(@PathVariable Integer postId, Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
@@ -2,15 +2,13 @@ package org.sopt.makers.crew.main.post.v2;
 
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
-
 import java.security.Principal;
-
 import lombok.RequiredArgsConstructor;
-
 import org.sopt.makers.crew.main.common.util.UserUtil;
 import org.sopt.makers.crew.main.post.v2.dto.query.PostGetPostsCommand;
 import org.sopt.makers.crew.main.post.v2.dto.request.PostV2CreatePostBodyDto;
 import org.sopt.makers.crew.main.post.v2.dto.request.PostV2MentionUserInPostRequestDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailBaseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2CreatePostResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
 import org.sopt.makers.crew.main.post.v2.service.PostV2Service;
@@ -18,6 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,34 +28,42 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PostV2Controller implements PostV2Api {
 
-	private final PostV2Service postV2Service;
+    private final PostV2Service postV2Service;
 
-	@Override
-	@PostMapping()
-	@ResponseStatus(HttpStatus.CREATED)
-	public ResponseEntity<PostV2CreatePostResponseDto> createPost(
-		@Valid @RequestBody PostV2CreatePostBodyDto requestBody, Principal principal) {
-		Integer userId = UserUtil.getUserId(principal);
-		return ResponseEntity.ok(postV2Service.createPost(requestBody, userId));
-	}
+    @Override
+    @PostMapping()
+    @ResponseStatus(HttpStatus.CREATED)
+    public ResponseEntity<PostV2CreatePostResponseDto> createPost(
+            @Valid @RequestBody PostV2CreatePostBodyDto requestBody, Principal principal) {
+        Integer userId = UserUtil.getUserId(principal);
+        return ResponseEntity.ok(postV2Service.createPost(requestBody, userId));
+    }
 
-	@Override
-	@GetMapping()
-	@ResponseStatus(HttpStatus.OK)
-	public ResponseEntity<PostV2GetPostsResponseDto> getPosts(
-		@ModelAttribute @Parameter(hidden = true) PostGetPostsCommand queryCommand,
-		Principal principal) {
-		Integer userId = UserUtil.getUserId(principal);
-		return ResponseEntity.ok(postV2Service.getPosts(queryCommand, userId));
-	}
+    @Override
+    @GetMapping()
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<PostV2GetPostsResponseDto> getPosts(
+            @ModelAttribute @Parameter(hidden = true) PostGetPostsCommand queryCommand,
+            Principal principal) {
+        Integer userId = UserUtil.getUserId(principal);
+        return ResponseEntity.ok(postV2Service.getPosts(queryCommand, userId));
+    }
 
-	@Override
-	@PostMapping("/mention")
-	@ResponseStatus(HttpStatus.OK)
-	public ResponseEntity<Void> mentionUserInPost(
-		@Valid @RequestBody PostV2MentionUserInPostRequestDto requestBody, Principal principal) {
-		Integer userId = UserUtil.getUserId(principal);
-		postV2Service.mentionUserInPost(requestBody, userId);
-		return ResponseEntity.status(HttpStatus.OK).build();
-	}
+    @Override
+    @PostMapping("/mention")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<Void> mentionUserInPost(
+            @Valid @RequestBody PostV2MentionUserInPostRequestDto requestBody, Principal principal) {
+        Integer userId = UserUtil.getUserId(principal);
+        postV2Service.mentionUserInPost(requestBody, userId);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @Override
+    @GetMapping("/{postId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<PostDetailBaseDto> getPost(@PathVariable Integer postId, Principal principal) {
+        Integer userId = UserUtil.getUserId(principal);
+        return ResponseEntity.ok(postV2Service.getPost(userId, postId));
+    }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
@@ -10,6 +10,7 @@ import org.sopt.makers.crew.main.post.v2.dto.request.PostV2CreatePostBodyDto;
 import org.sopt.makers.crew.main.post.v2.dto.request.PostV2MentionUserInPostRequestDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailBaseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2CreatePostResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostCountResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
 import org.sopt.makers.crew.main.post.v2.service.PostV2Service;
 import org.springframework.http.HttpStatus;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -65,5 +67,12 @@ public class PostV2Controller implements PostV2Api {
     public ResponseEntity<PostDetailBaseDto> getPost(@PathVariable Integer postId, Principal principal) {
         Integer userId = UserUtil.getUserId(principal);
         return ResponseEntity.ok(postV2Service.getPost(userId, postId));
+    }
+
+    @Override
+    @GetMapping("/count")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<PostV2GetPostCountResponseDto> getPostCount(@RequestParam Integer meetingId) {
+        return ResponseEntity.ok(postV2Service.getPostCount(meetingId));
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostMeetingDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostMeetingDto.java
@@ -1,19 +1,23 @@
 package org.sopt.makers.crew.main.post.v2.dto.response;
 
 import com.querydsl.core.annotations.QueryProjection;
+import java.util.List;
 import lombok.Getter;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
+import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 
 @Getter
 public class PostMeetingDto {
     private final Integer id;
     private final String title;
     private final String category;
+    private final List<ImageUrlVO> imageURL;
 
     @QueryProjection
-    public PostMeetingDto(Integer id, String title, MeetingCategory category) {
+    public PostMeetingDto(Integer id, String title, MeetingCategory category, List<ImageUrlVO> imageURL) {
         this.id = id;
         this.title = title;
         this.category = category.getValue();
+        this.imageURL = imageURL;
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostV2GetPostCountResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostV2GetPostCountResponseDto.java
@@ -1,0 +1,14 @@
+package org.sopt.makers.crew.main.post.v2.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class PostV2GetPostCountResponseDto {
+
+    /**
+     * 모임 게시글 개수
+     */
+    private Integer postCount;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2Service.java
@@ -3,14 +3,17 @@ package org.sopt.makers.crew.main.post.v2.service;
 import org.sopt.makers.crew.main.post.v2.dto.query.PostGetPostsCommand;
 import org.sopt.makers.crew.main.post.v2.dto.request.PostV2CreatePostBodyDto;
 import org.sopt.makers.crew.main.post.v2.dto.request.PostV2MentionUserInPostRequestDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailBaseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2CreatePostResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
 
 public interface PostV2Service {
 
-	PostV2CreatePostResponseDto createPost(PostV2CreatePostBodyDto requestBody, Integer userId);
+    PostV2CreatePostResponseDto createPost(PostV2CreatePostBodyDto requestBody, Integer userId);
 
-	PostV2GetPostsResponseDto getPosts(PostGetPostsCommand queryCommand, Integer userId);
+    PostV2GetPostsResponseDto getPosts(PostGetPostsCommand queryCommand, Integer userId);
 
-	void mentionUserInPost(PostV2MentionUserInPostRequestDto requestBody, Integer userId);
+    PostDetailBaseDto getPost(Integer userId, Integer postId);
+
+    void mentionUserInPost(PostV2MentionUserInPostRequestDto requestBody, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2Service.java
@@ -5,6 +5,7 @@ import org.sopt.makers.crew.main.post.v2.dto.request.PostV2CreatePostBodyDto;
 import org.sopt.makers.crew.main.post.v2.dto.request.PostV2MentionUserInPostRequestDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailBaseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2CreatePostResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostCountResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
 
 public interface PostV2Service {
@@ -16,4 +17,6 @@ public interface PostV2Service {
     PostDetailBaseDto getPost(Integer userId, Integer postId);
 
     void mentionUserInPost(PostV2MentionUserInPostRequestDto requestBody, Integer userId);
+
+    PostV2GetPostCountResponseDto getPostCount(Integer meetingId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
@@ -14,7 +14,6 @@ import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
 import org.sopt.makers.crew.main.entity.apply.Apply;
 import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
-import org.sopt.makers.crew.main.entity.like.LikeRepository;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
 import org.sopt.makers.crew.main.entity.post.Post;
@@ -29,6 +28,7 @@ import org.sopt.makers.crew.main.post.v2.dto.request.PostV2MentionUserInPostRequ
 import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailBaseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2CreatePostResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostCountResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -45,7 +45,6 @@ public class PostV2ServiceImpl implements PostV2Service {
     private final UserRepository userRepository;
     private final PostRepository postRepository;
     private final ApplyRepository applyRepository;
-    private final LikeRepository likeRepository;
     private final PushNotificationService pushNotificationService;
 
     @Value("${push-notification.web-url}")
@@ -156,5 +155,16 @@ public class PostV2ServiceImpl implements PostV2Service {
         );
 
         pushNotificationService.sendPushNotification(pushRequestDto);
+    }
+
+    /**
+     * 모임 게시글 개수 조회
+     *
+     * @apiNote 모든 유저가 조회 가능
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public PostV2GetPostCountResponseDto getPostCount(Integer meetingId) {
+        return PostV2GetPostCountResponseDto.of(postRepository.countByMeetingId(meetingId));
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
@@ -7,15 +7,14 @@ import static org.sopt.makers.crew.main.internal.notification.PushNotificationEn
 import static org.sopt.makers.crew.main.internal.notification.PushNotificationEnums.PUSH_NOTIFICATION_CATEGORY;
 
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
-
 import org.sopt.makers.crew.main.common.exception.ForbiddenException;
 import org.sopt.makers.crew.main.common.pagination.dto.PageMetaDto;
 import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
 import org.sopt.makers.crew.main.entity.apply.Apply;
 import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
+import org.sopt.makers.crew.main.entity.like.LikeRepository;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
 import org.sopt.makers.crew.main.entity.post.Post;
@@ -27,6 +26,7 @@ import org.sopt.makers.crew.main.internal.notification.dto.PushNotificationReque
 import org.sopt.makers.crew.main.post.v2.dto.query.PostGetPostsCommand;
 import org.sopt.makers.crew.main.post.v2.dto.request.PostV2CreatePostBodyDto;
 import org.sopt.makers.crew.main.post.v2.dto.request.PostV2MentionUserInPostRequestDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailBaseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2CreatePostResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
@@ -41,107 +41,120 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PostV2ServiceImpl implements PostV2Service {
 
-	private final MeetingRepository meetingRepository;
-	private final UserRepository userRepository;
-	private final PostRepository postRepository;
-	private final ApplyRepository applyRepository;
-	private final PushNotificationService pushNotificationService;
+    private final MeetingRepository meetingRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final ApplyRepository applyRepository;
+    private final LikeRepository likeRepository;
+    private final PushNotificationService pushNotificationService;
 
-	@Value("${push-notification.web-url}")
-	private String pushWebUrl;
+    @Value("${push-notification.web-url}")
+    private String pushWebUrl;
 
-	/**
-	 * 모임 게시글 작성
-	 *
-	 * @throws 403 모임에 속한 유저가 아닌 경우
-	 * @apiNote 모임에 속한 유저만 작성 가능
-	 */
-	@Override
-	@Transactional
-	public PostV2CreatePostResponseDto createPost(PostV2CreatePostBodyDto requestBody,
-		Integer userId) {
-		Meeting meeting = meetingRepository.findByIdOrThrow(requestBody.getMeetingId());
-		User user = userRepository.findByIdOrThrow(userId);
+    /**
+     * 모임 게시글 작성
+     *
+     * @throws 403 모임에 속한 유저가 아닌 경우
+     * @apiNote 모임에 속한 유저만 작성 가능
+     */
+    @Override
+    @Transactional
+    public PostV2CreatePostResponseDto createPost(PostV2CreatePostBodyDto requestBody,
+                                                  Integer userId) {
+        Meeting meeting = meetingRepository.findByIdOrThrow(requestBody.getMeetingId());
+        User user = userRepository.findByIdOrThrow(userId);
 
-		List<Apply> applies = applyRepository.findAllById(List.of(meeting.getId()));
+        List<Apply> applies = applyRepository.findAllById(List.of(meeting.getId()));
 
-		boolean isInMeeting = applies.stream()
-			.anyMatch(apply -> apply.getUserId().equals(userId)
-				&& apply.getStatus() == EnApplyStatus.APPROVE);
+        boolean isInMeeting = applies.stream()
+                .anyMatch(apply -> apply.getUserId().equals(userId)
+                        && apply.getStatus() == EnApplyStatus.APPROVE);
 
-		boolean isMeetingCreator = meeting.getUserId().equals(userId);
+        boolean isMeetingCreator = meeting.getUserId().equals(userId);
 
-		if (isInMeeting == false && isMeetingCreator == false) {
-			throw new ForbiddenException(FORBIDDEN_EXCEPTION.getErrorCode());
-		}
+        if (isInMeeting == false && isMeetingCreator == false) {
+            throw new ForbiddenException(FORBIDDEN_EXCEPTION.getErrorCode());
+        }
 
-		Post post = Post.builder()
-			.title(requestBody.getTitle())
-			.user(user)
-			.contents(requestBody.getContents())
-			.images(requestBody.getImages())
-			.meeting(meeting)
-			.build();
+        Post post = Post.builder()
+                .title(requestBody.getTitle())
+                .user(user)
+                .contents(requestBody.getContents())
+                .images(requestBody.getImages())
+                .meeting(meeting)
+                .build();
 
-		Post savedPost = postRepository.save(post);
+        Post savedPost = postRepository.save(post);
 
-		List<String> userIdList = applyRepository.findAllByMeetingIdAndStatus(meeting.getId(),
-				EnApplyStatus.APPROVE)
-			.stream()
-			.map(apply -> String.valueOf(apply.getUser().getOrgId()))
-			.collect(toList());
+        List<String> userIdList = applyRepository.findAllByMeetingIdAndStatus(meeting.getId(),
+                        EnApplyStatus.APPROVE)
+                .stream()
+                .map(apply -> String.valueOf(apply.getUser().getOrgId()))
+                .collect(toList());
 
-		String[] userIds = userIdList.toArray(new String[0]);
-		String pushNotificationContent = String.format("[%s의 새 글] : \"%s\"",
-			user.getName(), post.getTitle());
-		String pushNotificationWeblink = pushWebUrl + "/detail?id=" + meeting.getId();
+        String[] userIds = userIdList.toArray(new String[0]);
+        String pushNotificationContent = String.format("[%s의 새 글] : \"%s\"",
+                user.getName(), post.getTitle());
+        String pushNotificationWeblink = pushWebUrl + "/detail?id=" + meeting.getId();
 
-		PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(userIds,
-			NEW_POST_PUSH_NOTIFICATION_TITLE.getValue(),
-			pushNotificationContent,
-			PUSH_NOTIFICATION_CATEGORY.getValue(), pushNotificationWeblink);
+        PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(userIds,
+                NEW_POST_PUSH_NOTIFICATION_TITLE.getValue(),
+                pushNotificationContent,
+                PUSH_NOTIFICATION_CATEGORY.getValue(), pushNotificationWeblink);
 
-		pushNotificationService.sendPushNotification(pushRequestDto);
+        pushNotificationService.sendPushNotification(pushRequestDto);
 
-		return PostV2CreatePostResponseDto.of(savedPost.getId());
-	}
+        return PostV2CreatePostResponseDto.of(savedPost.getId());
+    }
 
-	@Override
-	@Transactional(readOnly = true)
-	public PostV2GetPostsResponseDto getPosts(PostGetPostsCommand queryCommand, Integer userId) {
-		Page<PostDetailResponseDto> meetingPostListDtos = postRepository.findPostList(queryCommand,
-			PageRequest.of(queryCommand.getPage() - 1, queryCommand.getTake()), userId);
+    @Override
+    @Transactional(readOnly = true)
+    public PostV2GetPostsResponseDto getPosts(PostGetPostsCommand queryCommand, Integer userId) {
+        Page<PostDetailResponseDto> meetingPostListDtos = postRepository.findPostList(queryCommand,
+                PageRequest.of(queryCommand.getPage() - 1, queryCommand.getTake()), userId);
 
-		PageOptionsDto pageOptionsDto = new PageOptionsDto(queryCommand.getPage(),
-			queryCommand.getTake());
-		PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto,
-			(int)meetingPostListDtos.getTotalElements());
+        PageOptionsDto pageOptionsDto = new PageOptionsDto(queryCommand.getPage(),
+                queryCommand.getTake());
+        PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto,
+                (int) meetingPostListDtos.getTotalElements());
 
-		return PostV2GetPostsResponseDto.of(meetingPostListDtos.getContent(), pageMetaDto);
-	}
+        return PostV2GetPostsResponseDto.of(meetingPostListDtos.getContent(), pageMetaDto);
+    }
 
-	@Override
-	public void mentionUserInPost(PostV2MentionUserInPostRequestDto requestBody, Integer userId) {
-		User user = userRepository.findByIdOrThrow(userId);
-		Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
+    /**
+     * 모임 게시글 단건 조회
+     *
+     * @throws 400
+     * @apiNote 모임에 속한 유저만 작성 가능
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public PostDetailBaseDto getPost(Integer userId, Integer postId) {
+        return postRepository.findPost(userId, postId);
+    }
 
-		String pushNotificationContent = String.format("[%s의 글] : \"%s\"",
-			user.getName(), post.getTitle());
-		String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
+    @Override
+    public void mentionUserInPost(PostV2MentionUserInPostRequestDto requestBody, Integer userId) {
+        User user = userRepository.findByIdOrThrow(userId);
+        Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
 
-		String[] userOrgIds = userRepository.findByIdIn(requestBody.getUserIds())
-			.stream()
-			.map(mentionedUser -> String.valueOf(mentionedUser.getOrgId()))
-			.toArray(String[]::new);
+        String pushNotificationContent = String.format("[%s의 글] : \"%s\"",
+                user.getName(), post.getTitle());
+        String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
 
-		PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(
-			userOrgIds,
-			NEW_POST_MENTION_PUSH_NOTIFICATION_TITLE.getValue(),
-			pushNotificationContent,
-			PUSH_NOTIFICATION_CATEGORY.getValue(),
-			pushNotificationWeblink
-		);
+        String[] userOrgIds = userRepository.findByIdIn(requestBody.getUserIds())
+                .stream()
+                .map(mentionedUser -> String.valueOf(mentionedUser.getOrgId()))
+                .toArray(String[]::new);
 
-		pushNotificationService.sendPushNotification(pushRequestDto);
-	}
+        PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(
+                userOrgIds,
+                NEW_POST_MENTION_PUSH_NOTIFICATION_TITLE.getValue(),
+                pushNotificationContent,
+                PUSH_NOTIFICATION_CATEGORY.getValue(),
+                pushNotificationWeblink
+        );
+
+        pushNotificationService.sendPushNotification(pushRequestDto);
+    }
 }

--- a/main/src/test/java/org/sopt/makers/crew/main/post/v2/repository/PostRepositoryTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/post/v2/repository/PostRepositoryTest.java
@@ -128,4 +128,19 @@ public class PostRepositoryTest {
                 .containsExactly(1, "스터디 구합니다1", "행사");
     }
 
+    @Test
+    void 게시글_개수_조회() {
+        // given
+        int meetingId1 = 1;
+        int meetingId2 = 2;
+
+        // when
+        Integer postCount1 = postRepository.countByMeetingId(meetingId1);
+        Integer postCount2 = postRepository.countByMeetingId(meetingId2);
+
+        // then
+        assertThat(postCount1).isEqualTo(3);
+        assertThat(postCount2).isEqualTo(2);
+    }
+
 }

--- a/server/src/post/v1/post-v1.controller.ts
+++ b/server/src/post/v1/post-v1.controller.ts
@@ -47,6 +47,7 @@ export class PostV1Controller {
 
   @ApiOperation({
     summary: '모임 게시글 개수 조회',
+    deprecated: true,
   })
   @ApiOkResponseCommon(PostV1GetPostCountResponseDto)
   @ApiResponse({
@@ -83,6 +84,7 @@ export class PostV1Controller {
 
   @ApiOperation({
     summary: '모임 게시글 조회',
+    deprecated: true,
   })
   @ApiOkResponseCommon(PostV1GetPostResponseDto)
   @ApiResponse({


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->

- 모임 게시글 단건 조회 및 모임 게시글 개수 조회 하는 API를 마이그레이션 했습니다.


## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

- 기존에 모임 게시글 목록 조회 API의 response DTO에서 사용하고 있던 `PostDetailBaseDto` 를 최대한 재사용하고자 했습니다.

- 재사용할 때 meeting 정보 안에 imageURL 리스트가 있고 없고만 차이가 있었기 때문에, 기존 모임 게시글 목록 조회 API의 구조에서 imageURL 컬럼이 추가되는게 괜찮은지 FE 분들과 논의 진행했구요. 논의 스레드는 아래와 같습니다 !

    - https://sopt-makers.slack.com/archives/C042SGKBFK7/p1719670283072089

- 따라서 모임 게시글 단건 조회 시에는 기존 모임 게시글 목록 조회 로직과 동일하므로 따로 테스트 코드를 작성하지는 않았습니다.

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #230 

## ✅ 점검사항

- [x] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [x] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [x] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?