### PR TITLE
[FEAT] 게시글 댓글 좋아요 토글 V2 API 구현

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/CommentV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/CommentV2Api.java
@@ -6,7 +6,9 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+
 import java.security.Principal;
+
 import org.sopt.makers.crew.main.comment.v2.dto.query.CommentV2GetCommentsQueryDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2CreateCommentBodyDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2MentionUserInCommentRequestDto;
@@ -26,77 +28,77 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 public interface CommentV2Api {
 
-  @Operation(summary = "모임 게시글 댓글 작성")
-  @ResponseStatus(HttpStatus.CREATED)
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "201", description = "성공"),
-  })
-  ResponseEntity<CommentV2CreateCommentResponseDto> createComment(
-      @Valid @RequestBody CommentV2CreateCommentBodyDto requestBody, Principal principal);
+	@Operation(summary = "모임 게시글 댓글 작성")
+	@ResponseStatus(HttpStatus.CREATED)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "201", description = "성공"),
+	})
+	ResponseEntity<CommentV2CreateCommentResponseDto> createComment(
+		@Valid @RequestBody CommentV2CreateCommentBodyDto requestBody, Principal principal);
 
-  @Operation(summary = "모임 게시글 댓글 수정")
-  @ResponseStatus(HttpStatus.OK)
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "성공"),
-  })
-  ResponseEntity<CommentV2UpdateCommentResponseDto> updateComment(
-      @PathVariable Integer commentId,
-      @Valid @RequestBody CommentV2UpdateCommentBodyDto requestBody,
-      Principal principal);
+	@Operation(summary = "모임 게시글 댓글 수정")
+	@ResponseStatus(HttpStatus.OK)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "성공"),
+	})
+	ResponseEntity<CommentV2UpdateCommentResponseDto> updateComment(
+		@PathVariable Integer commentId,
+		@Valid @RequestBody CommentV2UpdateCommentBodyDto requestBody,
+		Principal principal);
 
-  @Operation(summary = "댓글 신고하기")
-  @ResponseStatus(HttpStatus.CREATED)
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "201", description = "성공"),
-  })
-  ResponseEntity<CommentV2ReportCommentResponseDto> reportComment(
-      @PathVariable Integer commentId, Principal principal);
+	@Operation(summary = "댓글 신고하기")
+	@ResponseStatus(HttpStatus.CREATED)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "201", description = "성공"),
+	})
+	ResponseEntity<CommentV2ReportCommentResponseDto> reportComment(
+		@PathVariable Integer commentId, Principal principal);
 
-  @Operation(summary = "모임 게시글 댓글 삭제")
-  @ResponseStatus(HttpStatus.NO_CONTENT)
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "204", description = "성공"),
-  })
-  ResponseEntity<Void> deleteComment(Principal principal, @PathVariable Integer commentId);
+	@Operation(summary = "모임 게시글 댓글 삭제")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "204", description = "성공"),
+	})
+	ResponseEntity<Void> deleteComment(Principal principal, @PathVariable Integer commentId);
 
-  @Operation(summary = "댓글에서 유저 멘션")
-  @ResponseStatus(HttpStatus.OK)
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "성공"),
-  })
-  ResponseEntity<Void> mentionUserInComment(
-      @Valid @RequestBody CommentV2MentionUserInCommentRequestDto requestBody,
-      Principal principal);
+	@Operation(summary = "댓글에서 유저 멘션")
+	@ResponseStatus(HttpStatus.OK)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "성공"),
+	})
+	ResponseEntity<Void> mentionUserInComment(
+		@Valid @RequestBody CommentV2MentionUserInCommentRequestDto requestBody,
+		Principal principal);
 
-  @Operation(summary = "모임 게시글 댓글 리스트 조회")
-  @ResponseStatus(HttpStatus.OK)
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "성공"),
-  })
-  @Parameters({@Parameter(name = "page", description = "페이지, default = 1", example = "1"),
-      @Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50"),
-      @Parameter(name = "postId", description = "게시글 id", example = "3")})
-  ResponseEntity<CommentV2GetCommentsResponseDto> getComments(
-      @Valid @ModelAttribute @Parameter(hidden = true) CommentV2GetCommentsQueryDto request,
-      Principal principal);
+	@Operation(summary = "모임 게시글 댓글 리스트 조회")
+	@ResponseStatus(HttpStatus.OK)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "성공"),
+	})
+	@Parameters({@Parameter(name = "page", description = "페이지, default = 1", example = "1"),
+		@Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50"),
+		@Parameter(name = "postId", description = "게시글 id", example = "3")})
+	ResponseEntity<CommentV2GetCommentsResponseDto> getComments(
+		@Valid @ModelAttribute @Parameter(hidden = true) CommentV2GetCommentsQueryDto request,
+		Principal principal);
 
-  @Operation(summary = "[TEMP] 모임 게시글 댓글 리스트 조회")
-  @ResponseStatus(HttpStatus.OK)
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "성공"),
-  })
-  @Parameters({@Parameter(name = "page", description = "페이지, default = 1", example = "1"),
-      @Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50"),
-      @Parameter(name = "postId", description = "게시글 id", example = "3")})
-  ResponseEntity<TempResponseDto<CommentV2GetCommentsResponseDto>> getCommentsTemp(
-      @Valid @ModelAttribute @Parameter(hidden = true) CommentV2GetCommentsQueryDto request,
-      Principal principal);
+	@Operation(summary = "[TEMP] 모임 게시글 댓글 리스트 조회")
+	@ResponseStatus(HttpStatus.OK)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "성공"),
+	})
+	@Parameters({@Parameter(name = "page", description = "페이지, default = 1", example = "1"),
+		@Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50"),
+		@Parameter(name = "postId", description = "게시글 id", example = "3")})
+	ResponseEntity<TempResponseDto<CommentV2GetCommentsResponseDto>> getCommentsTemp(
+		@Valid @ModelAttribute @Parameter(hidden = true) CommentV2GetCommentsQueryDto request,
+		Principal principal);
 
-  @Operation(summary = "모임 게시글 댓글 좋아요 토글")
-  @ResponseStatus(HttpStatus.CREATED)
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "201", description = "성공"),
-  })
-  ResponseEntity<CommentV2SwitchCommentLikeResponseDto> switchCommentLike(Principal principal,
-      @PathVariable Integer commentId);
+	@Operation(summary = "모임 게시글 댓글 좋아요 토글")
+	@ResponseStatus(HttpStatus.CREATED)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "201", description = "성공"),
+	})
+	ResponseEntity<CommentV2SwitchCommentLikeResponseDto> switchCommentLike(Principal principal,
+		@PathVariable Integer commentId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/CommentV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/CommentV2Api.java
@@ -6,9 +6,7 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
-
 import java.security.Principal;
-
 import org.sopt.makers.crew.main.comment.v2.dto.query.CommentV2GetCommentsQueryDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2CreateCommentBodyDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2MentionUserInCommentRequestDto;
@@ -16,6 +14,7 @@ import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2UpdateCommentBo
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2CreateCommentResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2GetCommentsResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2ReportCommentResponseDto;
+import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2SwitchCommentLikeResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2UpdateCommentResponseDto;
 import org.sopt.makers.crew.main.common.dto.TempResponseDto;
 import org.springframework.http.HttpStatus;
@@ -27,67 +26,77 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 public interface CommentV2Api {
 
-	@Operation(summary = "모임 게시글 댓글 작성")
-	@ResponseStatus(HttpStatus.CREATED)
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "201", description = "성공"),
-	})
-	ResponseEntity<CommentV2CreateCommentResponseDto> createComment(
-		@Valid @RequestBody CommentV2CreateCommentBodyDto requestBody, Principal principal);
+  @Operation(summary = "모임 게시글 댓글 작성")
+  @ResponseStatus(HttpStatus.CREATED)
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "성공"),
+  })
+  ResponseEntity<CommentV2CreateCommentResponseDto> createComment(
+      @Valid @RequestBody CommentV2CreateCommentBodyDto requestBody, Principal principal);
 
-	@Operation(summary = "모임 게시글 댓글 수정")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "성공"),
-	})
-	ResponseEntity<CommentV2UpdateCommentResponseDto> updateComment(
-		@PathVariable Integer commentId,
-		@Valid @RequestBody CommentV2UpdateCommentBodyDto requestBody,
-		Principal principal);
+  @Operation(summary = "모임 게시글 댓글 수정")
+  @ResponseStatus(HttpStatus.OK)
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+  })
+  ResponseEntity<CommentV2UpdateCommentResponseDto> updateComment(
+      @PathVariable Integer commentId,
+      @Valid @RequestBody CommentV2UpdateCommentBodyDto requestBody,
+      Principal principal);
 
-	@Operation(summary = "댓글 신고하기")
-	@ResponseStatus(HttpStatus.CREATED)
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "201", description = "성공"),
-	})
-	ResponseEntity<CommentV2ReportCommentResponseDto> reportComment(
-		@PathVariable Integer commentId, Principal principal);
+  @Operation(summary = "댓글 신고하기")
+  @ResponseStatus(HttpStatus.CREATED)
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "성공"),
+  })
+  ResponseEntity<CommentV2ReportCommentResponseDto> reportComment(
+      @PathVariable Integer commentId, Principal principal);
 
