### PR TITLE
[FEAT] 모임 지원자 상태 변경 API 마이그레이션

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/common/exception/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/exception/ErrorStatus.java
@@ -28,6 +28,7 @@ public enum ErrorStatus {
     NOT_ACTIVE_GENERATION("활동 기수가 아닙니다."),
     NOT_TARGET_PART("지원 가능한 파트가 아닙니다."),
     NOT_FOUND_APPLY("신청상태가 아닌 모임입니다."),
+    ALREADY_PROCESSED_APPLY("이미 해당 상태로 처리된 신청 정보입니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/Apply.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/Apply.java
@@ -1,6 +1,7 @@
 package org.sopt.makers.crew.main.entity.apply;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
+import static org.sopt.makers.crew.main.common.exception.ErrorStatus.*;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -17,6 +18,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.entity.apply.enums.ApplyStatusConverter;
 import org.sopt.makers.crew.main.entity.apply.enums.ApplyTypeConverter;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
@@ -108,5 +111,11 @@ public class Apply {
 
     public void updateApplyStatus(EnApplyStatus status) {
         this.status = status;
+    }
+
+    public void validateDuplicateUpdateApplyStatus(EnApplyStatus updatedApplyStatus){
+        if(updatedApplyStatus.equals(this.getStatus())){
+            throw new BadRequestException(ALREADY_PROCESSED_APPLY.getErrorCode());
+        }
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -27,15 +27,14 @@ import lombok.NoArgsConstructor;
 
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
+import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.common.exception.ForbiddenException;
-import org.sopt.makers.crew.main.entity.apply.Apply;
 import org.sopt.makers.crew.main.entity.meeting.converter.MeetingCategoryConverter;
 import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 import org.sopt.makers.crew.main.entity.user.User;
-import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
@@ -80,7 +79,6 @@ public class Meeting {
 	 */
 	@Column(name = "imageURL", columnDefinition = "jsonb")
 	@Type(JsonBinaryType.class)
-	//@JdbcTypeCode(SqlTypes.JSON)
 	private List<ImageUrlVO> imageURL;
 
 	/**
@@ -229,6 +227,12 @@ public class Meeting {
 
 	public Boolean checkMeetingLeader(Integer userId) {
 		return this.userId.equals(userId);
+	}
+
+	public void validateCapacity(int approvedCount) {
+		if (approvedCount >= this.capacity) {
+			throw new BadRequestException(FULL_MEETING_CAPACITY.getErrorCode());
+		}
 	}
 
 	public void updateMeeting(Meeting updateMeeting) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -17,6 +17,7 @@ import org.sopt.makers.crew.main.common.dto.TempResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.ApplyV2UpdateStatusBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
@@ -106,8 +107,11 @@ public interface MeetingV2Api {
         Principal principal);
 
     @Operation(summary = "모임 삭제", description = "모임 삭제합니다.")
-    ResponseEntity<Void> deleteMeeting(@PathVariable("meetingId") Integer meetingId, Principal principal);
+    ResponseEntity<Void> deleteMeeting(@PathVariable Integer meetingId, Principal principal);
 
     @Operation(summary = "모임 수정", description = "모임 내용을 수정합니다.")
     ResponseEntity<Void> updateMeeting(@PathVariable Integer meetingId, @RequestBody @Valid MeetingV2CreateMeetingBodyDto requestBody ,Principal principal);
+
+    @Operation(summary = "모임 지원자 상태 변경", description = "모임 지원자의 지원 상태를 변경합니다.")
+    ResponseEntity<Void> updateApplyStatus(@PathVariable Integer meetingId, @RequestBody @Valid ApplyV2UpdateStatusBodyDto requestBody ,Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -13,6 +13,7 @@ import org.sopt.makers.crew.main.common.util.UserUtil;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.ApplyV2UpdateStatusBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
@@ -119,7 +120,7 @@ public class MeetingV2Controller implements MeetingV2Api {
 
 	@Override
 	@DeleteMapping("/{meetingId}")
-	public ResponseEntity<Void> deleteMeeting(@PathVariable("meetingId") Integer meetingId, Principal principal) {
+	public ResponseEntity<Void> deleteMeeting(@PathVariable Integer meetingId, Principal principal) {
 		Integer userId = UserUtil.getUserId(principal);
 		meetingV2Service.deleteMeeting(meetingId, userId);
 
@@ -135,6 +136,19 @@ public class MeetingV2Controller implements MeetingV2Api {
 
 		Integer userId = UserUtil.getUserId(principal);
 		meetingV2Service.updateMeeting(meetingId, requestBody, userId);
+
+		return ResponseEntity.ok().build();
+	}
+
+	@Override
+	@PutMapping("/{meetingId}/apply/status")
+	public ResponseEntity<Void> updateApplyStatus(
+		@PathVariable Integer meetingId,
+		@RequestBody @Valid ApplyV2UpdateStatusBodyDto requestBody,
+		Principal principal) {
+
+		Integer userId = UserUtil.getUserId(principal);
+		meetingV2Service.updateApplyStatus(meetingId, requestBody, userId);
 
 		return ResponseEntity.ok().build();
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/ApplyV2UpdateStatusBodyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/ApplyV2UpdateStatusBodyDto.java
@@ -1,0 +1,20 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "모임 지원자 상태 변경 request body dto")
+public class ApplyV2UpdateStatusBodyDto {
+	@Schema(example = "1", description = "신청/지원 id")
+	@NotNull
+	private final Integer applyId;
+
+	@Schema(example = "0", description = "0: 대기, 1: 승인, 2: 거절")
+	@NotNull
+	private final Integer status;
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.ApplyV2UpdateStatusBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
@@ -34,4 +35,6 @@ public interface MeetingV2Service {
     void deleteMeeting(Integer meetingId, Integer userId);
 
     void updateMeeting(Integer meetingId, MeetingV2CreateMeetingBodyDto requestBody, Integer userId);
+
+    void updateApplyStatus(Integer meetingId, ApplyV2UpdateStatusBodyDto requestBody, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -327,9 +327,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 			.filter(apply -> EnApplyStatus.APPROVE.equals(apply.getStatus()))
 			.toList();
 
-		if (approvedApplies.size() >= meeting.getCapacity()) {
-			throw new BadRequestException(FULL_MEETING_CAPACITY.getErrorCode());
-		}
+		meeting.validateCapacity(approvedApplies.size());
 	}
 
 	private void validateUserAlreadyApplied(Integer userId, List<Apply> applies) {

--- a/server/src/meeting/v0/meeting-v0.controller.ts
+++ b/server/src/meeting/v0/meeting-v0.controller.ts
@@ -47,6 +47,7 @@ export class MeetingV0Controller {
   @ApiOperation({
     summary: '모임 지원자 상태 변경',
     description: '모임 지원자 상태 변경',
+    deprecated: true,
   })
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 모임 지원자 상태 변경 API 마이그레이션 했습니다.
- 중복처리에 대한 방어로직도 추가했습니다.
## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #319 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?