### PR TITLE
[CHORE] 광고 조회 API 수정

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/advertisement/dto/AdvertisementGetResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/advertisement/dto/AdvertisementGetResponseDto.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(name = "AdvertisementGetResponseDto", description = "광고 구좌 조회 응답 Dto")
 public record AdvertisementGetResponseDto(
-	@Schema(description = "광고 구좌 이미지 객체", example = "[image Url]")
+	@Schema(description = "광고 구좌 이미지 객체", example = "")
 	@NotNull
 	List<AdvertisementImageDto> advertisementImages,
 	@Schema(description = "광고 구좌 링크", example = "https://www.naver.com")

--- a/main/src/main/java/org/sopt/makers/crew/main/advertisement/dto/AdvertisementGetResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/advertisement/dto/AdvertisementGetResponseDto.java
@@ -1,25 +1,22 @@
 package org.sopt.makers.crew.main.advertisement.dto;
 
-import org.sopt.makers.crew.main.entity.advertisement.Advertisement;
+import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 @Schema(name = "AdvertisementGetResponseDto", description = "광고 구좌 조회 응답 Dto")
 public record AdvertisementGetResponseDto(
-	@Schema(description = "광고 구좌 이미지 url", example = "[image Url]")
+	@Schema(description = "광고 구좌 이미지 객체", example = "[image Url]")
 	@NotNull
-	String advertisementImageUrl,
+	List<AdvertisementImageDto> advertisementImages,
 	@Schema(description = "광고 구좌 링크", example = "https://www.naver.com")
 	@NotNull
 	String advertisementLink
 ) {
-	public static AdvertisementGetResponseDto of(Advertisement advertisement){
-		if(advertisement == null){
-			return new AdvertisementGetResponseDto(null, null);
-		}
+	public static AdvertisementGetResponseDto of(List<AdvertisementImageDto> advertisementImages,
+		String advertisementLink) {
 
-		return new AdvertisementGetResponseDto(advertisement.getAdvertisementImageUrl(),
-			advertisement.getAdvertisementLink());
+		return new AdvertisementGetResponseDto(advertisementImages, advertisementLink);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/advertisement/dto/AdvertisementImageDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/advertisement/dto/AdvertisementImageDto.java
@@ -1,0 +1,19 @@
+package org.sopt.makers.crew.main.advertisement.dto;
+
+import org.sopt.makers.crew.main.entity.advertisement.AdvertisementImage;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+@Schema(name = "AdvertisementImageDto", description = "광고 구좌 이미지 Dto")
+public class AdvertisementImageDto {
+	private final String imageUrl;
+	private final int order;
+
+	public static AdvertisementImageDto of(AdvertisementImage advertisementImage){
+		return new AdvertisementImageDto(advertisementImage.getAdvertisementImageUrl(), advertisementImage.getImageOrder());
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/advertisement/dto/AdvertisementImageDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/advertisement/dto/AdvertisementImageDto.java
@@ -3,6 +3,7 @@ package org.sopt.makers.crew.main.advertisement.dto;
 import org.sopt.makers.crew.main.entity.advertisement.AdvertisementImage;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -10,8 +11,14 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @Schema(name = "AdvertisementImageDto", description = "광고 구좌 이미지 Dto")
 public class AdvertisementImageDto {
+
+	@Schema(description = "광고 구좌 이미지 url", example = "[url 형식]")
+	@NotNull
 	private final String imageUrl;
-	private final int order;
+
+	@Schema(description = "광고 이미지 순서, 서버에서 정렬해서 전달한다. </br> 프론트에서 확인용으로 사용하기 위함", example = "2")
+	@NotNull
+	private final int imageOrder;
 
 	public static AdvertisementImageDto of(AdvertisementImage advertisementImage){
 		return new AdvertisementImageDto(advertisementImage.getAdvertisementImageUrl(), advertisementImage.getImageOrder());

--- a/main/src/main/java/org/sopt/makers/crew/main/advertisement/service/AdvertisementService.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/advertisement/service/AdvertisementService.java
@@ -4,8 +4,11 @@ import java.util.List;
 import java.util.Optional;
 
 import org.sopt.makers.crew.main.advertisement.dto.AdvertisementGetResponseDto;
+import org.sopt.makers.crew.main.advertisement.dto.AdvertisementImageDto;
 import org.sopt.makers.crew.main.common.util.Time;
 import org.sopt.makers.crew.main.entity.advertisement.Advertisement;
+import org.sopt.makers.crew.main.entity.advertisement.AdvertisementImage;
+import org.sopt.makers.crew.main.entity.advertisement.AdvertisementImageRepository;
 import org.sopt.makers.crew.main.entity.advertisement.AdvertisementRepository;
 import org.sopt.makers.crew.main.entity.advertisement.enums.AdvertisementCategory;
 import org.springframework.stereotype.Service;
@@ -18,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class AdvertisementService {
 	private final AdvertisementRepository advertisementRepository;
+	private final AdvertisementImageRepository advertisementImageRepository;
 
 	private final Time time;
 
@@ -25,8 +29,17 @@ public class AdvertisementService {
 		Optional<Advertisement> advertisement = advertisementRepository.findFirstByAdvertisementCategoryAndAdvertisementEndDateBeforeAndAdvertisementStartDateAfterOrderByPriority(
 			advertisementCategory, time.now(), time.now());
 
-		return advertisement
-			.map(AdvertisementGetResponseDto::of)
-			.orElseGet(() -> AdvertisementGetResponseDto.of(null));
+		if (advertisement.isEmpty()) {
+			return AdvertisementGetResponseDto.of(null, null);
+		}
+
+		List<AdvertisementImage> advertisementImages = advertisementImageRepository.findAllByAdvertisementOrderByImageOrder(
+			advertisement.get());
+
+		List<AdvertisementImageDto> imageDtos = advertisementImages.stream()
+			.map(AdvertisementImageDto::of)
+			.toList();
+
+		return AdvertisementGetResponseDto.of(imageDtos, advertisement.get().getAdvertisementLink());
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/advertisement/AdvertisementImage.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/advertisement/AdvertisementImage.java
@@ -1,0 +1,42 @@
+package org.sopt.makers.crew.main.entity.advertisement;
+
+import static jakarta.persistence.GenerationType.*;
+
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "advertisement_image")
+public class AdvertisementImage {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Integer id;
+
+	@NotNull
+	private String advertisementImageUrl;
+
+	@NotNull
+	private Integer imageOrder;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "advertisementId")
+	@NotNull
+	private Advertisement advertisement;
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/advertisement/AdvertisementImageRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/advertisement/AdvertisementImageRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.makers.crew.main.entity.advertisement;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdvertisementImageRepository extends JpaRepository<AdvertisementImage, Long> {
+	List<AdvertisementImage> findAllByAdvertisementOrderByImageOrder(Advertisement advertisement);
+}


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 광고 조회 할 때, 단건 -> 리스트로 수정됨에 따라 변경했습니다.
<img width="807" alt="스크린샷 2024-08-24 오전 12 00 33" src="https://github.com/user-attachments/assets/a73448d4-25a8-4b3f-a9c9-7a00aeb27041">

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #322

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?