### PR TITLE
feat: 전체모임 검색 및 필터링 마이그레이션

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/common/dto/MeetingCreatorDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/dto/MeetingCreatorDto.java
@@ -2,23 +2,37 @@ package org.sopt.makers.crew.main.common.dto;
 
 import org.sopt.makers.crew.main.entity.user.User;
 
+import com.querydsl.core.annotations.QueryProjection;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
 
-public record MeetingCreatorDto(
+@Schema(name = "MeetingCreatorDto", description = "모임 개설자 Dto")
+@Getter
+public class MeetingCreatorDto {
 	@Schema(description = "모임장 id, 크루에서 사용하는 userId", example = "1")
 	@NotNull
-	Integer id,
+	Integer id;
 	@Schema(description = "모임장 이름", example = "홍길동")
 	@NotNull
-	String name,
+	String name;
 	@Schema(description = "모임장 org id, 메이커스 프로덕트에서 범용적으로 사용하는 userId", example = "1")
 	@NotNull
-	Integer orgId,
+	Integer orgId;
 	@Schema(description = "모임장 프로필 사진", example = "[url] 형식")
-	String profileImage
-) {
-	public static MeetingCreatorDto of(User user){
+	String profileImage;
+
+	@QueryProjection
+	public MeetingCreatorDto(Integer id, String name, Integer orgId, String profileImag) {
+		this.id = id;
+		this.name = name;
+		this.orgId = orgId;
+		this.profileImage = profileImag;
+	}
+
+	public static MeetingCreatorDto of(User user) {
 		return new MeetingCreatorDto(user.getId(), user.getName(), user.getOrgId(), user.getProfileImage());
 	}
+
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/common/dto/MeetingResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/dto/MeetingResponseDto.java
@@ -1,0 +1,114 @@
+package org.sopt.makers.crew.main.common.dto;
+
+import java.time.LocalDateTime;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.common.constant.CrewConst;
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+import org.sopt.makers.crew.main.entity.user.User;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Schema(name = "MeetingResponseDto", description = "모임 Dto")
+@RequiredArgsConstructor
+@Getter
+public class MeetingResponseDto {
+
+	@Schema(description = "모임 id", example = "1")
+	@NotNull
+	private final Integer id;
+	@Schema(description = "모임 제목", example = "모임 제목입니다")
+	@NotNull
+	String title;
+	@Schema(description = "대상 기수", example = "33")
+	@NotNull
+	private final Integer targetActiveGeneration;
+	@Schema(example = "[\n"
+		+ "    \"ANDROID\",\n"
+		+ "    \"IOS\"\n"
+		+ "  ]", description = "대상 파트 목록")
+	@NotNull
+	private final MeetingJoinablePart[] joinableParts;
+	@Schema(example = "스터디", description = "모임 카테고리")
+	@NotNull
+	private final String category;
+	@Schema(example = "false", description = "활동기수만 지원 가능 여부")
+	@NotNull
+	private final Boolean canJoinOnlyActiveGeneration;
+	@Schema(example = "2", description = "모임 활동 상태")
+	@NotNull
+	private final Integer status;
+	/**
+	 * 썸네일 이미지
+	 *
+	 * @apiNote 여러개여도 첫번째 이미지만 사용
+	 */
+	@Schema(description = "모임 사진", example = "[url] 형식")
+	@NotNull
+	private final List<ImageUrlVO> imageURL;
+	@Schema(example = "false", description = "멘토 필요 여부")
+	@NotNull
+	private final Boolean isMentorNeeded;
+	@Schema(description = "모임 활동 시작일", example = "2024-07-31T15:30:00")
+	@NotNull
+	private final LocalDateTime mStartDate;
+	@Schema(description = "모임 활동 종료일", example = "2024-08-25T15:30:00")
+	@NotNull
+	private final LocalDateTime mEndDate;
+	@Schema(description = "모집 인원", example = "20")
+	@NotNull
+	private final int capacity;
+	@Schema(description = "모임장 정보", example = "")
+	@NotNull
+	private final MeetingCreatorDto user;
+	@Schema(description = "신청 수", example = "7")
+	@NotNull
+	private final int appliedCount;
+
+	@QueryProjection
+	public MeetingResponseDto(Integer id, String title, Integer targetActiveGeneration,
+		@NotNull MeetingJoinablePart[] joinableParts, MeetingCategory category, Boolean canJoinOnlyActiveGeneration,
+		Integer status,
+		List<ImageUrlVO> imageURL, Boolean isMentorNeeded, LocalDateTime mStartDate, LocalDateTime mEndDate,
+		int capacity,
+		MeetingCreatorDto user, int appliedCount) {
+
+		boolean processedCanJoinOnlyActiveGeneration = canJoinOnlyActiveGeneration
+			&& (CrewConst.ACTIVE_GENERATION.equals(targetActiveGeneration));
+
+		this.id = id;
+		this.title = title;
+		this.targetActiveGeneration = targetActiveGeneration;
+		this.joinableParts = joinableParts;
+		this.category = category.getValue();
+		this.canJoinOnlyActiveGeneration = processedCanJoinOnlyActiveGeneration;
+		this.status = status;
+		this.imageURL = imageURL;
+		this.isMentorNeeded = isMentorNeeded;
+		this.mStartDate = mStartDate;
+		this.mEndDate = mEndDate;
+		this.capacity = capacity;
+		this.user = user;
+		this.appliedCount = appliedCount;
+	}
+
+	public static MeetingResponseDto of(Meeting meeting, User meetingCreator, int appliedCount){
+		MeetingCreatorDto creatorDto = MeetingCreatorDto.of(meetingCreator);
+		boolean canJoinOnlyActiveGeneration = meeting.getTargetActiveGeneration() == CrewConst.ACTIVE_GENERATION
+			&& meeting.getCanJoinOnlyActiveGeneration();
+
+		return new MeetingResponseDto(meeting.getId(), meeting.getTitle(),
+			meeting.getTargetActiveGeneration(), meeting.getJoinableParts(), meeting.getCategory(),
+			canJoinOnlyActiveGeneration, meeting.getMeetingStatus(), meeting.getImageURL(),
+			meeting.getIsMentorNeeded(), meeting.getMStartDate(), meeting.getMEndDate(), meeting.getCapacity(), creatorDto, appliedCount);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingRepository.java
@@ -9,7 +9,7 @@ import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MeetingRepository extends JpaRepository<Meeting, Integer> {
+public interface MeetingRepository extends JpaRepository<Meeting, Integer>, MeetingSearchRepository {
 
 	List<Meeting> findAllByUserId(Integer userId);
 

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.makers.crew.main.entity.meeting;
+
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MeetingSearchRepository {
+	Page<Meeting> findAllByQuery(MeetingV2GetAllMeetingQueryDto queryCommand, Pageable pageable);
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepository.java
@@ -1,9 +1,10 @@
 package org.sopt.makers.crew.main.entity.meeting;
 
+import org.sopt.makers.crew.main.common.util.Time;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface MeetingSearchRepository {
-	Page<Meeting> findAllByQuery(MeetingV2GetAllMeetingQueryDto queryCommand, Pageable pageable);
+	Page<Meeting> findAllByQuery(MeetingV2GetAllMeetingQueryDto queryCommand, Pageable pageable, Time time);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepositoryImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepositoryImpl.java
@@ -1,0 +1,170 @@
+package org.sopt.makers.crew.main.entity.meeting;
+
+import static org.sopt.makers.crew.main.entity.meeting.QMeeting.*;
+import static org.sopt.makers.crew.main.entity.user.QUser.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.sopt.makers.crew.main.common.constant.CrewConst;
+import org.sopt.makers.crew.main.common.util.Time;
+import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MeetingSearchRepositoryImpl implements MeetingSearchRepository {
+	private final JPAQueryFactory queryFactory;
+	private final Time time;
+
+	/**
+	 * @note: canJoinOnlyActiveGeneration 처리 유의
+	 * @note: status 처리 유의
+	 * */
+
+	@Override
+	public Page<Meeting> findAllByQuery(MeetingV2GetAllMeetingQueryDto queryCommand, Pageable pageable) {
+
+		List<Meeting> meetings = getMeetings(queryCommand, pageable);
+		JPAQuery<Long> countQuery = getCount(queryCommand);
+
+		return PageableExecutionUtils.getPage(meetings,
+			PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()), countQuery::fetchFirst);
+	}
+
+	private List<Meeting> getMeetings(MeetingV2GetAllMeetingQueryDto queryCommand, Pageable pageable) {
+		return queryFactory
+			.selectFrom(meeting)
+			.where(
+				eqCategory(queryCommand.getCategory()),
+				eqStatus(queryCommand.getStatus()),
+				isOnlyActiveGeneration(queryCommand.getIsOnlyActiveGeneration()),
+				eqJoinableParts(queryCommand.getJoinableParts()),
+				eqQuery(queryCommand.getQuery())
+			)
+			.innerJoin(meeting.user, user)
+			.fetchJoin()
+			.orderBy(meeting.id.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+	}
+
+	private JPAQuery<Long> getCount(MeetingV2GetAllMeetingQueryDto queryCommand) {
+		return queryFactory
+			.select(meeting.count())
+			.from(meeting)
+			.where(
+				eqCategory(queryCommand.getCategory()),
+				eqStatus(queryCommand.getStatus()),
+				isOnlyActiveGeneration(queryCommand.getIsOnlyActiveGeneration()),
+				eqJoinableParts(queryCommand.getJoinableParts()),
+				eqQuery(queryCommand.getQuery())
+			);
+	}
+
+	private BooleanExpression eqCategory(List<String> categories) {
+
+		if (categories == null || categories.isEmpty()) {
+			return null;
+		}
+
+		List<MeetingCategory> categoryList = categories.stream()
+			.map(MeetingCategory::ofValue)
+			.collect(Collectors.toList());
+
+		return meeting.category.in(categoryList);
+	}
+
+	private BooleanExpression eqStatus(List<String> statues) {
+
+		if (statues == null || statues.isEmpty()) {
+			return null;
+		}
+
+		List<BooleanExpression> conditions = new ArrayList<>();
+
+		List<Integer> statuesInt = statues.stream()
+			.map(Integer::parseInt)
+			.toList();
+
+		for (Integer status : statuesInt) {
+			if (status == EnMeetingStatus.BEFORE_START.getValue()) {
+				BooleanExpression condition = meeting.startDate.after(time.now());
+				conditions.add(condition);
+			} else if (status == EnMeetingStatus.APPLY_ABLE.getValue()) {
+				BooleanExpression afterStartDate = meeting.startDate.before(time.now());
+				BooleanExpression beforeEndDate = meeting.endDate.after(time.now());
+				BooleanExpression condition = afterStartDate.and(beforeEndDate);
+				conditions.add(condition);
+			} else if (status == EnMeetingStatus.RECRUITMENT_COMPLETE.getValue()) {
+				BooleanExpression condition = meeting.endDate.before(time.now());
+				conditions.add(condition);
+			}
+		}
+
+		if (conditions.isEmpty()) {
+			return null; // No valid conditions
+		}
+
+		BooleanExpression combinedCondition = conditions.get(0);
+		for (int i = 1; i < conditions.size(); i++) {
+			combinedCondition = combinedCondition.or(conditions.get(i));
+		}
+
+		return combinedCondition;
+	}
+
+	private BooleanExpression isOnlyActiveGeneration(boolean isOnlyActiveGeneration) {
+
+		if (isOnlyActiveGeneration) {
+			return meeting.canJoinOnlyActiveGeneration.eq(true)
+				.and(meeting.targetActiveGeneration.eq(CrewConst.ACTIVE_GENERATION));
+		}
+
+		return null;
+	}
+
+	private BooleanExpression eqJoinableParts(MeetingJoinablePart[] joinableParts) {
+
+		if (joinableParts == null || joinableParts.length == 0) {
+			return null;
+		}
+
+		String joinablePartsToString = Arrays.stream(joinableParts)
+			.map(Enum::name) // 각 요소를 큰따옴표로 감쌉니다.
+			.collect(Collectors.joining(",", "'{", "}'")); // 요소들을 쉼표로 연결하고 중괄호로 감쌉니다.
+
+		// SQL 템플릿을 사용하여 BooleanExpression 생성
+		return Expressions.booleanTemplate(
+			"arraycontains({0}, "+ joinablePartsToString + ") || '' = 'true'",
+			meeting.joinableParts,
+			joinablePartsToString
+		);
+	}
+
+	private BooleanExpression eqQuery(String query) {
+		if (query == null) {
+			return null;
+		}
+
+		return meeting.title.contains(query);
+	}
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -5,20 +5,25 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.List;
+
+import org.sopt.makers.crew.main.common.dto.TempResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -71,4 +76,32 @@ public interface MeetingV2Api {
     ResponseEntity<MeetingGetApplyListResponseDto> findApplyList(@PathVariable Integer meetingId,
                                                                  @ModelAttribute MeetingGetAppliesQueryDto queryCommand,
                                                                  Principal principal);
+
+    @Operation(summary = "모임 전체 조회/검색/필터링", description = "모임 전체 조회/검색/필터링\n")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "모임 지원자/참여자 조회 성공")})
+    @Parameters({
+        @Parameter(name = "page", description = "페이지, default = 1", example = "1", schema = @Schema(type = "integer", format = "int32")),
+        @Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50", schema = @Schema(type = "integer", format = "int32")),
+        @Parameter(name = "category", description = "카테고리", example = "스터디,번개", schema = @Schema(type = "string", format = "string")),
+        @Parameter(name = "status", description = "모임 모집 상태", example = "0,1", schema = @Schema(type = "string", format = "string")),
+        @Parameter(name = "isOnlyActiveGeneration", description = "활동기수만 참여여부", example = "true", schema = @Schema(type = "boolean", format = "boolean")),
+        @Parameter(name = "joinableParts", description = "검색할 활동 파트 다중 선택. OR 조건으로 검색됨 </br> Available values : PM, DESIGN, IOS, ANDROID, SERVER, WEB", example = "PM,DESIGN,IOS,ANDROID,SERVER,WEB", schema = @Schema(type = "array[string]", format = "array[string]")),
+        @Parameter(name = "query", description = "검색 내용", example = "고수스터디 검색", schema = @Schema(type = "string", format = "string")),
+    })
+    ResponseEntity<MeetingV2GetAllMeetingDto> getMeetings(@ModelAttribute MeetingV2GetAllMeetingQueryDto queryCommand,
+        Principal principal);
+
+    @Operation(summary = "[TEMP] 모임 전체 조회/검색/필터링", description = "모임 전체 조회/검색/필터링\n")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "모임 지원자/참여자 조회 성공")})
+    @Parameters({
+        @Parameter(name = "page", description = "페이지, default = 1", example = "1", schema = @Schema(type = "integer", format = "int32")),
+        @Parameter(name = "take", description = "가져올 데이터 개수, default = 12", example = "50", schema = @Schema(type = "integer", format = "int32")),
+        @Parameter(name = "category", description = "카테고리", example = "스터디,번개", schema = @Schema(type = "string", format = "string")),
+        @Parameter(name = "status", description = "모임 모집 상태", example = "0,1", schema = @Schema(type = "string", format = "string")),
+        @Parameter(name = "isOnlyActiveGeneration", description = "활동기수만 참여여부", example = "true", schema = @Schema(type = "boolean", format = "boolean")),
+        @Parameter(name = "joinableParts", description = "검색할 활동 파트 다중 선택. OR 조건으로 검색됨 </br> Available values : PM, DESIGN, IOS, ANDROID, SERVER, WEB", example = "PM,DESIGN,IOS,ANDROID,SERVER,WEB", schema = @Schema(type = "array[string]", format = "array[string]")),
+        @Parameter(name = "query", description = "검색 내용", example = "고수스터디 검색", schema = @Schema(type = "string", format = "string")),
+    })
+    ResponseEntity<TempResponseDto<MeetingV2GetAllMeetingDto>> getMeetingsTemp(@ModelAttribute MeetingV2GetAllMeetingQueryDto queryCommand,
+        Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -5,15 +5,19 @@ import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+
+import org.sopt.makers.crew.main.common.dto.TempResponseDto;
 import org.sopt.makers.crew.main.common.util.UserUtil;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.service.MeetingV2Service;
 import org.springframework.http.HttpStatus;
@@ -90,5 +94,22 @@ public class MeetingV2Controller implements MeetingV2Api {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(meetingV2Service.findApplyList(queryCommand, meetingId, userId));
+    }
+
+    @Override
+    @GetMapping
+    public ResponseEntity<MeetingV2GetAllMeetingDto> getMeetings(@ModelAttribute @Valid MeetingV2GetAllMeetingQueryDto queryCommand,
+        Principal principal) {
+
+        MeetingV2GetAllMeetingDto meetings = meetingV2Service.getMeetings(queryCommand);
+        return ResponseEntity.ok().body(meetings);
+    }
+
+    @Override
+    @GetMapping("/temp")
+    public ResponseEntity<TempResponseDto<MeetingV2GetAllMeetingDto>> getMeetingsTemp(
+        MeetingV2GetAllMeetingQueryDto queryCommand, Principal principal) {
+        MeetingV2GetAllMeetingDto meetings = meetingV2Service.getMeetings(queryCommand);
+        return ResponseEntity.ok().body(TempResponseDto.of(meetings));
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/query/MeetingV2GetAllMeetingQueryDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/query/MeetingV2GetAllMeetingQueryDto.java
@@ -1,0 +1,30 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.query;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MeetingV2GetAllMeetingQueryDto extends PageOptionsDto {
+
+
+	List<String> category;
+
+	List<String> status;
+	@NotNull
+	Boolean isOnlyActiveGeneration;
+	@NotNull
+	MeetingJoinablePart[] joinableParts;
+	@NotNull
+	String query;
+
+	public MeetingV2GetAllMeetingQueryDto(Integer page, Integer take) {
+		super(page, take);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetAllMeetingDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetAllMeetingDto.java
@@ -1,0 +1,23 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.common.dto.MeetingResponseDto;
+import org.sopt.makers.crew.main.common.pagination.dto.PageMetaDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(name = "MeetingV2GetAllMeetingDto", description = "모임 조회 응답 Dto")
+public record MeetingV2GetAllMeetingDto(
+	@Schema(description = "모임 객체 목록", example = "")
+	@NotNull
+	List<MeetingResponseDto> meetings,
+	@Schema(description = "페이지네이션 객체", example = "")
+	@NotNull
+	PageMetaDto meta
+) {
+	public static MeetingV2GetAllMeetingDto of(List<MeetingResponseDto> meetings, PageMetaDto meta){
+		return new MeetingV2GetAllMeetingDto(meetings, meta);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -3,12 +3,14 @@ package org.sopt.makers.crew.main.meeting.v2.service;
 import java.util.List;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
 
 public interface MeetingV2Service {
@@ -26,4 +28,6 @@ public interface MeetingV2Service {
 
     MeetingGetApplyListResponseDto findApplyList(MeetingGetAppliesQueryDto queryCommand, Integer meetingId,
                                                  Integer userId);
+
+    MeetingV2GetAllMeetingDto getMeetings(MeetingV2GetAllMeetingQueryDto queryCommand);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -25,6 +25,7 @@ import org.sopt.makers.crew.main.common.dto.MeetingResponseDto;
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.common.pagination.dto.PageMetaDto;
 import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
+import org.sopt.makers.crew.main.common.util.Time;
 import org.sopt.makers.crew.main.common.util.UserPartUtil;
 import org.sopt.makers.crew.main.entity.apply.Applies;
 import org.sopt.makers.crew.main.entity.apply.Apply;
@@ -75,6 +76,8 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
 	private final MeetingMapper meetingMapper;
 	private final ApplyMapper applyMapper;
+
+	private final Time time;
 
 	@Override
 	public MeetingV2GetAllMeetingByOrgUserDto getAllMeetingByOrgUser(
@@ -212,7 +215,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 	public MeetingV2GetAllMeetingDto getMeetings(MeetingV2GetAllMeetingQueryDto queryCommand) {
 
 		Page<Meeting> meetings = meetingRepository.findAllByQuery(queryCommand,
-			PageRequest.of(queryCommand.getPage() - 1, queryCommand.getTake()));
+			PageRequest.of(queryCommand.getPage() - 1, queryCommand.getTake()), time);
 		List<Integer> meetingIds = meetings.stream().map(Meeting::getId).toList();
 
 		Applies allApplies = new Applies(applyRepository.findAllByMeetingIdIn(meetingIds));

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -21,10 +21,12 @@ import java.util.stream.Stream;
 
 import lombok.RequiredArgsConstructor;
 
+import org.sopt.makers.crew.main.common.dto.MeetingResponseDto;
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.common.pagination.dto.PageMetaDto;
 import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
 import org.sopt.makers.crew.main.common.util.UserPartUtil;
+import org.sopt.makers.crew.main.entity.apply.Applies;
 import org.sopt.makers.crew.main.entity.apply.Apply;
 import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
@@ -42,6 +44,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.ApplyMapper;
 import org.sopt.makers.crew.main.meeting.v2.dto.MeetingMapper;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDto;
@@ -50,6 +53,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingRe
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserMeetingDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseUserDto;
 import org.springframework.data.domain.Page;
@@ -202,6 +206,26 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, (int)applyInfoDtos.getTotalElements());
 
 		return MeetingGetApplyListResponseDto.of(applyInfoDtos.getContent(), pageMetaDto);
+	}
+
+	@Override
+	public MeetingV2GetAllMeetingDto getMeetings(MeetingV2GetAllMeetingQueryDto queryCommand) {
+
+		Page<Meeting> meetings = meetingRepository.findAllByQuery(queryCommand,
+			PageRequest.of(queryCommand.getPage() - 1, queryCommand.getTake()));
+		List<Integer> meetingIds = meetings.stream().map(Meeting::getId).toList();
+
+		Applies allApplies = new Applies(applyRepository.findAllByMeetingIdIn(meetingIds));
+
+		List<MeetingResponseDto> meetingResponseDtos = meetings.getContent().stream()
+			.map(meeting -> MeetingResponseDto.of(meeting, meeting.getUser(),
+				allApplies.getAppliedCount(meeting.getId())))
+			.toList();
+
+		PageOptionsDto pageOptionsDto = new PageOptionsDto(queryCommand.getPage(), queryCommand.getTake());
+		PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, (int)meetings.getTotalElements());
+
+		return MeetingV2GetAllMeetingDto.of(meetingResponseDtos, pageMetaDto);
 	}
 
 	private Boolean checkMeetingLeader(Meeting meeting, Integer userId) {

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
@@ -3,6 +3,7 @@ package org.sopt.makers.crew.main.user.v2.dto.response;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.sopt.makers.crew.main.common.constant.CrewConst;
 import org.sopt.makers.crew.main.common.dto.MeetingCreatorDto;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
@@ -67,10 +68,12 @@ public record MeetingV2GetCreatedMeetingByUserResponseDto(
 ) {
 	public static MeetingV2GetCreatedMeetingByUserResponseDto of(Meeting meeting, User meetingCreator, int appliedCount) {
 		MeetingCreatorDto creatorDto = MeetingCreatorDto.of(meetingCreator);
+		boolean canJoinOnlyActiveGeneration = meeting.getTargetActiveGeneration() == CrewConst.ACTIVE_GENERATION
+			&& meeting.getCanJoinOnlyActiveGeneration();
 
 		return new MeetingV2GetCreatedMeetingByUserResponseDto(meeting.getId(), meeting.getTitle(),
 			meeting.getTargetActiveGeneration(), meeting.getJoinableParts(), meeting.getCategory().getValue(),
-			meeting.getCanJoinOnlyActiveGeneration(), meeting.getMeetingStatus(), meeting.getImageURL(),
+			canJoinOnlyActiveGeneration, meeting.getMeetingStatus(), meeting.getImageURL(),
 			meeting.getIsMentorNeeded(), meeting.getMStartDate(), meeting.getMEndDate(), meeting.getCapacity(), creatorDto, appliedCount);
 	}
 

--- a/server/src/meeting/v0/meeting-v0.controller.ts
+++ b/server/src/meeting/v0/meeting-v0.controller.ts
@@ -136,6 +136,7 @@ export class MeetingV0Controller {
   @ApiOperation({
     summary: '모임 전체 조회/검색/필터링',
     description: '모임 전체 조회/검색/필터링',
+    deprecated: true
   })
   @ApiOkResponseCommon(MeetingV0GetAllMeetingsResponseDto)
   @Get('/')


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 전체모임 검색 및 필터링 마이그레이션

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 동적쿼리 및 페이지네이션을 type-safe하게 + 깔끔하게 처리하기 위해서 querydsl를 사용했습니다.
- querydsl에서 postgresql 문법인 @> 사용에서 어려움이 있었습니다.
- 해당 코드는 `eqJoinableParts` 이며, `booleanTemplate` 로 `arraycontains` 를 사용하여 구현했습니다.

### 발생 쿼리
- 단 3번의 쿼리로 적은 쿼리 수로 구현했습니다!
```
Hibernate: select m1_0."id",m1_0."canJoinOnlyActiveGeneration",m1_0."capacity",m1_0."category",m1_0."createdGeneration",m1_0."desc",m1_0."endDate",m1_0."imageURL",m1_0."isMentorNeeded",m1_0."joinableParts",m1_0."leaderDesc",m1_0."mEndDate",m1_0."mStartDate",m1_0."note",m1_0."processDesc",m1_0."startDate",m1_0."targetActiveGeneration",m1_0."targetDesc",m1_0."title",m1_0."userId",u1_0."id",u1_0."activities",u1_0."name",u1_0."orgId",u1_0."phone",u1_0."profileImage" from "meeting" m1_0 join "user" u1_0 on u1_0."id"=m1_0."userId" where m1_0."category" in (?,?) and (m1_0."startDate">? or m1_0."startDate"<? and m1_0."endDate">? or m1_0."endDate"<?) and (arraycontains(m1_0."joinableParts",'{ANDROID,IOS,PM,WEB,SERVER}')||'')='true' order by m1_0."id" desc offset ? rows fetch first ? rows only

Hibernate: select count(m1_0."id") from "meeting" m1_0 where m1_0."category" in (?,?) and (m1_0."startDate">? or m1_0."startDate"<? and m1_0."endDate">? or m1_0."endDate"<?) and (arraycontains(m1_0."joinableParts",'{ANDROID,IOS,PM,WEB,SERVER}')||'')='true' fetch first ? rows only

Hibernate: select a1_0."id",a1_0."appliedDate",a1_0."content",a1_0."meetingId",a1_0."status",a1_0."type",a1_0."userId" from "apply" a1_0 where a1_0."meetingId" in (?,?,?,?,?,?,?,?,?,?,?,?)
```

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #309 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?