-	@Operation(summary = "모임 게시글 댓글 삭제")
-	@ResponseStatus(HttpStatus.NO_CONTENT)
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "204", description = "성공"),
-	})
-	ResponseEntity<Void> deleteComment(Principal principal, @PathVariable Integer commentId);
+  @Operation(summary = "모임 게시글 댓글 삭제")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "성공"),
+  })
+  ResponseEntity<Void> deleteComment(Principal principal, @PathVariable Integer commentId);
 
-	@Operation(summary = "댓글에서 유저 멘션")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "성공"),
-	})
-	ResponseEntity<Void> mentionUserInComment(
-		@Valid @RequestBody CommentV2MentionUserInCommentRequestDto requestBody,
-		Principal principal);
+  @Operation(summary = "댓글에서 유저 멘션")
+  @ResponseStatus(HttpStatus.OK)
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+  })
+  ResponseEntity<Void> mentionUserInComment(
+      @Valid @RequestBody CommentV2MentionUserInCommentRequestDto requestBody,
+      Principal principal);
 
-	@Operation(summary = "모임 게시글 댓글 리스트 조회")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "성공"),
-	})
-	@Parameters({@Parameter(name = "page", description = "페이지, default = 1", example = "1"),
-		@Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50"),
-		@Parameter(name = "postId", description = "게시글 id", example = "3")})
-	ResponseEntity<CommentV2GetCommentsResponseDto> getComments(
-		@Valid @ModelAttribute @Parameter(hidden = true) CommentV2GetCommentsQueryDto request, Principal principal);
+  @Operation(summary = "모임 게시글 댓글 리스트 조회")
+  @ResponseStatus(HttpStatus.OK)
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+  })
+  @Parameters({@Parameter(name = "page", description = "페이지, default = 1", example = "1"),
+      @Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50"),
+      @Parameter(name = "postId", description = "게시글 id", example = "3")})
+  ResponseEntity<CommentV2GetCommentsResponseDto> getComments(
+      @Valid @ModelAttribute @Parameter(hidden = true) CommentV2GetCommentsQueryDto request,
+      Principal principal);
 
