### PR TITLE
[FEAT] 모임 삭제 API 구현

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
@@ -24,7 +24,7 @@ import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.common.exception.ForbiddenException;
 import org.sopt.makers.crew.main.common.pagination.dto.PageMetaDto;
 import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
-import org.sopt.makers.crew.main.common.response.ErrorStatus;
+import org.sopt.makers.crew.main.common.exception.ErrorStatus;
 import org.sopt.makers.crew.main.common.util.MentionSecretStringRemover;
 import org.sopt.makers.crew.main.common.util.Time;
 import org.sopt.makers.crew.main.entity.comment.Comment;

--- a/main/src/main/java/org/sopt/makers/crew/main/common/advice/ControllerExceptionAdvice.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/advice/ControllerExceptionAdvice.java
@@ -1,8 +1,8 @@
 package org.sopt.makers.crew.main.common.advice;
 
 import org.sopt.makers.crew.main.common.exception.BaseException;
-import org.sopt.makers.crew.main.common.response.CommonResponseDto;
-import org.sopt.makers.crew.main.common.response.ErrorStatus;
+import org.sopt.makers.crew.main.common.exception.CommonResponseDto;
+import org.sopt.makers.crew.main.common.exception.ErrorStatus;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MissingServletRequestParameterException;

--- a/main/src/main/java/org/sopt/makers/crew/main/common/exception/CommonResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/exception/CommonResponseDto.java
@@ -1,4 +1,4 @@
-package org.sopt.makers.crew.main.common.response;
+package org.sopt.makers.crew.main.common.exception;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;

--- a/main/src/main/java/org/sopt/makers/crew/main/common/exception/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/exception/ErrorStatus.java
@@ -1,4 +1,4 @@
-package org.sopt.makers.crew.main.common.response;
+package org.sopt.makers.crew.main.common.exception;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/main/src/main/java/org/sopt/makers/crew/main/common/jwt/JwtAuthenticationFilter.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/jwt/JwtAuthenticationFilter.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 
 import lombok.RequiredArgsConstructor;
 
-import org.sopt.makers.crew.main.common.response.ErrorStatus;
+import org.sopt.makers.crew.main.common.exception.ErrorStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
@@ -1,6 +1,6 @@
 package org.sopt.makers.crew.main.entity.apply;
 
-import static org.sopt.makers.crew.main.common.response.ErrorStatus.NOT_FOUND_APPLY;
+import static org.sopt.makers.crew.main.common.exception.ErrorStatus.NOT_FOUND_APPLY;
 
 import java.util.List;
 import java.util.Optional;
@@ -40,5 +40,10 @@ public interface ApplyRepository extends JpaRepository<Apply, Integer>, ApplySea
         return findById(applyId)
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_APPLY.getErrorCode()));
     }
+
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("DELETE FROM Apply a WHERE a.meetingId = :meetingId")
+    void deleteAllByMeetingIdQuery(Integer meetingId);
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/Comment.java
@@ -1,6 +1,6 @@
 package org.sopt.makers.crew.main.entity.comment;
 
-import static org.sopt.makers.crew.main.common.response.ErrorStatus.*;
+import static org.sopt.makers.crew.main.common.exception.ErrorStatus.*;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/comment/CommentRepository.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
-import org.sopt.makers.crew.main.common.response.ErrorStatus;
+import org.sopt.makers.crew.main.common.exception.ErrorStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -30,8 +30,15 @@ public interface CommentRepository extends JpaRepository<Comment, Integer>, Comm
 
 	List<Comment> findAllByPostIdOrderByCreatedDate(Integer postId);
 
+	List<Comment> findAllByPostIdIsIn(List<Integer> postIds);
+
 	@Modifying(clearAutomatically = true)
 	@Transactional
 	@Query("DELETE FROM Comment c WHERE c.postId = :postId")
 	void deleteAllByPostId(Integer postId);
