### PR TITLE
fix: ReplyDto 구현

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/response/ReplyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/response/ReplyDto.java
@@ -1,21 +1,16 @@
 package org.sopt.makers.crew.main.comment.v2.dto.response;
 
 import java.time.LocalDateTime;
-import java.util.List;
-
 import org.sopt.makers.crew.main.entity.comment.Comment;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.querydsl.core.annotations.QueryProjection;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
-@Schema(name = "CommentDto", description = "댓글 객체 응답 Dto")
-public class CommentDto {
+@Schema(name = "ReplyDto", description = "대댓글 객체 응답 Dto")
+public class ReplyDto {
 
-	@Schema(description = "댓글 id", example = "1")
+	@Schema(description = "대댓글 id", example = "1")
 	private final Integer id;
 
 	@Schema(description = "댓글 내용", example = "이것은 댓글 내용입니다.")
@@ -39,12 +34,9 @@ public class CommentDto {
 	@Schema(description = "댓글 순서", example = "2")
 	private final int order;
 
-	@Schema(description = "대댓글 객체 목록", example = "")
-	private final List<ReplyDto> replies;
-
 	@QueryProjection
-	public CommentDto(Integer id, String contents, CommentWriterDto user, LocalDateTime updatedDate, int likeCount,
-		boolean isLiked, boolean isWriter, int order, List<ReplyDto> replies) {
+	public ReplyDto(Integer id, String contents, CommentWriterDto user, LocalDateTime updatedDate, int likeCount,
+		Boolean isLiked, Boolean isWriter, int order) {
 		this.id = id;
 		this.contents = contents;
 		this.user = user;
@@ -53,13 +45,12 @@ public class CommentDto {
 		this.isLiked = isLiked;
 		this.isWriter = isWriter;
 		this.order = order;
-		this.replies = replies;
 	}
 
-	public static CommentDto of(Comment comment, boolean isLiked, boolean isWriter, List<ReplyDto> replies) {
-		return new CommentDto(comment.getId(), comment.getContents(),
+	public static ReplyDto of(Comment comment, boolean isLiked, boolean isWriter) {
+		return new ReplyDto(comment.getId(), comment.getContents(),
 			new CommentWriterDto(comment.getUser().getId(), comment.getUser().getOrgId(), comment.getUser().getName(),
 				comment.getUser().getProfileImage()), comment.getUpdatedDate(), comment.getLikeCount(),
-			isLiked, isWriter, comment.getOrder(), replies);
+			isLiked, isWriter, comment.getOrder());
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
@@ -18,6 +18,7 @@ import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2CreateCommentR
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2GetCommentsResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2ReportCommentResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2UpdateCommentResponseDto;
+import org.sopt.makers.crew.main.comment.v2.dto.response.ReplyDto;
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.common.exception.ForbiddenException;
 import org.sopt.makers.crew.main.common.response.ErrorStatus;
@@ -162,13 +163,13 @@ public class CommentV2ServiceImpl implements CommentV2Service {
 
 		MyLikes myLikes = new MyLikes(likeRepository.findAllByUserIdAndPostIdNotNull(userId));
 
-		Map<Integer, List<CommentDto>> replyMap = new HashMap<>();
+		Map<Integer, List<ReplyDto>> replyMap = new HashMap<>();
 		comments.stream()
 			.filter(comment -> !comment.isParentComment())
 			.forEach(
 				comment -> replyMap.computeIfAbsent(comment.getParentId(), k -> new ArrayList<>())
-					.add(CommentDto.of(comment, myLikes.isLikeComment(comment.getId()),
-						comment.isWriter(userId), null)));
+					.add(ReplyDto.of(comment, myLikes.isLikeComment(comment.getId()),
+						comment.isWriter(userId))));
 
 		List<CommentDto> commentDtos = comments.stream()
 			.filter(Comment::isParentComment)


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 스웨거 설정을 위해 ReplyDto를 생성했습니다.
- 뿐만 아니라, 댓글과 대댓글을 Dto 상으로 분리하는게 나중에 변화에도 유연하게 대처가 가능할 것 같아서 이렇게 수정했습니다!

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #280 

## ✅ 점검사항

- [x] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [x] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [x] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?