### PR TITLE
[FEAT] 모임 게시글 삭제 V2 API 구현

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentRepository.java
@@ -6,6 +6,9 @@ import java.util.Optional;
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.common.response.ErrorStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface CommentRepository extends JpaRepository<Comment, Integer>, CommentSearchRepository {
 
@@ -26,4 +29,9 @@ public interface CommentRepository extends JpaRepository<Comment, Integer>, Comm
 	}
 
 	List<Comment> findAllByPostIdOrderByCreatedDate(Integer postId);
+
+	@Modifying(clearAutomatically = true)
+	@Transactional
+	@Query("DELETE FROM Comment c WHERE c.postId = :postId")
+	void deleteAllByPostId(Integer postId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
@@ -12,11 +12,11 @@ public interface LikeRepository extends JpaRepository<Like, Integer> {
 
     @Modifying(clearAutomatically = true)
     @Transactional
-    @Query("DELETE FROM Comment c WHERE c.postId = :postId")
+    @Query("DELETE FROM Like l WHERE l.postId = :postId")
     void deleteAllByPostId(Integer postId);
 
     @Modifying(clearAutomatically = true)
     @Transactional
-    @Query("DELETE FROM Comment c WHERE c.postId IN :commentIds")
+    @Query("DELETE FROM Like l WHERE l.commentId IN :commentIds")
     void deleteAllByIdsInQuery(List<Integer> commentIds);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
@@ -2,10 +2,21 @@ package org.sopt.makers.crew.main.entity.like;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface LikeRepository extends JpaRepository<Like, Integer> {
 
     List<Like> findAllByUserIdAndPostIdNotNull(Integer userId);
 
-    boolean existsByUserIdAndPostId(Integer userId, Integer postId);
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("DELETE FROM Comment c WHERE c.postId = :postId")
+    void deleteAllByPostId(Integer postId);
+
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("DELETE FROM Comment c WHERE c.postId IN :commentIds")
+    void deleteAllByIdsInQuery(List<Integer> commentIds);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/post/Post.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/post/Post.java
@@ -1,5 +1,7 @@
 package org.sopt.makers.crew.main.entity.post;
 
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.*;
+
 import io.hypersistence.utils.hibernate.type.array.StringArrayType;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -21,6 +23,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import org.hibernate.annotations.Type;
+import org.sopt.makers.crew.main.common.exception.ForbiddenException;
 import org.sopt.makers.crew.main.entity.comment.Comment;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.user.User;
@@ -137,5 +140,11 @@ public class Post {
 
 	public void decreaseCommentCount() {
 		this.commentCount--;
+	}
+
+	public void isWriter(Integer userId){
+		if (!this.userId.equals(userId)) {
+			throw new ForbiddenException(FORBIDDEN_EXCEPTION.getErrorCode());
+		}
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostSearchRepositoryImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostSearchRepositoryImpl.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.crew.main.entity.post;
 
+import static org.sopt.makers.crew.main.common.response.ErrorStatus.NOT_FOUND_POST;
 import static org.sopt.makers.crew.main.entity.comment.QComment.comment;
 import static org.sopt.makers.crew.main.entity.like.QLike.like;
 import static org.sopt.makers.crew.main.entity.meeting.QMeeting.meeting;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.post.v2.dto.query.PostGetPostsCommand;
 import org.sopt.makers.crew.main.post.v2.dto.response.CommenterThumbnails;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailBaseDto;
@@ -50,7 +52,7 @@ public class PostSearchRepositoryImpl implements PostSearchRepository {
 
     @Override
     public PostDetailBaseDto findPost(Integer userId, Integer postId) {
-        return queryFactory
+        PostDetailBaseDto postDetail = queryFactory
                 .select(new QPostDetailBaseDto(
                         post.id,
                         post.title,
@@ -84,6 +86,12 @@ public class PostSearchRepositoryImpl implements PostSearchRepository {
                 .innerJoin(post.user, user)
                 .where(post.id.eq(postId))
                 .fetchFirst();
+
+        if (postDetail == null) {
+            throw new BadRequestException(NOT_FOUND_POST.getErrorCode());
+        }
+
+        return postDetail;
     }
 
     private List<PostDetailResponseDto> getContentList(Pageable pageable, Integer meetingId,

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
@@ -68,4 +68,12 @@ public interface PostV2Api {
             @ApiResponse(responseCode = "400", description = "모임이 없습니다", content = @Content)
     })
     ResponseEntity<PostV2GetPostCountResponseDto> getPostCount(@RequestParam Integer meetingId);
+
+    @Operation(summary = "모임 게시글 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "모임이 없습니다.", content = @Content),
+            @ApiResponse(responseCode = "403", description = "권한이 없습니다.", content = @Content)
+    })
+    ResponseEntity<Void> deletePost(@PathVariable Integer postId, Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
@@ -15,6 +15,7 @@ import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
 import org.sopt.makers.crew.main.post.v2.service.PostV2Service;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -74,5 +75,14 @@ public class PostV2Controller implements PostV2Api {
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<PostV2GetPostCountResponseDto> getPostCount(@RequestParam Integer meetingId) {
         return ResponseEntity.ok(postV2Service.getPostCount(meetingId));
+    }
+
+    @Override
+    @DeleteMapping("/{postId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<Void> deletePost(@PathVariable Integer postId, Principal principal) {
+        Integer userId = UserUtil.getUserId(principal);
+        postV2Service.deletePost(postId, userId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2Service.java
@@ -19,4 +19,6 @@ public interface PostV2Service {
     void mentionUserInPost(PostV2MentionUserInPostRequestDto requestBody, Integer userId);
 
     PostV2GetPostCountResponseDto getPostCount(Integer meetingId);
+
+    void deletePost(Integer postId, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
@@ -188,10 +188,10 @@ public class PostV2ServiceImpl implements PostV2Service {
         List<Comment> comments = commentRepository.findAllByPostIdOrderByCreatedDate(postId);
         List<Integer> commentIds = comments.stream().map(Comment::getId).toList();
 
-        postRepository.delete(post);
         commentRepository.deleteAllByPostId(postId);
         likeRepository.deleteAllByPostId(postId);
         likeRepository.deleteAllByIdsInQuery(commentIds);
 
+        postRepository.delete(post);
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
@@ -166,4 +166,20 @@ public class PostV2ServiceImpl implements PostV2Service {
     public PostV2GetPostCountResponseDto getPostCount(Integer meetingId) {
         return PostV2GetPostCountResponseDto.of(postRepository.countByMeetingId(meetingId));
     }
+
+    /**
+     * 모임 게시글 삭제
+     *
+     * @throws 403 글 작성자가 아닌 경우
+     * @apiNote 글을 작성한 유저만 삭제 가능
+     */
+    @Override
+    @Transactional
+    public void deletePost(Integer postId, Integer userId) {
+        Post post = postRepository.findByIdOrThrow(postId);
+        if (!post.getUserId().equals(userId)) {
+            throw new ForbiddenException(FORBIDDEN_EXCEPTION.getErrorCode());
+        }
+        postRepository.delete(post);
+    }
 }

--- a/server/src/post/v1/post-v1.controller.ts
+++ b/server/src/post/v1/post-v1.controller.ts
@@ -182,6 +182,7 @@ export class PostV1Controller {
 
   @ApiOperation({
     summary: '모임 게시글 삭제',
+    deprecated: true,
   })
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 모임 게시글을 삭제하는 API를 V2로 마이그레이션 하였습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

- 개발 하다보니 이전에 모임 게시글 단건 조회에서 없는 게시글 id를 보냈을 때 예외 처리가 누락되어 있어서 해당 부분도 수정해놓았습니다.

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #278 

## ✅ 점검사항

- [x] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [x] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [x] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?