-	@Operation(summary = "[TEMP] 모임 게시글 댓글 리스트 조회")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "성공"),
-	})
-	@Parameters({@Parameter(name = "page", description = "페이지, default = 1", example = "1"),
-		@Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50"),
-		@Parameter(name = "postId", description = "게시글 id", example = "3")})
-	ResponseEntity<TempResponseDto<CommentV2GetCommentsResponseDto>> getCommentsTemp(
-		@Valid @ModelAttribute @Parameter(hidden = true) CommentV2GetCommentsQueryDto request, Principal principal);
+  @Operation(summary = "[TEMP] 모임 게시글 댓글 리스트 조회")
+  @ResponseStatus(HttpStatus.OK)
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+  })
+  @Parameters({@Parameter(name = "page", description = "페이지, default = 1", example = "1"),
+      @Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50"),
+      @Parameter(name = "postId", description = "게시글 id", example = "3")})
+  ResponseEntity<TempResponseDto<CommentV2GetCommentsResponseDto>> getCommentsTemp(
+      @Valid @ModelAttribute @Parameter(hidden = true) CommentV2GetCommentsQueryDto request,
+      Principal principal);
+
+  @Operation(summary = "모임 게시글 댓글 좋아요 토글")
+  @ResponseStatus(HttpStatus.CREATED)
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "성공"),
+  })
+  ResponseEntity<CommentV2SwitchCommentLikeResponseDto> switchCommentLike(Principal principal,
+      @PathVariable Integer commentId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/CommentV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/CommentV2Controller.java
@@ -3,11 +3,8 @@ package org.sopt.makers.crew.main.comment.v2;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-
 import java.security.Principal;
-
 import lombok.RequiredArgsConstructor;
-
 import org.sopt.makers.crew.main.comment.v2.dto.query.CommentV2GetCommentsQueryDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2CreateCommentBodyDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2MentionUserInCommentRequestDto;
@@ -15,16 +12,17 @@ import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2UpdateCommentBo
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2CreateCommentResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2GetCommentsResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2ReportCommentResponseDto;
+import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2SwitchCommentLikeResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2UpdateCommentResponseDto;
 import org.sopt.makers.crew.main.comment.v2.service.CommentV2Service;
 import org.sopt.makers.crew.main.common.dto.TempResponseDto;
 import org.sopt.makers.crew.main.common.util.UserUtil;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,80 +35,93 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "댓글/대댓글")
 public class CommentV2Controller implements CommentV2Api {
 
-	private final CommentV2Service commentV2Service;
+  private final CommentV2Service commentV2Service;
 
-	@Override
-	@PostMapping()
-	public ResponseEntity<CommentV2CreateCommentResponseDto> createComment(
-		@Valid @RequestBody CommentV2CreateCommentBodyDto requestBody, Principal principal) {
-		Integer userId = UserUtil.getUserId(principal);
-		return ResponseEntity.ok(commentV2Service.createComment(requestBody, userId));
-	}
+  @Override
+  @PostMapping()
+  public ResponseEntity<CommentV2CreateCommentResponseDto> createComment(
+      @Valid @RequestBody CommentV2CreateCommentBodyDto requestBody, Principal principal) {
+    Integer userId = UserUtil.getUserId(principal);
+    return ResponseEntity.ok(commentV2Service.createComment(requestBody, userId));
+  }
 
-	@Override
-	@PutMapping("/{commentId}")
-	public ResponseEntity<CommentV2UpdateCommentResponseDto> updateComment(
-		@PathVariable Integer commentId,
-		@Valid @RequestBody CommentV2UpdateCommentBodyDto requestBody,
-		Principal principal) {
-		Integer userId = UserUtil.getUserId(principal);
-		return ResponseEntity.ok(
-			commentV2Service.updateComment(commentId, requestBody.getContents(), userId));
-	}
+  @Override
+  @PutMapping("/{commentId}")
+  public ResponseEntity<CommentV2UpdateCommentResponseDto> updateComment(
+      @PathVariable Integer commentId,
+      @Valid @RequestBody CommentV2UpdateCommentBodyDto requestBody,
+      Principal principal) {
+    Integer userId = UserUtil.getUserId(principal);
+    return ResponseEntity.ok(
+        commentV2Service.updateComment(commentId, requestBody.getContents(), userId));
+  }
 
-	@Override
-	@PostMapping("/{commentId}/report")
-	public ResponseEntity<CommentV2ReportCommentResponseDto> reportComment(
-		@PathVariable Integer commentId, Principal principal) {
-		Integer userId = UserUtil.getUserId(principal);
-		return ResponseEntity.ok(commentV2Service.reportComment(commentId, userId));
-	}
+  @Override
+  @PostMapping("/{commentId}/report")
+  public ResponseEntity<CommentV2ReportCommentResponseDto> reportComment(
+      @PathVariable Integer commentId, Principal principal) {
+    Integer userId = UserUtil.getUserId(principal);
+    return ResponseEntity.ok(commentV2Service.reportComment(commentId, userId));
+  }
 
-	@Override
-	@DeleteMapping("/{commentId}")
-	public ResponseEntity<Void> deleteComment(
-		Principal principal,
-		@PathVariable Integer commentId) {
-		Integer userId = UserUtil.getUserId(principal);
+  @Override
+  @DeleteMapping("/{commentId}")
+  public ResponseEntity<Void> deleteComment(
+      Principal principal,
+      @PathVariable Integer commentId) {
+    Integer userId = UserUtil.getUserId(principal);
 
-		commentV2Service.deleteComment(commentId, userId);
+    commentV2Service.deleteComment(commentId, userId);
 
-		return ResponseEntity.noContent().build();
-	}
+    return ResponseEntity.noContent().build();
+  }
 
-	@Override
-	@PostMapping("/mention")
-	public ResponseEntity<Void> mentionUserInComment(
-		@Valid @RequestBody CommentV2MentionUserInCommentRequestDto requestBody,
-		Principal principal) {
-		Integer userId = UserUtil.getUserId(principal);
-		commentV2Service.mentionUserInComment(requestBody, userId);
-		return ResponseEntity.status(HttpStatus.OK).build();
-	}
+  @Override
+  @PostMapping("/mention")
+  public ResponseEntity<Void> mentionUserInComment(
+      @Valid @RequestBody CommentV2MentionUserInCommentRequestDto requestBody,
+      Principal principal) {
+    Integer userId = UserUtil.getUserId(principal);
+    commentV2Service.mentionUserInComment(requestBody, userId);
+    return ResponseEntity.status(HttpStatus.OK).build();
+  }
 
-	@Override
-	@GetMapping
-	public ResponseEntity<CommentV2GetCommentsResponseDto> getComments(
-		@Valid @ModelAttribute @Parameter(hidden = true) CommentV2GetCommentsQueryDto request,
-		Principal principal) {
+  @Override
+  @GetMapping
+  public ResponseEntity<CommentV2GetCommentsResponseDto> getComments(
+      @Valid @ModelAttribute @Parameter(hidden = true) CommentV2GetCommentsQueryDto request,
+      Principal principal) {
 
-		Integer userId = UserUtil.getUserId(principal);
-		CommentV2GetCommentsResponseDto commentDtos = commentV2Service.getComments(request.getPostId(),
-			request.getPage(), request.getTake(), userId);
+    Integer userId = UserUtil.getUserId(principal);
+    CommentV2GetCommentsResponseDto commentDtos = commentV2Service.getComments(request.getPostId(),
+        request.getPage(), request.getTake(), userId);
 
-		return ResponseEntity.status(HttpStatus.OK).body(commentDtos);
-	}
+    return ResponseEntity.status(HttpStatus.OK).body(commentDtos);
+  }
 
-	@Override
-	@GetMapping("/temp")
-	public ResponseEntity<TempResponseDto<CommentV2GetCommentsResponseDto>> getCommentsTemp(
-		@Valid @ModelAttribute @Parameter(hidden = true) CommentV2GetCommentsQueryDto request,
-		Principal principal) {
+  @Override
+  @GetMapping("/temp")
+  public ResponseEntity<TempResponseDto<CommentV2GetCommentsResponseDto>> getCommentsTemp(
+      @Valid @ModelAttribute @Parameter(hidden = true) CommentV2GetCommentsQueryDto request,
+      Principal principal) {
 
-		Integer userId = UserUtil.getUserId(principal);
-		CommentV2GetCommentsResponseDto commentDtos = commentV2Service.getComments(request.getPostId(),
-			request.getPage(), request.getTake(), userId);
+    Integer userId = UserUtil.getUserId(principal);
+    CommentV2GetCommentsResponseDto commentDtos = commentV2Service.getComments(request.getPostId(),
+        request.getPage(), request.getTake(), userId);
 
-		return ResponseEntity.status(HttpStatus.OK).body(TempResponseDto.of(commentDtos));
-	}
+    return ResponseEntity.status(HttpStatus.OK).body(TempResponseDto.of(commentDtos));
+  }
+
+  @Override
+  @PostMapping("/{commentId}/like")
+  public ResponseEntity<CommentV2SwitchCommentLikeResponseDto> switchCommentLike(
+      Principal principal,
+      @PathVariable Integer commentId) {
+    Integer userId = UserUtil.getUserId(principal);
+
+    CommentV2SwitchCommentLikeResponseDto result = commentV2Service.switchCommentToggle(commentId,
+        userId);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(result);
+  }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/CommentV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/CommentV2Controller.java
@@ -3,8 +3,11 @@ package org.sopt.makers.crew.main.comment.v2;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+
 import java.security.Principal;
+
 import lombok.RequiredArgsConstructor;
+
 import org.sopt.makers.crew.main.comment.v2.dto.query.CommentV2GetCommentsQueryDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2CreateCommentBodyDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2MentionUserInCommentRequestDto;
@@ -35,93 +38,93 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "댓글/대댓글")
 public class CommentV2Controller implements CommentV2Api {
 
-  private final CommentV2Service commentV2Service;
+	private final CommentV2Service commentV2Service;
 
-  @Override
-  @PostMapping()
-  public ResponseEntity<CommentV2CreateCommentResponseDto> createComment(
-      @Valid @RequestBody CommentV2CreateCommentBodyDto requestBody, Principal principal) {
-    Integer userId = UserUtil.getUserId(principal);
-    return ResponseEntity.ok(commentV2Service.createComment(requestBody, userId));
-  }
+	@Override
+	@PostMapping()
+	public ResponseEntity<CommentV2CreateCommentResponseDto> createComment(
+		@Valid @RequestBody CommentV2CreateCommentBodyDto requestBody, Principal principal) {
+		Integer userId = UserUtil.getUserId(principal);
+		return ResponseEntity.ok(commentV2Service.createComment(requestBody, userId));
+	}
 
-  @Override
-  @PutMapping("/{commentId}")
-  public ResponseEntity<CommentV2UpdateCommentResponseDto> updateComment(
-      @PathVariable Integer commentId,
-      @Valid @RequestBody CommentV2UpdateCommentBodyDto requestBody,
-      Principal principal) {
-    Integer userId = UserUtil.getUserId(principal);
-    return ResponseEntity.ok(
-        commentV2Service.updateComment(commentId, requestBody.getContents(), userId));
-  }
+	@Override
+	@PutMapping("/{commentId}")
+	public ResponseEntity<CommentV2UpdateCommentResponseDto> updateComment(
+		@PathVariable Integer commentId,
+		@Valid @RequestBody CommentV2UpdateCommentBodyDto requestBody,
+		Principal principal) {
+		Integer userId = UserUtil.getUserId(principal);
+		return ResponseEntity.ok(
+			commentV2Service.updateComment(commentId, requestBody.getContents(), userId));
+	}
 
-  @Override
-  @PostMapping("/{commentId}/report")
-  public ResponseEntity<CommentV2ReportCommentResponseDto> reportComment(
-      @PathVariable Integer commentId, Principal principal) {
-    Integer userId = UserUtil.getUserId(principal);
-    return ResponseEntity.ok(commentV2Service.reportComment(commentId, userId));
-  }
+	@Override
+	@PostMapping("/{commentId}/report")
+	public ResponseEntity<CommentV2ReportCommentResponseDto> reportComment(
+		@PathVariable Integer commentId, Principal principal) {
+		Integer userId = UserUtil.getUserId(principal);
+		return ResponseEntity.ok(commentV2Service.reportComment(commentId, userId));
+	}
 
-  @Override
-  @DeleteMapping("/{commentId}")
-  public ResponseEntity<Void> deleteComment(
-      Principal principal,
-      @PathVariable Integer commentId) {
-    Integer userId = UserUtil.getUserId(principal);
+	@Override
+	@DeleteMapping("/{commentId}")
+	public ResponseEntity<Void> deleteComment(
+		Principal principal,
+		@PathVariable Integer commentId) {
+		Integer userId = UserUtil.getUserId(principal);
 
-    commentV2Service.deleteComment(commentId, userId);
+		commentV2Service.deleteComment(commentId, userId);
 
-    return ResponseEntity.noContent().build();
-  }
+		return ResponseEntity.noContent().build();
+	}
 
-  @Override
-  @PostMapping("/mention")
-  public ResponseEntity<Void> mentionUserInComment(
-      @Valid @RequestBody CommentV2MentionUserInCommentRequestDto requestBody,
-      Principal principal) {
-    Integer userId = UserUtil.getUserId(principal);
-    commentV2Service.mentionUserInComment(requestBody, userId);
-    return ResponseEntity.status(HttpStatus.OK).build();
-  }
+	@Override
+	@PostMapping("/mention")
+	public ResponseEntity<Void> mentionUserInComment(
+		@Valid @RequestBody CommentV2MentionUserInCommentRequestDto requestBody,
+		Principal principal) {
+		Integer userId = UserUtil.getUserId(principal);
+		commentV2Service.mentionUserInComment(requestBody, userId);
+		return ResponseEntity.status(HttpStatus.OK).build();
+	}
 
-  @Override
-  @GetMapping
-  public ResponseEntity<CommentV2GetCommentsResponseDto> getComments(
-      @Valid @ModelAttribute @Parameter(hidden = true) CommentV2GetCommentsQueryDto request,
-      Principal principal) {
+	@Override
+	@GetMapping
+	public ResponseEntity<CommentV2GetCommentsResponseDto> getComments(
+		@Valid @ModelAttribute @Parameter(hidden = true) CommentV2GetCommentsQueryDto request,
+		Principal principal) {
 
-    Integer userId = UserUtil.getUserId(principal);
-    CommentV2GetCommentsResponseDto commentDtos = commentV2Service.getComments(request.getPostId(),
-        request.getPage(), request.getTake(), userId);
+		Integer userId = UserUtil.getUserId(principal);
+		CommentV2GetCommentsResponseDto commentDtos = commentV2Service.getComments(request.getPostId(),
+			request.getPage(), request.getTake(), userId);
 
-    return ResponseEntity.status(HttpStatus.OK).body(commentDtos);
-  }
+		return ResponseEntity.status(HttpStatus.OK).body(commentDtos);
+	}
 
-  @Override
-  @GetMapping("/temp")
-  public ResponseEntity<TempResponseDto<CommentV2GetCommentsResponseDto>> getCommentsTemp(
-      @Valid @ModelAttribute @Parameter(hidden = true) CommentV2GetCommentsQueryDto request,
-      Principal principal) {
+	@Override
+	@GetMapping("/temp")
+	public ResponseEntity<TempResponseDto<CommentV2GetCommentsResponseDto>> getCommentsTemp(
+		@Valid @ModelAttribute @Parameter(hidden = true) CommentV2GetCommentsQueryDto request,
+		Principal principal) {
 
-    Integer userId = UserUtil.getUserId(principal);
-    CommentV2GetCommentsResponseDto commentDtos = commentV2Service.getComments(request.getPostId(),
-        request.getPage(), request.getTake(), userId);
+		Integer userId = UserUtil.getUserId(principal);
+		CommentV2GetCommentsResponseDto commentDtos = commentV2Service.getComments(request.getPostId(),
+			request.getPage(), request.getTake(), userId);
 
-    return ResponseEntity.status(HttpStatus.OK).body(TempResponseDto.of(commentDtos));
-  }
+		return ResponseEntity.status(HttpStatus.OK).body(TempResponseDto.of(commentDtos));
+	}
 
-  @Override
-  @PostMapping("/{commentId}/like")
-  public ResponseEntity<CommentV2SwitchCommentLikeResponseDto> switchCommentLike(
-      Principal principal,
-      @PathVariable Integer commentId) {
-    Integer userId = UserUtil.getUserId(principal);
+	@Override
+	@PostMapping("/{commentId}/like")
+	public ResponseEntity<CommentV2SwitchCommentLikeResponseDto> switchCommentLike(
+		Principal principal,
+		@PathVariable Integer commentId) {
+		Integer userId = UserUtil.getUserId(principal);
 
-    CommentV2SwitchCommentLikeResponseDto result = commentV2Service.switchCommentToggle(commentId,
-        userId);
+		CommentV2SwitchCommentLikeResponseDto result = commentV2Service.switchCommentToggle(commentId,
+			userId);
 
-    return ResponseEntity.status(HttpStatus.CREATED).body(result);
-  }
+		return ResponseEntity.status(HttpStatus.CREATED).body(result);
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/response/CommentV2SwitchCommentLikeResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/response/CommentV2SwitchCommentLikeResponseDto.java
@@ -1,0 +1,17 @@
+package org.sopt.makers.crew.main.comment.v2.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+@Schema(name = "CommentV2SwitchCommentLikeResponseDto", description = "댓글 좋아요 토글 응답 Dto")
+public class CommentV2SwitchCommentLikeResponseDto {
+
+  /**
+   * 요청 후 내가 좋아요를 누른 상태
+   */
+  @Schema(description = "요청 후 내가 좋아요를 누른 상태", example = "false")
+  private Boolean isLiked;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/response/CommentV2SwitchCommentLikeResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/response/CommentV2SwitchCommentLikeResponseDto.java
@@ -9,9 +9,9 @@ import lombok.Getter;
 @Schema(name = "CommentV2SwitchCommentLikeResponseDto", description = "댓글 좋아요 토글 응답 Dto")
 public class CommentV2SwitchCommentLikeResponseDto {
 
-  /**
-   * 요청 후 내가 좋아요를 누른 상태
-   */
-  @Schema(description = "요청 후 내가 좋아요를 누른 상태", example = "false")
-  private Boolean isLiked;
+	/**
+	 * 요청 후 내가 좋아요를 누른 상태
+	 */
+	@Schema(description = "요청 후 내가 좋아요를 누른 상태", example = "false")
+	private Boolean isLiked;
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2Service.java
@@ -5,24 +5,27 @@ import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2MentionUserInCo
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2CreateCommentResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2GetCommentsResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2ReportCommentResponseDto;
+import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2SwitchCommentLikeResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2UpdateCommentResponseDto;
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
-import org.sopt.makers.crew.main.common.exception.ForbiddenException;
 
 public interface CommentV2Service {
 
-	CommentV2CreateCommentResponseDto createComment(CommentV2CreateCommentBodyDto requestBody,
-		Integer userId);
+  CommentV2CreateCommentResponseDto createComment(CommentV2CreateCommentBodyDto requestBody,
+      Integer userId);
 
-	CommentV2ReportCommentResponseDto reportComment(Integer commentId, Integer userId)
-		throws BadRequestException;
+  CommentV2ReportCommentResponseDto reportComment(Integer commentId, Integer userId)
+      throws BadRequestException;
 
-	void deleteComment(Integer commentId, Integer userId);
+  void deleteComment(Integer commentId, Integer userId);
 
-	void mentionUserInComment(CommentV2MentionUserInCommentRequestDto requestBody, Integer userId);
+  void mentionUserInComment(CommentV2MentionUserInCommentRequestDto requestBody, Integer userId);
 
-	CommentV2UpdateCommentResponseDto updateComment(Integer commentId, String contents,
-		Integer userId);
+  CommentV2UpdateCommentResponseDto updateComment(Integer commentId, String contents,
+      Integer userId);
 
-	CommentV2GetCommentsResponseDto getComments(Integer postId, Integer page, Integer take, Integer userId);
+  CommentV2GetCommentsResponseDto getComments(Integer postId, Integer page, Integer take,
+      Integer userId);
+
+  CommentV2SwitchCommentLikeResponseDto switchCommentToggle(Integer commentId, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2Service.java
@@ -11,21 +11,21 @@ import org.sopt.makers.crew.main.common.exception.BadRequestException;
 
 public interface CommentV2Service {
 
-  CommentV2CreateCommentResponseDto createComment(CommentV2CreateCommentBodyDto requestBody,
-      Integer userId);
+	CommentV2CreateCommentResponseDto createComment(CommentV2CreateCommentBodyDto requestBody,
+		Integer userId);
 
-  CommentV2ReportCommentResponseDto reportComment(Integer commentId, Integer userId)
-      throws BadRequestException;
+	CommentV2ReportCommentResponseDto reportComment(Integer commentId, Integer userId)
+		throws BadRequestException;
 
-  void deleteComment(Integer commentId, Integer userId);
+	void deleteComment(Integer commentId, Integer userId);
 
-  void mentionUserInComment(CommentV2MentionUserInCommentRequestDto requestBody, Integer userId);
+	void mentionUserInComment(CommentV2MentionUserInCommentRequestDto requestBody, Integer userId);
 
-  CommentV2UpdateCommentResponseDto updateComment(Integer commentId, String contents,
-      Integer userId);
+	CommentV2UpdateCommentResponseDto updateComment(Integer commentId, String contents,
+		Integer userId);
 
-  CommentV2GetCommentsResponseDto getComments(Integer postId, Integer page, Integer take,
-      Integer userId);
+	CommentV2GetCommentsResponseDto getComments(Integer postId, Integer page, Integer take,
+		Integer userId);
 
-  CommentV2SwitchCommentLikeResponseDto switchCommentToggle(Integer commentId, Integer userId);
+	CommentV2SwitchCommentLikeResponseDto switchCommentToggle(Integer commentId, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
@@ -9,7 +9,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
+
 import org.sopt.makers.crew.main.comment.v2.dto.CommentMapper;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2CreateCommentBodyDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2MentionUserInCommentRequestDto;
@@ -49,255 +51,255 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class CommentV2ServiceImpl implements CommentV2Service {
 
-  private static final int IS_REPLY_COMMENT = 1;
+	private static final int IS_REPLY_COMMENT = 1;
 
-  private final PostRepository postRepository;
-  private final UserRepository userRepository;
-  private final CommentRepository commentRepository;
-  private final ReportRepository reportRepository;
-  private final LikeRepository likeRepository;
+	private final PostRepository postRepository;
+	private final UserRepository userRepository;
+	private final CommentRepository commentRepository;
+	private final ReportRepository reportRepository;
+	private final LikeRepository likeRepository;
 
-  private final PushNotificationService pushNotificationService;
+	private final PushNotificationService pushNotificationService;
 
-  private final CommentMapper commentMapper;
+	private final CommentMapper commentMapper;
 
-  @Value("${push-notification.web-url}")
-  private String pushWebUrl;
+	@Value("${push-notification.web-url}")
+	private String pushWebUrl;
 
-  private final Time time;
+	private final Time time;
 
-  /**
-   * 모임 게시글 댓글 작성
-   *
-   * @throws 400 존재하지 않는 게시글일 떄
-   * @apiNote 모임에 속한 유저만 작성 가능
-   */
-  @Override
-  @Transactional
-  public CommentV2CreateCommentResponseDto createComment(
-      CommentV2CreateCommentBodyDto requestBody,
-      Integer userId) {
-    Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
-    User writer = userRepository.findByIdOrThrow(userId);
+	/**
+	 * 모임 게시글 댓글 작성
+	 *
+	 * @throws 400 존재하지 않는 게시글일 떄
+	 * @apiNote 모임에 속한 유저만 작성 가능
+	 */
+	@Override
+	@Transactional
+	public CommentV2CreateCommentResponseDto createComment(
+		CommentV2CreateCommentBodyDto requestBody,
+		Integer userId) {
+		Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
+		User writer = userRepository.findByIdOrThrow(userId);
 
-    int depth = 0;
-    int order = 0;
-    Integer parentId = 0;
+		int depth = 0;
+		int order = 0;
+		Integer parentId = 0;
 
-    boolean isReplyComment = !requestBody.getIsParent();
-    if (isReplyComment) {
-      validateParentCommentId(requestBody);
-      depth = 1;
-      parentId = requestBody.getParentCommentId();
-      order = getOrder(parentId);
-    }
+		boolean isReplyComment = !requestBody.getIsParent();
+		if (isReplyComment) {
+			validateParentCommentId(requestBody);
+			depth = 1;
+			parentId = requestBody.getParentCommentId();
+			order = getOrder(parentId);
+		}
 
-    Comment comment = commentMapper.toComment(requestBody, post, writer, depth, order,
-        parentId);
+		Comment comment = commentMapper.toComment(requestBody, post, writer, depth, order,
+			parentId);
 
-    Comment savedComment = commentRepository.save(comment);
-    post.increaseCommentCount();
+		Comment savedComment = commentRepository.save(comment);
+		post.increaseCommentCount();
 
-    sendPushNotification(requestBody, post, writer);
+		sendPushNotification(requestBody, post, writer);
 
-    return CommentV2CreateCommentResponseDto.of(savedComment.getId());
-  }
+		return CommentV2CreateCommentResponseDto.of(savedComment.getId());
+	}
 
-  private void sendPushNotification(CommentV2CreateCommentBodyDto requestBody, Post post,
-      User user) {
-    User PostWriter = post.getUser();
-    String[] userIds = {String.valueOf(PostWriter.getOrgId())};
-    String secretStringRemovedContent = MentionSecretStringRemover.removeSecretString(
-        requestBody.getContents());
-    String pushNotificationContent = String.format("[%s의 댓글] : \"%s\"",
-        user.getName(), secretStringRemovedContent);
-    String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
+	private void sendPushNotification(CommentV2CreateCommentBodyDto requestBody, Post post,
+		User user) {
+		User PostWriter = post.getUser();
+		String[] userIds = {String.valueOf(PostWriter.getOrgId())};
+		String secretStringRemovedContent = MentionSecretStringRemover.removeSecretString(
+			requestBody.getContents());
+		String pushNotificationContent = String.format("[%s의 댓글] : \"%s\"",
+			user.getName(), secretStringRemovedContent);
+		String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
 
-    PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(userIds,
-        NEW_COMMENT_PUSH_NOTIFICATION_TITLE.getValue(),
-        pushNotificationContent,
-        PUSH_NOTIFICATION_CATEGORY.getValue(), pushNotificationWeblink);
+		PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(userIds,
+			NEW_COMMENT_PUSH_NOTIFICATION_TITLE.getValue(),
+			pushNotificationContent,
+			PUSH_NOTIFICATION_CATEGORY.getValue(), pushNotificationWeblink);
 
-    pushNotificationService.sendPushNotification(pushRequestDto);
-  }
+		pushNotificationService.sendPushNotification(pushRequestDto);
+	}
 
-  private void validateParentCommentId(CommentV2CreateCommentBodyDto requestBody) {
-    commentRepository.findByIdAndPostIdOrThrow(requestBody.getParentCommentId(),
-        requestBody.getPostId());
-  }
+	private void validateParentCommentId(CommentV2CreateCommentBodyDto requestBody) {
+		commentRepository.findByIdAndPostIdOrThrow(requestBody.getParentCommentId(),
+			requestBody.getPostId());
+	}
 
-  private int getOrder(Integer parentId) {
-    Optional<Comment> recentComment = commentRepository.findFirstByParentIdOrderByOrderDesc(
-        parentId);
-    return recentComment.map(comment -> comment.getOrder() + 1).orElse(1);
-  }
+	private int getOrder(Integer parentId) {
+		Optional<Comment> recentComment = commentRepository.findFirstByParentIdOrderByOrderDesc(
+			parentId);
+		return recentComment.map(comment -> comment.getOrder() + 1).orElse(1);
+	}
 
-  /**
-   * 모임 게시글 댓글 수정
-   *
-   * @param commentId 수정할 댓글 ID
-   * @param contents  수정할 내용
-   * @param userId    수정하는 유저 ID
-   * @return 수정된 댓글 정보
-   */
-  @Override
-  @Transactional
-  public CommentV2UpdateCommentResponseDto updateComment(Integer commentId,
-      String contents, Integer userId) {
-    // 1. id를 기반으로 comment를 찾는다.
-    Comment comment = commentRepository.findByIdOrThrow(commentId);
+	/**
+	 * 모임 게시글 댓글 수정
+	 *
+	 * @param commentId 수정할 댓글 ID
+	 * @param contents  수정할 내용
+	 * @param userId    수정하는 유저 ID
+	 * @return 수정된 댓글 정보
+	 */
+	@Override
+	@Transactional
+	public CommentV2UpdateCommentResponseDto updateComment(Integer commentId,
+		String contents, Integer userId) {
+		// 1. id를 기반으로 comment를 찾는다.
+		Comment comment = commentRepository.findByIdOrThrow(commentId);
 
-    // 2. comment의 user_id와 userId가 같은지 확인한다.
-    comment.validateWriter(userId);
+		// 2. comment의 user_id와 userId가 같은지 확인한다.
+		comment.validateWriter(userId);
 
-    // 3. comment의 contents를 수정한다.
-    comment.updateContents(contents);
+		// 3. comment의 contents를 수정한다.
+		comment.updateContents(contents);
 
-    // 4. 수정된 comment의 id, contents, updatedDate를 반환한다.
-    return CommentV2UpdateCommentResponseDto.of(comment.getId(), comment.getContents(),
-        String.valueOf(time.now()));
-  }
+		// 4. 수정된 comment의 id, contents, updatedDate를 반환한다.
+		return CommentV2UpdateCommentResponseDto.of(comment.getId(), comment.getContents(),
+			String.valueOf(time.now()));
+	}
 
-  @Override
-  public CommentV2GetCommentsResponseDto getComments(Integer postId, Integer page, Integer take,
-      Integer userId) {
-    // TODO : 페이지네이션 구현
+	@Override
+	public CommentV2GetCommentsResponseDto getComments(Integer postId, Integer page, Integer take,
+		Integer userId) {
+		// TODO : 페이지네이션 구현
 
-    List<Comment> comments = commentRepository.findAllByPostIdOrderByCreatedDate(postId);
+		List<Comment> comments = commentRepository.findAllByPostIdOrderByCreatedDate(postId);
 
-    MyLikes myLikes = new MyLikes(likeRepository.findAllByUserIdAndCommentIdNotNull(userId));
+		MyLikes myLikes = new MyLikes(likeRepository.findAllByUserIdAndCommentIdNotNull(userId));
 
-    Map<Integer, List<ReplyDto>> replyMap = new HashMap<>();
-    comments.stream()
-        .filter(comment -> !comment.isParentComment())
-        .forEach(
-            comment -> replyMap.computeIfAbsent(comment.getParentId(), k -> new ArrayList<>())
-                .add(ReplyDto.of(comment, myLikes.isLikeComment(comment.getId()),
-                    comment.isWriter(userId))));
+		Map<Integer, List<ReplyDto>> replyMap = new HashMap<>();
+		comments.stream()
+			.filter(comment -> !comment.isParentComment())
+			.forEach(
+				comment -> replyMap.computeIfAbsent(comment.getParentId(), k -> new ArrayList<>())
+					.add(ReplyDto.of(comment, myLikes.isLikeComment(comment.getId()),
+						comment.isWriter(userId))));
 
-    List<CommentDto> commentDtos = comments.stream()
-        .filter(Comment::isParentComment)
-        .map(comment -> CommentDto.of(comment, myLikes.isLikeComment(comment.getId()),
-            comment.isWriter(userId),
-            replyMap.get(comment.getId())))
-        .toList();
+		List<CommentDto> commentDtos = comments.stream()
+			.filter(Comment::isParentComment)
+			.map(comment -> CommentDto.of(comment, myLikes.isLikeComment(comment.getId()),
+				comment.isWriter(userId),
+				replyMap.get(comment.getId())))
+			.toList();
 
-    return CommentV2GetCommentsResponseDto.of(commentDtos);
-  }
+		return CommentV2GetCommentsResponseDto.of(commentDtos);
+	}
 
-  /**
-   * 댓글 신고하기
-   *
-   * @param commentId 댓글 신고할 댓글 id
-   * @param userId    신고하는 유저 id
-   * @return 신고 ID
-   * @throws BadRequestException 이미 신고한 댓글일 때
-   * @apiNote 댓글 신고는 한 댓글당 한번만 가능
-   */
-  @Override
-  @Transactional
-  public CommentV2ReportCommentResponseDto reportComment(Integer commentId, Integer userId)
-      throws BadRequestException {
-    Comment comment = commentRepository.findByIdOrThrow(commentId);
-    User user = userRepository.findByIdOrThrow(userId);
+	/**
+	 * 댓글 신고하기
+	 *
+	 * @param commentId 댓글 신고할 댓글 id
+	 * @param userId    신고하는 유저 id
+	 * @return 신고 ID
+	 * @throws BadRequestException 이미 신고한 댓글일 때
+	 * @apiNote 댓글 신고는 한 댓글당 한번만 가능
+	 */
+	@Override
+	@Transactional
+	public CommentV2ReportCommentResponseDto reportComment(Integer commentId, Integer userId)
+		throws BadRequestException {
+		Comment comment = commentRepository.findByIdOrThrow(commentId);
+		User user = userRepository.findByIdOrThrow(userId);
 
-    Optional<Report> existingReport = reportRepository.findByCommentAndUser(comment, user);
+		Optional<Report> existingReport = reportRepository.findByCommentAndUser(comment, user);
 
-    if (existingReport.isPresent()) {
-      throw new BadRequestException(ErrorStatus.ALREADY_REPORTED_COMMENT.getErrorCode());
-    }
+		if (existingReport.isPresent()) {
+			throw new BadRequestException(ErrorStatus.ALREADY_REPORTED_COMMENT.getErrorCode());
+		}
 
-    Report report = Report.builder()
-        .comment(comment)
-        .user(user)
-        .build();
+		Report report = Report.builder()
+			.comment(comment)
+			.user(user)
+			.build();
 
-    Report savedReport = reportRepository.save(report);
+		Report savedReport = reportRepository.save(report);
 
-    return CommentV2ReportCommentResponseDto.of(savedReport.getId());
-  }
+		return CommentV2ReportCommentResponseDto.of(savedReport.getId());
+	}
 
-  /**
-   * 모임 게시글 댓글 삭제
-   *
-   * @throws ForbiddenException 댓글 작성자가 아닐 때
-   * @apiNote 댓글 삭제시 게시글의 댓글 수를 1 감소시킴
-   */
-  @Override
-  @Transactional
-  public void deleteComment(Integer commentId, Integer userId) {
-    Comment comment = commentRepository.findByIdOrThrow(commentId);
-    comment.validateWriter(userId);
-    User user = comment.getUser();
+	/**
+	 * 모임 게시글 댓글 삭제
+	 *
+	 * @throws ForbiddenException 댓글 작성자가 아닐 때
+	 * @apiNote 댓글 삭제시 게시글의 댓글 수를 1 감소시킴
+	 */
+	@Override
+	@Transactional
+	public void deleteComment(Integer commentId, Integer userId) {
+		Comment comment = commentRepository.findByIdOrThrow(commentId);
+		comment.validateWriter(userId);
+		User user = comment.getUser();
 
-    Post post = postRepository.findByIdOrThrow(comment.getPostId());
-    post.decreaseCommentCount();
+		Post post = postRepository.findByIdOrThrow(comment.getPostId());
+		post.decreaseCommentCount();
 
-    Comments childComments = new Comments(
-        commentRepository.findAllByParentIdOrderByOrderDesc(comment.getId()));
+		Comments childComments = new Comments(
+			commentRepository.findAllByParentIdOrderByOrderDesc(comment.getId()));
 
-    if (comment.getDepth() == IS_REPLY_COMMENT || !childComments.hasChild()) {
-      commentRepository.delete(comment);
-      return;
-    }
+		if (comment.getDepth() == IS_REPLY_COMMENT || !childComments.hasChild()) {
+			commentRepository.delete(comment);
+			return;
+		}
 
-    comment.deleteParentComment();
-    childComments.deleteMention(user.getName(), user.getOrgId().toString());
-  }
+		comment.deleteParentComment();
+		childComments.deleteMention(user.getName(), user.getOrgId().toString());
+	}
 
-  @Override
-  public void mentionUserInComment(CommentV2MentionUserInCommentRequestDto requestBody,
-      Integer userId) {
-    User user = userRepository.findByIdOrThrow(userId);
-    Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
+	@Override
+	public void mentionUserInComment(CommentV2MentionUserInCommentRequestDto requestBody,
+		Integer userId) {
+		User user = userRepository.findByIdOrThrow(userId);
+		Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
 
-    String pushNotificationContent = "\"" + requestBody.getContent() + "\"";
-    String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
+		String pushNotificationContent = "\"" + requestBody.getContent() + "\"";
+		String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
 
-    String[] userOrgIds = requestBody.getUserIds().stream()
-        .map(Object::toString)
-        .toArray(String[]::new);
+		String[] userOrgIds = requestBody.getUserIds().stream()
+			.map(Object::toString)
+			.toArray(String[]::new);
 
-    String newCommentMentionPushNotificationTitle = String.format(
-        NEW_COMMENT_MENTION_PUSH_NOTIFICATION_TITLE.getValue(), user.getName());
+		String newCommentMentionPushNotificationTitle = String.format(
+			NEW_COMMENT_MENTION_PUSH_NOTIFICATION_TITLE.getValue(), user.getName());
 
-    PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(
-        userOrgIds,
-        newCommentMentionPushNotificationTitle,
-        pushNotificationContent,
-        PUSH_NOTIFICATION_CATEGORY.getValue(),
-        pushNotificationWeblink
-    );
+		PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(
+			userOrgIds,
+			newCommentMentionPushNotificationTitle,
+			pushNotificationContent,
+			PUSH_NOTIFICATION_CATEGORY.getValue(),
+			pushNotificationWeblink
+		);
 
-    pushNotificationService.sendPushNotification(pushRequestDto);
-  }
+		pushNotificationService.sendPushNotification(pushRequestDto);
+	}
 
-  @Override
-  @Transactional
-  public CommentV2SwitchCommentLikeResponseDto switchCommentToggle(Integer commentId,
-      Integer userId) throws BadRequestException, UnAuthorizedException {
+	@Override
+	@Transactional
+	public CommentV2SwitchCommentLikeResponseDto switchCommentToggle(Integer commentId,
+		Integer userId) {
 
-    Comment comment = commentRepository.findByIdOrThrow(commentId);
-    User user = userRepository.findByIdOrThrow(userId);
+		Comment comment = commentRepository.findByIdOrThrow(commentId);
+		User user = userRepository.findByIdOrThrow(userId);
 
-    boolean isLike = likeRepository.existsByUserIdAndCommentId(userId, commentId);
+		boolean isLike = likeRepository.existsByUserIdAndCommentId(userId, commentId);
 
-    if (isLike) {
-      likeRepository.deleteByUserIdAndCommentId(userId, commentId);
-      comment.decreaseLikeCount();
-      return CommentV2SwitchCommentLikeResponseDto.of(false);
-    }
+		if (isLike) {
+			likeRepository.deleteByUserIdAndCommentId(userId, commentId);
+			comment.decreaseLikeCount();
+			return CommentV2SwitchCommentLikeResponseDto.of(false);
+		}
 
-    Like like = Like.builder()
-        .user(user)
-        .userId(userId)
-        .comment(comment)
-        .commentId(commentId)
-        .build();
+		Like like = Like.builder()
+			.user(user)
+			.userId(userId)
+			.comment(comment)
+			.commentId(commentId)
+			.build();
 
-    likeRepository.save(like);
-    comment.increaseLikeCount();
+		likeRepository.save(like);
+		comment.increaseLikeCount();
 
-    return CommentV2SwitchCommentLikeResponseDto.of(true);
-  }
+		return CommentV2SwitchCommentLikeResponseDto.of(true);
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
@@ -284,6 +284,7 @@ public class CommentV2ServiceImpl implements CommentV2Service {
 
     if (isLike) {
       likeRepository.deleteByUserIdAndCommentId(userId, commentId);
+      comment.decreaseLikeCount();
       return CommentV2SwitchCommentLikeResponseDto.of(false);
     }
 
@@ -295,6 +296,7 @@ public class CommentV2ServiceImpl implements CommentV2Service {
         .build();
 
     likeRepository.save(like);
+    comment.increaseLikeCount();
 
     return CommentV2SwitchCommentLikeResponseDto.of(true);
   }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
@@ -35,130 +35,140 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(name = "comment")
 public class Comment {
 
-	private static final int PARENT_COMMENT = 0;
-	private static final String DELETE_COMMENT_CONTENT = "삭제된 댓글입니다.";
+  private static final int PARENT_COMMENT = 0;
+  private static final String DELETE_COMMENT_CONTENT = "삭제된 댓글입니다.";
 
 
-	/**
-	 * 댓글의 고유 식별자
-	 */
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Integer id;
+  /**
+   * 댓글의 고유 식별자
+   */
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer id;
 
-	/**
-	 * 댓글 내용
-	 */
-	@Column(nullable = false)
-	private String contents;
+  /**
+   * 댓글 내용
+   */
+  @Column(nullable = false)
+  private String contents;
 
-	/**
-	 * 댓글/대댓글 구분자 (0 = 댓글, 1 = 대댓글)
-	 */
-	@Column(nullable = false, columnDefinition = "int default 0")
-	private int depth;
+  /**
+   * 댓글/대댓글 구분자 (0 = 댓글, 1 = 대댓글)
+   */
+  @Column(nullable = false, columnDefinition = "int default 0")
+  private int depth;
 
-	/**
-	 * 댓글 순서 (댓글일 경우 0, 대댓글은 1부터 시작)
-	 */
-	@Column(nullable = false, columnDefinition = "int default 0")
-	private int order;
+  /**
+   * 댓글 순서 (댓글일 경우 0, 대댓글은 1부터 시작)
+   */
+  @Column(nullable = false, columnDefinition = "int default 0")
+  private int order;
 
-	/**
-	 * 작성일
-	 */
-	@Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
-	@CreatedDate
-	private LocalDateTime createdDate;
+  /**
+   * 작성일
+   */
+  @Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
+  @CreatedDate
+  private LocalDateTime createdDate;
 
-	/**
-	 * 수정일
-	 */
-	@Column(name = "updatedDate", nullable = false, columnDefinition = "TIMESTAMP")
-	@LastModifiedDate
-	private LocalDateTime updatedDate;
+  /**
+   * 수정일
+   */
+  @Column(name = "updatedDate", nullable = false, columnDefinition = "TIMESTAMP")
+  @LastModifiedDate
+  private LocalDateTime updatedDate;
 
-	/**
-	 * 작성자 정보
-	 */
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "userId")
-	private User user;
+  /**
+   * 작성자 정보
+   */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "userId")
+  private User user;
 
-	/**
-	 * 작성자의 고유 식별자
-	 */
-	@Column(insertable = false, updatable = false)
-	private Integer userId;
+  /**
+   * 작성자의 고유 식별자
+   */
+  @Column(insertable = false, updatable = false)
+  private Integer userId;
 
-	/**
-	 * 댓글이 속한 게시글 정보
-	 */
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "postId", nullable = false)
-	private Post post;
+  /**
+   * 댓글이 속한 게시글 정보
+   */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "postId", nullable = false)
+  private Post post;
 
-	/**
-	 * 댓글이 속한 게시글의 고유 식별자
-	 */
-	@Column(insertable = false, updatable = false)
-	private Integer postId;
+  /**
+   * 댓글이 속한 게시글의 고유 식별자
+   */
+  @Column(insertable = false, updatable = false)
+  private Integer postId;
 
-	/**
-	 * 댓글에 대한 좋아요 수
-	 */
-	@Column(nullable = false, columnDefinition = "int default 0")
-	private int likeCount;
+  /**
+   * 댓글에 대한 좋아요 수
+   */
+  @Column(nullable = false, columnDefinition = "int default 0")
+  private int likeCount;
 
-	/**
-	 * 부모 댓글의 고유 식별자
-	 */
-	private Integer parentId;
+  /**
+   * 부모 댓글의 고유 식별자
+   */
+  private Integer parentId;
 
-	public static class CommentListener {
-		@PostPersist
-		public void setParentId(Comment comment) {
-			if (comment.depth == PARENT_COMMENT) { // 댓글일 경우
-				comment.parentId = comment.id;
-			}
-		}
-	}
+  public static class CommentListener {
 
-	@Builder
-	public Comment(String contents, int depth, int order, User user, Integer userId, Post post, Integer postId,
-		int likeCount, Integer parentId) {
-		this.contents = contents;
-		this.depth = depth;
-		this.order = order;
-		this.user = user;
-		this.userId = userId;
-		this.post = post;
-		this.postId = postId;
-		this.likeCount = likeCount;
-		this.parentId = parentId;
-	}
+    @PostPersist
+    public void setParentId(Comment comment) {
+      if (comment.depth == PARENT_COMMENT) { // 댓글일 경우
+        comment.parentId = comment.id;
+      }
+    }
+  }
 
-	public void updateContents(String contents) {
-		this.contents = contents;
-	}
+  @Builder
+  public Comment(String contents, int depth, int order, User user, Integer userId, Post post,
+      Integer postId,
+      int likeCount, Integer parentId) {
+    this.contents = contents;
+    this.depth = depth;
+    this.order = order;
+    this.user = user;
+    this.userId = userId;
+    this.post = post;
+    this.postId = postId;
+    this.likeCount = likeCount;
+    this.parentId = parentId;
+  }
 
-	public void deleteParentComment() {
-		this.contents = DELETE_COMMENT_CONTENT;
-		this.user = null;
-		this.userId = null;
-	}
+  public void updateContents(String contents) {
+    this.contents = contents;
+  }
 
-	public void validateWriter(Integer userId) {
-		if (!isWriter(userId)) {
-			throw new ForbiddenException(FORBIDDEN_EXCEPTION.getErrorCode());
-		}
-	}
+  public void deleteParentComment() {
+    this.contents = DELETE_COMMENT_CONTENT;
+    this.user = null;
+    this.userId = null;
+  }
 
-	public boolean isWriter(Integer userId) {
-		return this.userId.equals(userId);
-	}
+  public void validateWriter(Integer userId) {
+    if (!isWriter(userId)) {
+      throw new ForbiddenException(FORBIDDEN_EXCEPTION.getErrorCode());
+    }
+  }
 
-	public boolean isParentComment() {
-		return this.depth == PARENT_COMMENT;
-	}
+  public boolean isWriter(Integer userId) {
+    return this.userId.equals(userId);
+  }
+
+  public boolean isParentComment() {
+    return this.depth == PARENT_COMMENT;
+  }
+
+  public void increaseLikeCount() {
+    this.likeCount++;
+  }
+
+  public void decreaseLikeCount() {
+    this.likeCount--;
+  }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
@@ -35,140 +35,139 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(name = "comment")
 public class Comment {
 
-  private static final int PARENT_COMMENT = 0;
-  private static final String DELETE_COMMENT_CONTENT = "삭제된 댓글입니다.";
+	private static final int PARENT_COMMENT = 0;
+	private static final String DELETE_COMMENT_CONTENT = "삭제된 댓글입니다.";
 
+	/**
+	 * 댓글의 고유 식별자
+	 */
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
 
-  /**
-   * 댓글의 고유 식별자
-   */
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Integer id;
+	/**
+	 * 댓글 내용
+	 */
+	@Column(nullable = false)
+	private String contents;
 
-  /**
-   * 댓글 내용
-   */
-  @Column(nullable = false)
-  private String contents;
+	/**
+	 * 댓글/대댓글 구분자 (0 = 댓글, 1 = 대댓글)
+	 */
+	@Column(nullable = false, columnDefinition = "int default 0")
+	private int depth;
 
-  /**
-   * 댓글/대댓글 구분자 (0 = 댓글, 1 = 대댓글)
-   */
-  @Column(nullable = false, columnDefinition = "int default 0")
-  private int depth;
+	/**
+	 * 댓글 순서 (댓글일 경우 0, 대댓글은 1부터 시작)
+	 */
+	@Column(nullable = false, columnDefinition = "int default 0")
+	private int order;
 
-  /**
-   * 댓글 순서 (댓글일 경우 0, 대댓글은 1부터 시작)
-   */
-  @Column(nullable = false, columnDefinition = "int default 0")
-  private int order;
+	/**
+	 * 작성일
+	 */
+	@Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
+	@CreatedDate
+	private LocalDateTime createdDate;
 
-  /**
-   * 작성일
-   */
-  @Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
-  @CreatedDate
-  private LocalDateTime createdDate;
+	/**
+	 * 수정일
+	 */
+	@Column(name = "updatedDate", nullable = false, columnDefinition = "TIMESTAMP")
+	@LastModifiedDate
+	private LocalDateTime updatedDate;
 
-  /**
-   * 수정일
-   */
-  @Column(name = "updatedDate", nullable = false, columnDefinition = "TIMESTAMP")
-  @LastModifiedDate
-  private LocalDateTime updatedDate;
+	/**
+	 * 작성자 정보
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "userId")
+	private User user;
 
-  /**
-   * 작성자 정보
-   */
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "userId")
-  private User user;
+	/**
+	 * 작성자의 고유 식별자
+	 */
+	@Column(insertable = false, updatable = false)
+	private Integer userId;
 
-  /**
-   * 작성자의 고유 식별자
-   */
-  @Column(insertable = false, updatable = false)
-  private Integer userId;
+	/**
+	 * 댓글이 속한 게시글 정보
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "postId", nullable = false)
+	private Post post;
 
-  /**
-   * 댓글이 속한 게시글 정보
-   */
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "postId", nullable = false)
-  private Post post;
+	/**
+	 * 댓글이 속한 게시글의 고유 식별자
+	 */
+	@Column(insertable = false, updatable = false)
+	private Integer postId;
 
-  /**
-   * 댓글이 속한 게시글의 고유 식별자
-   */
-  @Column(insertable = false, updatable = false)
-  private Integer postId;
+	/**
+	 * 댓글에 대한 좋아요 수
+	 */
+	@Column(nullable = false, columnDefinition = "int default 0")
+	private int likeCount;
 
-  /**
-   * 댓글에 대한 좋아요 수
-   */
-  @Column(nullable = false, columnDefinition = "int default 0")
-  private int likeCount;
+	/**
+	 * 부모 댓글의 고유 식별자
+	 */
+	private Integer parentId;
 
-  /**
-   * 부모 댓글의 고유 식별자
-   */
-  private Integer parentId;
+	public static class CommentListener {
 
-  public static class CommentListener {
+		@PostPersist
+		public void setParentId(Comment comment) {
+			if (comment.depth == PARENT_COMMENT) { // 댓글일 경우
+				comment.parentId = comment.id;
+			}
+		}
+	}
 
-    @PostPersist
-    public void setParentId(Comment comment) {
-      if (comment.depth == PARENT_COMMENT) { // 댓글일 경우
-        comment.parentId = comment.id;
-      }
-    }
-  }
+	@Builder
+	public Comment(String contents, int depth, int order, User user, Integer userId, Post post,
+		Integer postId,
+		int likeCount, Integer parentId) {
+		this.contents = contents;
+		this.depth = depth;
+		this.order = order;
+		this.user = user;
+		this.userId = userId;
+		this.post = post;
+		this.postId = postId;
+		this.likeCount = likeCount;
+		this.parentId = parentId;
+	}
 
-  @Builder
-  public Comment(String contents, int depth, int order, User user, Integer userId, Post post,
-      Integer postId,
-      int likeCount, Integer parentId) {
-    this.contents = contents;
-    this.depth = depth;
-    this.order = order;
-    this.user = user;
-    this.userId = userId;
-    this.post = post;
-    this.postId = postId;
-    this.likeCount = likeCount;
-    this.parentId = parentId;
-  }
+	public void updateContents(String contents) {
+		this.contents = contents;
+	}
 
-  public void updateContents(String contents) {
-    this.contents = contents;
-  }
+	public void deleteParentComment() {
+		this.contents = DELETE_COMMENT_CONTENT;
+		this.user = null;
+		this.userId = null;
+	}
 
-  public void deleteParentComment() {
-    this.contents = DELETE_COMMENT_CONTENT;
-    this.user = null;
-    this.userId = null;
-  }
+	public void validateWriter(Integer userId) {
+		if (!isWriter(userId)) {
+			throw new ForbiddenException(FORBIDDEN_EXCEPTION.getErrorCode());
+		}
+	}
 
-  public void validateWriter(Integer userId) {
-    if (!isWriter(userId)) {
-      throw new ForbiddenException(FORBIDDEN_EXCEPTION.getErrorCode());
-    }
-  }
+	public boolean isWriter(Integer userId) {
+		return this.userId.equals(userId);
+	}
 
-  public boolean isWriter(Integer userId) {
-    return this.userId.equals(userId);
-  }
+	public boolean isParentComment() {
+		return this.depth == PARENT_COMMENT;
+	}
 
-  public boolean isParentComment() {
-    return this.depth == PARENT_COMMENT;
-  }
+	public void increaseLikeCount() {
+		this.likeCount++;
+	}
 
-  public void increaseLikeCount() {
-    this.likeCount++;
-  }
-
-  public void decreaseLikeCount() {
-    this.likeCount--;
-  }
+	public void decreaseLikeCount() {
+		this.likeCount--;
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/like/Like.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/like/Like.java
@@ -10,11 +10,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+
 import java.time.LocalDateTime;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import org.sopt.makers.crew.main.entity.comment.Comment;
 import org.sopt.makers.crew.main.entity.post.Post;
 import org.sopt.makers.crew.main.entity.user.User;
@@ -28,68 +31,68 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public class Like {
 
-  /**
-   * Primary key
-   */
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private int id;
+	/**
+	 * Primary key
+	 */
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private int id;
 
-  /**
-   * 좋아요 누른 날짜
-   */
-  @Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
-  @CreatedDate
-  private LocalDateTime createdDate;
+	/**
+	 * 좋아요 누른 날짜
+	 */
+	@Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
+	@CreatedDate
+	private LocalDateTime createdDate;
 
-  /**
-   * 신고자
-   */
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "userId", nullable = false)
-  private User user;
+	/**
+	 * 신고자
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "userId", nullable = false)
+	private User user;
 
-  /**
-   * 좋아요 누른사람 id
-   */
-  @Column(insertable = false, nullable = false, updatable = false)
-  private int userId;
+	/**
+	 * 좋아요 누른사람 id
+	 */
+	@Column(insertable = false, nullable = false, updatable = false)
+	private int userId;
 
-  /**
-   * 게시글
-   */
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "postId")
-  private Post post;
+	/**
+	 * 게시글
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "postId")
+	private Post post;
 
-  /**
-   * 게시글 id - 게시글 좋아요가 아닐 경우 null
-   */
-  @Column(insertable = false, updatable = false)
-  private Integer postId;
+	/**
+	 * 게시글 id - 게시글 좋아요가 아닐 경우 null
+	 */
+	@Column(insertable = false, updatable = false)
+	private Integer postId;
 
-  /**
-   * 댓글
-   */
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "commentId")
-  private Comment comment;
+	/**
+	 * 댓글
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "commentId")
+	private Comment comment;
 
-  /**
-   * 댓글 id - 댓글 좋아요가 아닐 경우 null
-   */
-  @Column(insertable = false, updatable = false)
-  private Integer commentId;
+	/**
+	 * 댓글 id - 댓글 좋아요가 아닐 경우 null
+	 */
+	@Column(insertable = false, updatable = false)
+	private Integer commentId;
 
-  @Builder
-  public Like(Integer userId, Integer postId, Integer commentId, User user, Post post,
-      Comment comment) {
-    this.userId = userId;
-    this.user = user;
-    this.post = post;
-    this.postId = postId;
-    this.comment = comment;
-    this.commentId = commentId;
-  }
+	@Builder
+	public Like(Integer userId, Integer postId, Integer commentId, User user, Post post,
+		Comment comment) {
+		this.userId = userId;
+		this.user = user;
+		this.post = post;
+		this.postId = postId;
+		this.comment = comment;
+		this.commentId = commentId;
+	}
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/like/Like.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/like/Like.java
@@ -3,15 +3,21 @@ package org.sopt.makers.crew.main.entity.like;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.sopt.makers.crew.main.entity.comment.Comment;
+import org.sopt.makers.crew.main.entity.post.Post;
+import org.sopt.makers.crew.main.entity.user.User;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -21,43 +27,69 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(name = "like")
 @EntityListeners(AuditingEntityListener.class)
 public class Like {
-    /**
-     * Primary key
-     */
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
 
-    /**
-     * 좋아요 누른 날짜
-     */
-    @Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
-    @CreatedDate
-    private LocalDateTime createdDate;
+  /**
+   * Primary key
+   */
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private int id;
 
-    /**
-     * 좋아요 누른사람 id
-     */
-    @Column(insertable = false, updatable = false)
-    private Integer userId;
+  /**
+   * 좋아요 누른 날짜
+   */
+  @Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
+  @CreatedDate
+  private LocalDateTime createdDate;
 
-    /**
-     * 게시글 id - 게시글 좋아요가 아닐 경우 null
-     */
-    @Column(insertable = false, updatable = false)
-    private Integer postId;
+  /**
+   * 신고자
+   */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "userId", nullable = false)
+  private User user;
 
-    /**
-     * 댓글 id - 댓글 좋아요가 아닐 경우 null
-     */
-    @Column(insertable = false, updatable = false)
-    private Integer commentId;
+  /**
+   * 좋아요 누른사람 id
+   */
+  @Column(insertable = false, nullable = false, updatable = false)
+  private int userId;
 
-    @Builder
-    public Like(Integer userId, Integer postId, Integer commentId) {
-        this.userId = userId;
-        this.postId = postId;
-        this.commentId = commentId;
-    }
+  /**
+   * 게시글
+   */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "postId")
+  private Post post;
+
+  /**
+   * 게시글 id - 게시글 좋아요가 아닐 경우 null
+   */
+  @Column(insertable = false, updatable = false)
+  private Integer postId;
+
+  /**
+   * 댓글
+   */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "commentId")
+  private Comment comment;
+
+  /**
+   * 댓글 id - 댓글 좋아요가 아닐 경우 null
+   */
+  @Column(insertable = false, updatable = false)
+  private Integer commentId;
+
+  @Builder
+  public Like(Integer userId, Integer postId, Integer commentId, User user, Post post,
+      Comment comment) {
+    this.userId = userId;
+    this.user = user;
+    this.post = post;
+    this.postId = postId;
+    this.comment = comment;
+    this.commentId = commentId;
+  }
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
@@ -5,7 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Integer> {
 
-    List<Like> findAllByUserIdAndCommentIdNotNull(Integer userId);
+  List<Like> findAllByUserIdAndCommentIdNotNull(Integer userId);
 
-    boolean existsByUserIdAndPostId(Integer userId, Integer postId);
+  boolean existsByUserIdAndCommentId(Integer userId, Integer commentId);
+
+  void deleteByUserIdAndCommentId(Integer userId, Integer commentId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
@@ -1,13 +1,14 @@
 package org.sopt.makers.crew.main.entity.like;
 
 import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Integer> {
 
-  List<Like> findAllByUserIdAndCommentIdNotNull(Integer userId);
+	List<Like> findAllByUserIdAndCommentIdNotNull(Integer userId);
 
-  boolean existsByUserIdAndCommentId(Integer userId, Integer commentId);
+	boolean existsByUserIdAndCommentId(Integer userId, Integer commentId);
 
-  void deleteByUserIdAndCommentId(Integer userId, Integer commentId);
+	void deleteByUserIdAndCommentId(Integer userId, Integer commentId);
 }

--- a/server/src/comment/v1/comment-v1.controller.ts
+++ b/server/src/comment/v1/comment-v1.controller.ts
@@ -61,8 +61,12 @@ export class CommentV1Controller {
     return this.commentV1Service.getComments({ query, user });
   }
 
+  /**
+   * @deprecated
+   */
   @ApiOperation({
     summary: '댓글 좋아요 토글',
+    deprecated: true,
   })
   @ApiOkResponseCommon(CommentV1SwitchCommentLikeResponseDto)
   @ApiBearerAuth()
@@ -98,6 +102,9 @@ export class CommentV1Controller {
     return this.commentV1Service.reportComment({ param, user });
   }
 
+  /**
+   * @deprecated
+   */
   @ApiOperation({
     summary: '모임 게시글 댓글 작성',
     deprecated: true,


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 기존 nestjs에 구현되어있던 게시글 댓글 좋아요 토글 V1 API를 Spring 에 구현했습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
본래 3기 마지막 알림 기능이 추가가 될 때 좋아요 누를 시에 알림이 가도록 설정해서 마이그레이션 시에 해당 기능을 붙이기로 했었습니다. 다만 고려할 점이 있어서 해당 기능을 붙이지 않았습니다.
- 사용자 실수로 좋아요를 더블클릭하는 경우 알림이 2번 갈 수 있습니다.
- 위의 문제를 해결하기 위해서는 별도의 배치 프로그램 (lambda 혹은 redis 활용)을 개발해서 주기적으로 좋아요 summary를 보내주는 방법이 있지만, 마이그레이션 시에는 기능 변경을 최소화 해야하므로 해당 기능은 구현하지 않았습니다.
  - 추후 개선 사항있을 시에 아키텍처 개선 진행하면 좋을 것 같습니다.

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #217

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?