+
+	@Modifying(clearAutomatically = true)
+	@Transactional
+	@Query("DELETE FROM Comment c WHERE c.postId IN :postIds")
+	void deleteAllByPostIdsInQuery(List<Integer> postIds);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
@@ -6,9 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface LikeRepository extends JpaRepository<Like, Integer> {
 
@@ -21,10 +18,19 @@ public interface LikeRepository extends JpaRepository<Like, Integer> {
 
     @Modifying(clearAutomatically = true)
     @Transactional
+    @Query("DELETE FROM Like l WHERE l.postId IN :postIds")
+    void deleteAllByPostIdsInQuery(List<Integer> postIds);
+
+    @Modifying(clearAutomatically = true)
+    @Transactional
     @Query("DELETE FROM Like l WHERE l.commentId IN :commentIds")
-    void deleteAllByIdsInQuery(List<Integer> commentIds);
+    void deleteAllByCommentIdsInQuery(List<Integer> commentIds);
 
 	boolean existsByUserIdAndCommentId(Integer userId, Integer commentId);
 
 	void deleteByUserIdAndCommentId(Integer userId, Integer commentId);
+
+    List<Like> findAllByPostIdIsIn(List<Integer> postIds);
+    List<Like> findAllByCommentIdIsIn(List<Integer> commentIds);
+
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -1,9 +1,10 @@
 package org.sopt.makers.crew.main.entity.meeting;
 
+import static org.sopt.makers.crew.main.common.exception.ErrorStatus.*;
+
 import io.hypersistence.utils.hibernate.type.array.EnumArrayType;
 import io.hypersistence.utils.hibernate.type.array.internal.AbstractArrayType;
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
@@ -26,6 +27,7 @@ import lombok.NoArgsConstructor;
 
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
+import org.sopt.makers.crew.main.common.exception.ForbiddenException;
 import org.sopt.makers.crew.main.entity.apply.Apply;
 import org.sopt.makers.crew.main.entity.meeting.converter.MeetingCategoryConverter;
 import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
@@ -215,6 +217,12 @@ public class Meeting {
 			return EnMeetingStatus.APPLY_ABLE.getValue();
 		} else {
 			return EnMeetingStatus.RECRUITMENT_COMPLETE.getValue();
+		}
+	}
+
+	public void validateMeetingCreator(Integer requestUserId){
+		if(!this.userId.equals(requestUserId)){
+			throw new ForbiddenException(FORBIDDEN_EXCEPTION.getErrorCode());
 		}
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingRepository.java
@@ -1,6 +1,6 @@
 package org.sopt.makers.crew.main.entity.meeting;
 
-import static org.sopt.makers.crew.main.common.response.ErrorStatus.NOT_FOUND_MEETING;
+import static org.sopt.makers.crew.main.common.exception.ErrorStatus.NOT_FOUND_MEETING;
 
 import java.util.List;
 import java.util.Optional;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/post/Post.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/post/Post.java
@@ -1,9 +1,8 @@
 package org.sopt.makers.crew.main.entity.post;
 
-import static org.sopt.makers.crew.main.common.response.ErrorStatus.*;
+import static org.sopt.makers.crew.main.common.exception.ErrorStatus.*;
 
 import io.hypersistence.utils.hibernate.type.array.StringArrayType;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -24,7 +23,6 @@ import lombok.NoArgsConstructor;
 
 import org.hibernate.annotations.Type;
 import org.sopt.makers.crew.main.common.exception.ForbiddenException;
-import org.sopt.makers.crew.main.entity.comment.Comment;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.springframework.data.annotation.CreatedDate;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostRepository.java
@@ -1,10 +1,14 @@
 package org.sopt.makers.crew.main.entity.post;
 
-import static org.sopt.makers.crew.main.common.response.ErrorStatus.NOT_FOUND_POST;
+import static org.sopt.makers.crew.main.common.exception.ErrorStatus.NOT_FOUND_POST;
 
+import java.util.List;
 import java.util.Optional;
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface PostRepository extends JpaRepository<Post, Integer>, PostSearchRepository {
 
@@ -18,4 +22,11 @@ public interface PostRepository extends JpaRepository<Post, Integer>, PostSearch
     Optional<Post> findFirstByMeetingIdOrderByIdDesc(Integer meetingId);
 
     Integer countByMeetingId(Integer meetingId);
+
+    List<Post> findAllByMeetingId(Integer meetingId);
+
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("DELETE FROM Post p WHERE p.meetingId = :meetingId")
+    void deleteAllByMeetingIdQuery(Integer meetingId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostSearchRepositoryImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostSearchRepositoryImpl.java
@@ -1,6 +1,6 @@
 package org.sopt.makers.crew.main.entity.post;
 
-import static org.sopt.makers.crew.main.common.response.ErrorStatus.NOT_FOUND_POST;
+import static org.sopt.makers.crew.main.common.exception.ErrorStatus.NOT_FOUND_POST;
 import static org.sopt.makers.crew.main.entity.comment.QComment.comment;
 import static org.sopt.makers.crew.main.entity.like.QLike.like;
 import static org.sopt.makers.crew.main.entity.meeting.QMeeting.meeting;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
@@ -1,6 +1,6 @@
 package org.sopt.makers.crew.main.entity.user;
 
-import static org.sopt.makers.crew.main.common.response.ErrorStatus.*;
+import static org.sopt.makers.crew.main.common.exception.ErrorStatus.*;
 
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserRepository.java
@@ -1,6 +1,6 @@
 package org.sopt.makers.crew.main.entity.user;
 
-import static org.sopt.makers.crew.main.common.response.ErrorStatus.*;
+import static org.sopt.makers.crew.main.common.exception.ErrorStatus.*;
 
 import java.util.Optional;
 

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/notification/PushNotificationService.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/notification/PushNotificationService.java
@@ -1,6 +1,6 @@
 package org.sopt.makers.crew.main.internal.notification;
 
-import static org.sopt.makers.crew.main.common.response.ErrorStatus.*;
+import static org.sopt.makers.crew.main.common.exception.ErrorStatus.*;
 import static org.sopt.makers.crew.main.internal.notification.PushNotificationEnums.PUSH_NOTIFICATION_ACTION;
 
 import java.util.UUID;

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -104,4 +104,7 @@ public interface MeetingV2Api {
     })
     ResponseEntity<TempResponseDto<MeetingV2GetAllMeetingDto>> getMeetingsTemp(@ModelAttribute MeetingV2GetAllMeetingQueryDto queryCommand,
         Principal principal);
+
+    @Operation(summary = "모임 삭제", description = "모임 삭제합니다.")
+    ResponseEntity<Void> deleteMeeting(@PathVariable("id") Integer meetingId, Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -112,4 +112,13 @@ public class MeetingV2Controller implements MeetingV2Api {
         MeetingV2GetAllMeetingDto meetings = meetingV2Service.getMeetings(queryCommand);
         return ResponseEntity.ok().body(TempResponseDto.of(meetings));
     }
+
+    @Override
+    @DeleteMapping("/{meetingId}")
+    public ResponseEntity<Void> deleteMeeting(@PathVariable("meetingId") Integer meetingId, Principal principal) {
+        Integer userId = UserUtil.getUserId(principal);
+        meetingV2Service.deleteMeeting(meetingId, userId);
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -30,4 +30,6 @@ public interface MeetingV2Service {
                                                  Integer userId);
 
     MeetingV2GetAllMeetingDto getMeetings(MeetingV2GetAllMeetingQueryDto queryCommand);
+
+    void deleteMeeting(Integer meetingId, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -237,15 +237,17 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		return MeetingV2GetAllMeetingDto.of(meetingResponseDtos, pageMetaDto);
 	}
 
+	/**
+	 * @note: 1. like(Comment, post 관련) -> comment -> post 순으로 삭제
+	 * 		  2. apply 삭제
+	 * 		  3. meeting 삭제
+	 * */
+
 	@Override
 	@Transactional
 	public void deleteMeeting(Integer meetingId, Integer userId) {
 		Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
 		meeting.validateMeetingCreator(userId);
-
-		// like(Comment, post) -> comment -> post 순으로 삭제
-		// apply 삭제
-		// meeting 삭제
 
 		List<Post> posts = postRepository.findAllByMeetingId(meetingId);
 		List<Integer> postIds = posts.stream().map(Post::getId).toList();

--- a/main/src/main/java/org/sopt/makers/crew/main/notice/service/NoticeV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/notice/service/NoticeV2Service.java
@@ -1,11 +1,11 @@
 package org.sopt.makers.crew.main.notice.service;
 
-import static org.sopt.makers.crew.main.common.response.ErrorStatus.FORBIDDEN_EXCEPTION;
+import static org.sopt.makers.crew.main.common.exception.ErrorStatus.FORBIDDEN_EXCEPTION;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.sopt.makers.crew.main.common.exception.BadRequestException;
+
 import org.sopt.makers.crew.main.common.exception.ForbiddenException;
 import org.sopt.makers.crew.main.entity.notice.Notice;
 import org.sopt.makers.crew.main.entity.notice.NoticeRepository;

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
@@ -1,7 +1,7 @@
 package org.sopt.makers.crew.main.post.v2.service;
 
 import static java.util.stream.Collectors.toList;
-import static org.sopt.makers.crew.main.common.response.ErrorStatus.FORBIDDEN_EXCEPTION;
+import static org.sopt.makers.crew.main.common.exception.ErrorStatus.FORBIDDEN_EXCEPTION;
 import static org.sopt.makers.crew.main.internal.notification.PushNotificationEnums.NEW_POST_MENTION_PUSH_NOTIFICATION_TITLE;
 import static org.sopt.makers.crew.main.internal.notification.PushNotificationEnums.NEW_POST_PUSH_NOTIFICATION_TITLE;
 import static org.sopt.makers.crew.main.internal.notification.PushNotificationEnums.PUSH_NOTIFICATION_CATEGORY;
@@ -190,7 +190,7 @@ public class PostV2ServiceImpl implements PostV2Service {
 
         commentRepository.deleteAllByPostId(postId);
         likeRepository.deleteAllByPostId(postId);
-        likeRepository.deleteAllByIdsInQuery(commentIds);
+        likeRepository.deleteAllByCommentIdsInQuery(commentIds);
 
         postRepository.delete(post);
     }

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -4,8 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
-import static org.sopt.makers.crew.main.common.response.ErrorStatus.FULL_MEETING_CAPACITY;
-import static org.sopt.makers.crew.main.common.response.ErrorStatus.NOT_IN_APPLY_PERIOD;
+import static org.sopt.makers.crew.main.common.exception.ErrorStatus.FULL_MEETING_CAPACITY;
+import static org.sopt.makers.crew.main.common.exception.ErrorStatus.NOT_IN_APPLY_PERIOD;
 
 import java.time.LocalDateTime;
 import java.time.Month;

--- a/server/src/meeting/v0/meeting-v0.controller.ts
+++ b/server/src/meeting/v0/meeting-v0.controller.ts
@@ -149,6 +149,7 @@ export class MeetingV0Controller {
   @ApiOperation({
     summary: '모임 삭제',
     description: '모임 삭제',
+    deprecated: true,
   })
   @ApiResponse({
     status: HttpStatus.OK,


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 모임 삭제 API 구현

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 삭제할 떄, 최소한의 쿼리를 사용해서 삭제하도록 구현했습니다.

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #312

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?