### PR TITLE
[FEAT] 모임 상세 조회 API 마이그레이션

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/common/constant/CrewConst.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/constant/CrewConst.java
@@ -5,11 +5,15 @@ public abstract class CrewConst {
     /**
      * 매 기수 시작하기 전에 수정 필요
      * */
-    public final static Integer ACTIVE_GENERATION = 34;
+    public static final Integer ACTIVE_GENERATION = 34;
 
-    public final static String DAY_START_TIME = " 00:00:00";
-    public final static String DAY_END_TIME = " 23:59:59";
+    public static final String DAY_START_TIME = " 00:00:00";
+    public static final String DAY_END_TIME = " 23:59:59";
 
-    public final static String DAY_FORMAT = "yyyy.MM.dd";
-    public final static String DAY_TIME_FORMAT = "yyyy.MM.dd HH:mm:ss";
+    public static final String DAY_FORMAT = "yyyy.MM.dd";
+    public static final String DAY_TIME_FORMAT = "yyyy.MM.dd HH:mm:ss";
+
+    public static final String ORDER_ASC = "asc";
+    public static final String ORDER_DESC = "desc";
+
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/common/dto/MeetingCreatorDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/dto/MeetingCreatorDto.java
@@ -1,38 +1,45 @@
 package org.sopt.makers.crew.main.common.dto;
 
-import org.sopt.makers.crew.main.entity.user.User;
+import java.util.List;
 
-import com.querydsl.core.annotations.QueryProjection;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
-@Schema(name = "MeetingCreatorDto", description = "모임 개설자 Dto")
 @Getter
+@RequiredArgsConstructor
+@Schema(name = "MeetingCreatorDto", description = "모임 개설자 Dto")
 public class MeetingCreatorDto {
 	@Schema(description = "모임장 id, 크루에서 사용하는 userId", example = "1")
 	@NotNull
-	Integer id;
+	private final Integer id;
+
 	@Schema(description = "모임장 이름", example = "홍길동")
 	@NotNull
-	String name;
+	private final String name;
+
 	@Schema(description = "모임장 org id, 메이커스 프로덕트에서 범용적으로 사용하는 userId", example = "1")
 	@NotNull
-	Integer orgId;
-	@Schema(description = "모임장 프로필 사진", example = "[url] 형식")
-	String profileImage;
+	private final Integer orgId;
 
-	@QueryProjection
-	public MeetingCreatorDto(Integer id, String name, Integer orgId, String profileImag) {
-		this.id = id;
-		this.name = name;
-		this.orgId = orgId;
-		this.profileImage = profileImag;
-	}
+	@Schema(description = "모임장 프로필 사진", example = "[url] 형식")
+	private final String profileImage;
+
+	@Schema(description = "활동 기수", example = "")
+	@NotNull
+	private final List<UserActivityVO> activities;
+
+	@Schema(description = "전화번호", example = "01094726796")
+	@NotNull
+	private final String phone;
 
 	public static MeetingCreatorDto of(User user) {
-		return new MeetingCreatorDto(user.getId(), user.getName(), user.getOrgId(), user.getProfileImage());
+		return new MeetingCreatorDto(user.getId(), user.getName(), user.getOrgId(), user.getProfileImage(),
+			user.getActivities(), user.getPhone());
 	}
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/common/dto/MeetingResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/dto/MeetingResponseDto.java
@@ -101,14 +101,14 @@ public class MeetingResponseDto {
 		this.appliedCount = appliedCount;
 	}
 
-	public static MeetingResponseDto of(Meeting meeting, User meetingCreator, int appliedCount){
+	public static MeetingResponseDto of(Meeting meeting, User meetingCreator, int appliedCount, LocalDateTime now){
 		MeetingCreatorDto creatorDto = MeetingCreatorDto.of(meetingCreator);
 		boolean canJoinOnlyActiveGeneration = meeting.getTargetActiveGeneration() == CrewConst.ACTIVE_GENERATION
 			&& meeting.getCanJoinOnlyActiveGeneration();
 
 		return new MeetingResponseDto(meeting.getId(), meeting.getTitle(),
 			meeting.getTargetActiveGeneration(), meeting.getJoinableParts(), meeting.getCategory(),
-			canJoinOnlyActiveGeneration, meeting.getMeetingStatus(), meeting.getImageURL(),
+			canJoinOnlyActiveGeneration, meeting.getMeetingStatus(now), meeting.getImageURL(),
 			meeting.getIsMentorNeeded(), meeting.getMStartDate(), meeting.getMEndDate(), meeting.getCapacity(), creatorDto, appliedCount);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/Applies.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/Applies.java
@@ -4,9 +4,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
+
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Getter
 public class Applies {
 
 	/**
@@ -30,5 +34,22 @@ public class Applies {
 			return 0;
 		}
 		return applies.size();
+	}
+
+	public long getApprovedCount(Integer meetingId) {
+		return appliesMap.get(meetingId).stream()
+			.filter(apply -> apply.getStatus().equals(EnApplyStatus.APPROVE))
+			.count();
+	}
+
+	public Boolean isApply(Integer meetingId, Integer userId) {
+		return appliesMap.get(meetingId).stream()
+			.anyMatch(apply -> apply.getUserId().equals(userId));
+	}
+
+	public Boolean isApproved(Integer meetingId, Integer userId) {
+		return appliesMap.get(meetingId).stream()
+			.anyMatch(apply -> apply.getUserId().equals(userId)
+				&& apply.getStatus().equals(EnApplyStatus.APPROVE));
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/Apply.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/Apply.java
@@ -118,4 +118,12 @@ public class Apply {
             throw new BadRequestException(ALREADY_PROCESSED_APPLY.getErrorCode());
         }
     }
+
+    public String getContent(Integer requestUserId){
+        if(!this.userId.equals(requestUserId)){
+            return "";
+        }
+
+        return this.content;
+    }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepositoryImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplySearchRepositoryImpl.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.crew.main.entity.apply;
 
+import static org.sopt.makers.crew.main.common.constant.CrewConst.*;
 import static org.sopt.makers.crew.main.entity.apply.QApply.apply;
 import static org.sopt.makers.crew.main.entity.user.QUser.user;
 
@@ -47,7 +48,7 @@ public class ApplySearchRepositoryImpl implements ApplySearchRepository {
                         apply.meetingId.eq(meetingId),
                         apply.status.in(queryCommand.getStatus())
                 )
-                .orderBy(queryCommand.getDate().equals("desc") ? apply.appliedDate.desc() : apply.appliedDate.asc())
+                .orderBy(queryCommand.getDate().equals(ORDER_DESC) ? apply.appliedDate.desc() : apply.appliedDate.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -208,8 +208,8 @@ public class Meeting {
 	 *
 	 * @return 모임 모집상태
 	 */
-	public Integer getMeetingStatus() {
-		LocalDateTime now = LocalDateTime.now();
+	public Integer getMeetingStatus(LocalDateTime now) {
+
 		if (now.isBefore(startDate)) {
 			return EnMeetingStatus.BEFORE_START.getValue();
 		} else if (now.isBefore(endDate)) {

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/vo/UserActivityVO.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/vo/UserActivityVO.java
@@ -1,5 +1,7 @@
 package org.sopt.makers.crew.main.entity.user.vo;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -9,7 +11,12 @@ import lombok.ToString;
 @ToString
 public class UserActivityVO {
 
-  private final String part;
-  private final int generation;
+    @Schema(description = "파트", example = "서버")
+    @NotNull
+    private final String part;
+
+    @Schema(description = "기수", example = "36")
+    @NotNull
+    private final int generation;
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -29,6 +29,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingR
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingByIdResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.PreSignedUrlResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -129,4 +130,9 @@ public interface MeetingV2Api {
         @RequestParam(name = "type") List<Integer> type,
         @RequestParam(name = "order", required = false, defaultValue = "desc") String order,
         Principal principal);
+
+    @Operation(summary = "모임 상세 조회", description = "모임 상세 조회")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "모임 상세 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "모임이 없습니다.", content = @Content),})
+    ResponseEntity<MeetingV2GetMeetingByIdResponseDto> getMeetingById(@PathVariable Integer meetingId, Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -25,6 +25,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingR
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingByIdResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.PreSignedUrlResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.service.MeetingV2Service;
 import org.springframework.http.HttpStatus;
@@ -182,5 +183,13 @@ public class MeetingV2Controller implements MeetingV2Api {
 		AppliesCsvFileUrlResponseDto responseDto = meetingV2Service.getAppliesCsvFileUrl(meetingId, status, order, userId);
 
 		return ResponseEntity.ok(responseDto);
+	}
+
+	@Override
+	@GetMapping("/{meetingId}")
+	public ResponseEntity<MeetingV2GetMeetingByIdResponseDto> getMeetingById(@PathVariable Integer meetingId, Principal principal) {
+		Integer userId = UserUtil.getUserId(principal);
+
+		return ResponseEntity.ok(meetingV2Service.getMeetingById(meetingId, userId));
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplicantByMeetingDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplicantByMeetingDto.java
@@ -29,7 +29,7 @@ public class ApplicantByMeetingDto {
 
 	@Schema(description = "신청자 기수 정보", example = "[{\"part\": \"웹\", \"generation\": 32}]")
 	@NotNull
-	private final List<UserActivityVO> recentActivity;
+	private final List<UserActivityVO> activities;
 
 	@Schema(description = "신청자 프로필 사진", example = "[url] 형식")
 	private final String profileImage;

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplicantByMeetingDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplicantByMeetingDto.java
@@ -1,0 +1,44 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Schema(name = "ApplicantByMeetingDto", description = "모임 신청자 객체 Dto")
+public class ApplicantByMeetingDto {
+
+	@Schema(description = "신청자 id, 크루에서 사용하는 userId", example = "1")
+	@NotNull
+	private final Integer id;
+
+	@Schema(description = "신청자 이름", example = "송민규")
+	@NotNull
+	private final String name;
+
+	@Schema(description = "신청자 org id, 메이커스 프로덕트에서 범용적으로 사용하는 userId", example = "1")
+	@NotNull
+	private final Integer orgId;
+
+	@Schema(description = "신청자 기수 정보", example = "[{\"part\": \"웹\", \"generation\": 32}]")
+	@NotNull
+	private final List<UserActivityVO> recentActivity;
+
+	@Schema(description = "신청자 프로필 사진", example = "[url] 형식")
+	private final String profileImage;
+
+	@Schema(description = "신청자 핸드폰 번호", example = "010-1234-5678")
+	private final String phone;
+
+	public static ApplicantByMeetingDto of(User user){
+		return new ApplicantByMeetingDto(user.getId(), user.getName(), user.getOrgId(), user.getActivities(),
+			user.getProfileImage(), user.getPhone());
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyWholeInfoDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyWholeInfoDto.java
@@ -27,6 +27,10 @@ public class ApplyWholeInfoDto {
 	@NotNull
 	private final Integer meetingId;
 
+	@Schema(description = "신청자 id", example = "184")
+	@NotNull
+	private final Integer userId;
+
 	@Schema(description = "신청 내용", example = "모임장에게 전하는 말입니다.")
 	@NotNull
 	private final String content;
@@ -47,7 +51,7 @@ public class ApplyWholeInfoDto {
 
 		ApplicantByMeetingDto applicantByMeetingDto = ApplicantByMeetingDto.of(user);
 
-		return new ApplyWholeInfoDto(apply.getId(), apply.getType().getValue(), apply.getMeetingId(),
+		return new ApplyWholeInfoDto(apply.getId(), apply.getType().getValue(), apply.getMeetingId(), apply.getUserId(),
 			apply.getContent(requestUserId), apply.getAppliedDate(), apply.getStatus().getValue(),
 			applicantByMeetingDto);
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyWholeInfoDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyWholeInfoDto.java
@@ -1,0 +1,54 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import java.time.LocalDateTime;
+
+import org.sopt.makers.crew.main.entity.apply.Apply;
+import org.sopt.makers.crew.main.entity.user.User;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Schema(description = "신청 정보 조회 dto")
+public class ApplyWholeInfoDto {
+
+	@Schema(description = "신청 id", example = "3")
+	@NotNull
+	private final Integer id;
+
+	@Schema(description = "신청 타입", example = "0")
+	@NotNull
+	private final Integer type;
+
+	@Schema(description = "모임 id", example = "13")
+	@NotNull
+	private final Integer meetingId;
+
+	@Schema(description = "신청 내용", example = "모임장에게 전하는 말입니다.")
+	@NotNull
+	private final String content;
+
+	@Schema(description = "신청 날짜 및 시간", example = "2024-10-13T23:59:59")
+	@NotNull
+	private final LocalDateTime appliedDate;
+
+	@Schema(description = "신청 상태", example = "1")
+	@NotNull
+	private final Integer status;
+
+	@Schema(description = "신청자 객체", example = "")
+	@NotNull
+	private final ApplicantByMeetingDto user;
+
+	public static ApplyWholeInfoDto of(Apply apply, User user, Integer requestUserId) {
+
+		ApplicantByMeetingDto applicantByMeetingDto = ApplicantByMeetingDto.of(user);
+
+		return new ApplyWholeInfoDto(apply.getId(), apply.getType().getValue(), apply.getMeetingId(),
+			apply.getContent(requestUserId), apply.getAppliedDate(), apply.getStatus().getValue(),
+			applicantByMeetingDto);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
@@ -23,6 +23,10 @@ public class MeetingV2GetMeetingByIdResponseDto {
 	@NotNull
 	private final Integer id;
 
+	@Schema(description = "모임장 id", example = "184")
+	@NotNull
+	private final Integer userId;
+
 	@Schema(description = "모임 제목", example = "모임 제목입니다.")
 	@NotNull
 	private final String title;
@@ -33,7 +37,7 @@ public class MeetingV2GetMeetingByIdResponseDto {
 
 	@Schema(description = "모임 이미지", example = "[url 형식]")
 	@NotNull
-	private final List<ImageUrlVO> imageURLs;
+	private final List<ImageUrlVO> imageURL;
 
 	@Schema(description = "모임 신청 시작 시간", example = "2024-07-10T15:30:00")
 	@NotNull
@@ -138,12 +142,20 @@ public class MeetingV2GetMeetingByIdResponseDto {
 
 		Integer meetingStatus = meeting.getMeetingStatus(now);
 
-		return new MeetingV2GetMeetingByIdResponseDto(meeting.getId(), meeting.getTitle(),
+		return new MeetingV2GetMeetingByIdResponseDto(meeting.getId(), meeting.getUserId(), meeting.getTitle(),
 			meeting.getCategory().getValue(), meeting.getImageURL(), meeting.getStartDate(), meeting.getEndDate(),
 			meeting.getCapacity(), meeting.getDesc(), meeting.getProcessDesc(), meeting.getMStartDate(),
 			meeting.getMEndDate(), meeting.getLeaderDesc(), meeting.getTargetDesc(), meeting.getNote(),
 			meeting.getIsMentorNeeded(), meeting.getCanJoinOnlyActiveGeneration(), meeting.getCreatedGeneration(),
 			meeting.getTargetActiveGeneration(), meeting.getJoinableParts(), meetingStatus,
 			approvedCount, isHost, isApply, isApproved, meetingCreatorDto, appliedInfo);
+	}
+
+	public LocalDateTime getmStartDate() {
+		return mStartDate;
+	}
+
+	public LocalDateTime getmEndDate() {
+		return mEndDate;
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
@@ -132,11 +132,11 @@ public class MeetingV2GetMeetingByIdResponseDto {
 
 	public static MeetingV2GetMeetingByIdResponseDto of(Meeting meeting, long approvedCount, Boolean isHost, Boolean isApply,
 		Boolean isApproved, User meetingCreator,
-		List<ApplyWholeInfoDto> appliedInfo) {
+		List<ApplyWholeInfoDto> appliedInfo, LocalDateTime now) {
 
 		MeetingCreatorDto meetingCreatorDto = MeetingCreatorDto.of(meetingCreator);
 
-		Integer meetingStatus = meeting.getMeetingStatus();
+		Integer meetingStatus = meeting.getMeetingStatus(now);
 
 		return new MeetingV2GetMeetingByIdResponseDto(meeting.getId(), meeting.getTitle(),
 			meeting.getCategory().getValue(), meeting.getImageURL(), meeting.getStartDate(), meeting.getEndDate(),

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
@@ -1,0 +1,149 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.sopt.makers.crew.main.common.dto.MeetingCreatorDto;
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+import org.sopt.makers.crew.main.entity.user.User;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Schema(description = "모임 상세 조회 dto")
+public class MeetingV2GetMeetingByIdResponseDto {
+
+	@Schema(description = "모임 id", example = "2")
+	@NotNull
+	private final Integer id;
+
+	@Schema(description = "모임 제목", example = "모임 제목입니다.")
+	@NotNull
+	private final String title;
+
+	@Schema(description = "모임 카테고리", example = "스터디")
+	@NotNull
+	private final String category;
+
+	@Schema(description = "모임 이미지", example = "[url 형식]")
+	@NotNull
+	private final List<ImageUrlVO> imageURLs;
+
+	@Schema(description = "모임 신청 시작 시간", example = "2024-07-10T15:30:00")
+	@NotNull
+	private final LocalDateTime startDate;
+
+	@Schema(description = "모임 신청 종료 시간", example = "2024-07-30T23:59:59")
+	@NotNull
+	private final LocalDateTime endDate;
+
+	@Schema(description = "모집 인원", example = "23")
+	@NotNull
+	private final int capacity;
+
+	@Schema(description = "모임 소개", example = "모임 소개 입니다.")
+	@NotNull
+	private final String desc;
+
+	@Schema(description = "진행방식 소개", example = "진행방식 설명입니다.")
+	@NotNull
+	private final String processDesc;
+
+	@Schema(description = "모임 활동 시작 시간", example = "2024-08-13T15:30:00")
+	@NotNull
+	private final LocalDateTime mStartDate;
+
+	@Schema(description = "모임 활동 종료 시간", example = "2024-10-13T23:59:59")
+	@NotNull
+	private final LocalDateTime mEndDate;
+
+	@Schema(description = "개설자 소개", example = "개설자 소개 입니다.")
+	@NotNull
+	private final String leaderDesc;
+
+	@Schema(description = "모집 대상 소개", example = "모집 대상 소개입니다.")
+	@NotNull
+	private final String targetDesc;
+
+	@Schema(description = "유의사항", example = "유의사항입니다.")
+	@NotNull
+	private final String note;
+
+	@Schema(description = "멘토 필요 여부", example = "true")
+	@NotNull
+	private final Boolean isMentorNeeded;
+
+	@Schema(description = "활동 기수만 신청가능한 여부", example = "false")
+	@NotNull
+	private final Boolean canJoinOnlyActiveGeneration;
+
+	@Schema(description = "개설 기수", example = "36")
+	@NotNull
+	private final Integer createdGeneration;
+
+	@Schema(description = "모집 대상 기수", example = "36")
+	@NotNull
+	private final Integer targetActiveGeneration;
+
+	@Schema(description = "모집 대상 파트", example = "[\n"
+		+ "            \"PM\",\n"
+		+ "            \"DESIGN\",\n"
+		+ "            \"WEB\",\n"
+		+ "            \"ANDROID\",\n"
+		+ "            \"IOS\",\n"
+		+ "            \"SERVER\"\n"
+		+ "        ]")
+	@NotNull
+	private final MeetingJoinablePart[] joinableParts;
+
+	@Schema(description = "모임 상태, 0: 모집전, 1: 모집중, 2: 모집종료", example = "1")
+	@NotNull
+	private final Integer status;
+
+	@Schema(description = "승인된 신청 수", example = "7")
+	@NotNull
+	private final long approvedApplyCount;
+
+	@Schema(description = "모임 개설자 여부", example = "true")
+	@NotNull
+	private final Boolean host;
+
+	@Schema(description = "모임 신청 여부", example = "false")
+	@NotNull
+	private final Boolean apply;
+
+	@Schema(description = "모임 승인 여부", example = "false")
+	@NotNull
+	private final Boolean approved;
+
+	@Schema(description = "모임장 객체", example = "")
+	@NotNull
+	private final MeetingCreatorDto user;
+
+	@Schema(description = "신청 목록", example = "")
+	@NotNull
+	private final List<ApplyWholeInfoDto> appliedInfo;
+
+	public static MeetingV2GetMeetingByIdResponseDto of(Meeting meeting, long approvedCount, Boolean isHost, Boolean isApply,
+		Boolean isApproved, User meetingCreator,
+		List<ApplyWholeInfoDto> appliedInfo) {
+
+		MeetingCreatorDto meetingCreatorDto = MeetingCreatorDto.of(meetingCreator);
+
+		Integer meetingStatus = meeting.getMeetingStatus();
+
+		return new MeetingV2GetMeetingByIdResponseDto(meeting.getId(), meeting.getTitle(),
+			meeting.getCategory().getValue(), meeting.getImageURL(), meeting.getStartDate(), meeting.getEndDate(),
+			meeting.getCapacity(), meeting.getDesc(), meeting.getProcessDesc(), meeting.getMStartDate(),
+			meeting.getMEndDate(), meeting.getLeaderDesc(), meeting.getTargetDesc(), meeting.getNote(),
+			meeting.getIsMentorNeeded(), meeting.getCanJoinOnlyActiveGeneration(), meeting.getCreatedGeneration(),
+			meeting.getTargetActiveGeneration(), meeting.getJoinableParts(), meetingStatus,
+			approvedCount, isHost, isApply, isApproved, meetingCreatorDto, appliedInfo);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -14,6 +14,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingR
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingByIdResponseDto;
 
 public interface MeetingV2Service {
 
@@ -40,4 +41,6 @@ public interface MeetingV2Service {
     void updateApplyStatus(Integer meetingId, ApplyV2UpdateStatusBodyDto requestBody, Integer userId);
 
     AppliesCsvFileUrlResponseDto getAppliesCsvFileUrl(Integer meetingId, List<Integer> status, String order, Integer userId);
+
+    MeetingV2GetMeetingByIdResponseDto getMeetingById(Integer meetingId, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -154,7 +154,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 					meeting.getEndDate(),
 					meeting.getCapacity(), recentActivityDate, meeting.getTargetActiveGeneration(),
 					meeting.getJoinableParts(), applicantCount, appliedUserCount, meetingLeaderDto,
-					meeting.getMeetingStatus());
+					meeting.getMeetingStatus(time.now()));
 			}).toList();
 	}
 
@@ -236,7 +236,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
 		List<MeetingResponseDto> meetingResponseDtos = meetings.getContent().stream()
 			.map(meeting -> MeetingResponseDto.of(meeting, meeting.getUser(),
-				allApplies.getAppliedCount(meeting.getId())))
+				allApplies.getAppliedCount(meeting.getId()), time.now()))
 			.toList();
 
 		PageOptionsDto pageOptionsDto = new PageOptionsDto(queryCommand.getPage(), queryCommand.getTake());
@@ -345,7 +345,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
 
 		return MeetingV2GetMeetingByIdResponseDto.of(meeting, approvedCount, isHost, isApply, isApproved,
-			meetingCreator, applyWholeInfoDtos);
+			meetingCreator, applyWholeInfoDtos, time.now());
 	}
 
 	private void deleteCsvFile(String filePath) {

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
@@ -66,14 +66,14 @@ public record MeetingV2GetCreatedMeetingByUserResponseDto(
 	@NotNull
 	int appliedCount
 ) {
-	public static MeetingV2GetCreatedMeetingByUserResponseDto of(Meeting meeting, User meetingCreator, int appliedCount) {
+	public static MeetingV2GetCreatedMeetingByUserResponseDto of(Meeting meeting, User meetingCreator, int appliedCount, LocalDateTime now) {
 		MeetingCreatorDto creatorDto = MeetingCreatorDto.of(meetingCreator);
 		boolean canJoinOnlyActiveGeneration = meeting.getTargetActiveGeneration() == CrewConst.ACTIVE_GENERATION
 			&& meeting.getCanJoinOnlyActiveGeneration();
 
 		return new MeetingV2GetCreatedMeetingByUserResponseDto(meeting.getId(), meeting.getTitle(),
 			meeting.getTargetActiveGeneration(), meeting.getJoinableParts(), meeting.getCategory().getValue(),
-			canJoinOnlyActiveGeneration, meeting.getMeetingStatus(), meeting.getImageURL(),
+			canJoinOnlyActiveGeneration, meeting.getMeetingStatus(now), meeting.getImageURL(),
 			meeting.getIsMentorNeeded(), meeting.getMStartDate(), meeting.getMEndDate(), meeting.getCapacity(), creatorDto, appliedCount);
 	}
 

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 
 import org.sopt.makers.crew.main.common.exception.BaseException;
+import org.sopt.makers.crew.main.common.util.Time;
 import org.sopt.makers.crew.main.entity.apply.Applies;
 import org.sopt.makers.crew.main.entity.apply.Apply;
 import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
@@ -35,6 +36,8 @@ public class UserV2ServiceImpl implements UserV2Service {
 	private final UserRepository userRepository;
 	private final ApplyRepository applyRepository;
 	private final MeetingRepository meetingRepository;
+
+	private final Time time;
 
 	@Override
 	public List<UserV2GetAllMeetingByUserMeetingDto> getAllMeetingByUser(Integer userId) {
@@ -93,7 +96,7 @@ public class UserV2ServiceImpl implements UserV2Service {
 
 		List<MeetingV2GetCreatedMeetingByUserResponseDto> meetingByUserDtos = meetings.stream()
 			.map(meeting -> MeetingV2GetCreatedMeetingByUserResponseDto.of(meeting, meetingCreator,
-				applies.getAppliedCount(meeting.getId())))
+				applies.getAppliedCount(meeting.getId()), time.now()))
 			.toList();
 
 		return UserV2GetCreatedMeetingByUserResponseDto.of(meetingByUserDtos);
@@ -110,7 +113,7 @@ public class UserV2ServiceImpl implements UserV2Service {
 			.map(apply -> ApplyV2GetAppliedMeetingByUserResponseDto.of(
 				apply.getId(), apply.getStatus().getValue(),
 				MeetingV2GetCreatedMeetingByUserResponseDto.of(apply.getMeeting(), apply.getMeeting().getUser(),
-					allApplies.getAppliedCount(apply.getMeetingId()))
+					allApplies.getAppliedCount(apply.getMeetingId()), time.now())
 			)).toList();
 
 		return UserV2GetAppliedMeetingByUserResponseDto.of(appliedMeetingByUserDtos);

--- a/main/src/test/java/org/sopt/makers/crew/main/entity/apply/AppliesTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/entity/apply/AppliesTest.java
@@ -1,0 +1,218 @@
+package org.sopt.makers.crew.main.entity.apply;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyType;
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
+
+public class AppliesTest {
+
+	@Test
+	void 승인된_신청자_수_조회(){
+		// given
+		User host = User.builder().name("김철수")
+			.orgId(1)
+			.activities(List.of(new UserActivityVO("웹", 31)))
+			.profileImage(null)
+			.phone("010-2222-2222")
+			.build();
+
+		Meeting meeting = Meeting.builder()
+			.user(host)
+			.title("모임 제목입니다")
+			.category(MeetingCategory.EVENT)
+			.startDate(LocalDateTime.of(2024,4,24,0,0,0))
+			.endDate(LocalDateTime.of(2024,4,29,23,59,59))
+			.capacity(20)
+			.desc("모임 소개입니다")
+			.processDesc("진행방식 소개입니다")
+			.mStartDate(LocalDateTime.of(2024,5,24,0,0,0))
+			.mEndDate(LocalDateTime.of(2024,6,24,0,0,0))
+			.leaderDesc("스장 소개입니다")
+			.targetDesc("모집 대상입니다")
+			.isMentorNeeded(true)
+			.canJoinOnlyActiveGeneration(false)
+			.createdGeneration(34)
+			.targetActiveGeneration(null)
+			.joinableParts(MeetingJoinablePart.values())
+			.build();
+
+		User applicant1 = User.builder().name("홍길동")
+			.orgId(2)
+			.activities(List.of(new UserActivityVO("서버", 33)))
+			.profileImage(null)
+			.phone("010-1234-5678")
+			.build();
+
+		User applicant2 = User.builder().name("김삼순")
+			.orgId(3)
+			.activities(List.of(new UserActivityVO("디자인", 34)))
+			.profileImage(null)
+			.phone("010-1111-1111")
+			.build();
+
+		Apply apply1 = Apply.builder()
+			.type(EnApplyType.APPLY)
+			.user(applicant1)
+			.userId(2)
+			.content("지원동기입니다1")
+			.meeting(meeting)
+			.meetingId(1)
+			.build();
+
+		Apply apply2 = Apply.builder()
+			.type(EnApplyType.APPLY)
+			.user(applicant2)
+			.userId(3)
+			.content("지원동기입니다2")
+			.meeting(meeting)
+			.meetingId(1)
+			.build();
+		apply2.updateApplyStatus(EnApplyStatus.APPROVE);
+
+		Applies applyGroups = new Applies(List.of(apply1, apply2));
+
+		// when
+		long approvedCount = applyGroups.getApprovedCount(1);
+
+		// then
+		Assertions.assertThat(approvedCount).isEqualTo(1L);
+	}
+
+	@Test
+	void 특정_사용자가_신청했는지_조회(){
+		// given
+		User host = User.builder().name("김철수")
+			.orgId(1)
+			.activities(List.of(new UserActivityVO("웹", 31)))
+			.profileImage(null)
+			.phone("010-2222-2222")
+			.build();
+
+		Meeting meeting = Meeting.builder()
+			.user(host)
+			.title("모임 제목입니다")
+			.category(MeetingCategory.EVENT)
+			.startDate(LocalDateTime.of(2024,4,24,0,0,0))
+			.endDate(LocalDateTime.of(2024,4,29,23,59,59))
+			.capacity(20)
+			.desc("모임 소개입니다")
+			.processDesc("진행방식 소개입니다")
+			.mStartDate(LocalDateTime.of(2024,5,24,0,0,0))
+			.mEndDate(LocalDateTime.of(2024,6,24,0,0,0))
+			.leaderDesc("스장 소개입니다")
+			.targetDesc("모집 대상입니다")
+			.isMentorNeeded(true)
+			.canJoinOnlyActiveGeneration(false)
+			.createdGeneration(34)
+			.targetActiveGeneration(null)
+			.joinableParts(MeetingJoinablePart.values())
+			.build();
+
+		User applicant1 = User.builder().name("홍길동")
+			.orgId(2)
+			.activities(List.of(new UserActivityVO("서버", 33)))
+			.profileImage(null)
+			.phone("010-1234-5678")
+			.build();
+
+		Apply apply1 = Apply.builder()
+			.type(EnApplyType.APPLY)
+			.user(applicant1)
+			.userId(2)
+			.content("지원동기입니다1")
+			.meeting(meeting)
+			.meetingId(1)
+			.build();
+
+		Applies applies = new Applies(List.of(apply1));
+
+		// when
+		Boolean isApply = applies.isApply(1,2);
+
+		// then
+		Assertions.assertThat(isApply).isEqualTo(true);
+	}
+
+	@Test
+	void 특정_사용자가_승인되었는지_조회(){
+		// given
+		User host = User.builder().name("김철수")
+			.orgId(1)
+			.activities(List.of(new UserActivityVO("웹", 31)))
+			.profileImage(null)
+			.phone("010-2222-2222")
+			.build();
+
+		Meeting meeting = Meeting.builder()
+			.user(host)
+			.title("모임 제목입니다")
+			.category(MeetingCategory.EVENT)
+			.startDate(LocalDateTime.of(2024,4,24,0,0,0))
+			.endDate(LocalDateTime.of(2024,4,29,23,59,59))
+			.capacity(20)
+			.desc("모임 소개입니다")
+			.processDesc("진행방식 소개입니다")
+			.mStartDate(LocalDateTime.of(2024,5,24,0,0,0))
+			.mEndDate(LocalDateTime.of(2024,6,24,0,0,0))
+			.leaderDesc("스장 소개입니다")
+			.targetDesc("모집 대상입니다")
+			.isMentorNeeded(true)
+			.canJoinOnlyActiveGeneration(false)
+			.createdGeneration(34)
+			.targetActiveGeneration(null)
+			.joinableParts(MeetingJoinablePart.values())
+			.build();
+
+		User applicant1 = User.builder().name("홍길동")
+			.orgId(2)
+			.activities(List.of(new UserActivityVO("서버", 33)))
+			.profileImage(null)
+			.phone("010-1234-5678")
+			.build();
+
+		User applicant2 = User.builder().name("김삼순")
+			.orgId(3)
+			.activities(List.of(new UserActivityVO("디자인", 34)))
+			.profileImage(null)
+			.phone("010-1111-1111")
+			.build();
+
+		Apply apply1 = Apply.builder()
+			.type(EnApplyType.APPLY)
+			.user(applicant1)
+			.userId(2)
+			.content("지원동기입니다1")
+			.meeting(meeting)
+			.meetingId(1)
+			.build();
+
+		Apply apply2 = Apply.builder()
+			.type(EnApplyType.APPLY)
+			.user(applicant2)
+			.userId(3)
+			.content("지원동기입니다2")
+			.meeting(meeting)
+			.meetingId(1)
+			.build();
+		apply2.updateApplyStatus(EnApplyStatus.APPROVE);
+
+		Applies applies = new Applies(List.of(apply1, apply2));
+
+		// when
+		Boolean isApproved1 = applies.isApproved(1,2);
+		Boolean isApproved2 = applies.isApproved(1,3);
+
+		// then
+		Assertions.assertThat(isApproved1).isEqualTo(false);
+		Assertions.assertThat(isApproved2).isEqualTo(true);
+	}
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/entity/meeting/MeetingTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/entity/meeting/MeetingTest.java
@@ -1,0 +1,108 @@
+package org.sopt.makers.crew.main.entity.meeting;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
+
+public class MeetingTest {
+
+	@Test
+	void 스터디장인지_확인(){
+		// given
+		User host = User.builder().name("김철수")
+			.orgId(1)
+			.activities(List.of(new UserActivityVO("웹", 31)))
+			.profileImage(null)
+			.phone("010-2222-2222")
+			.build();
+
+		Meeting meeting = Meeting.builder()
+			.user(host)
+			.userId(1)
+			.title("모임 제목입니다")
+			.category(MeetingCategory.EVENT)
+			.startDate(LocalDateTime.of(2024,4,24,0,0,0))
+			.endDate(LocalDateTime.of(2024,4,29,23,59,59))
+			.capacity(20)
+			.desc("모임 소개입니다")
+			.processDesc("진행방식 소개입니다")
+			.mStartDate(LocalDateTime.of(2024,5,24,0,0,0))
+			.mEndDate(LocalDateTime.of(2024,6,24,0,0,0))
+			.leaderDesc("스장 소개입니다")
+			.targetDesc("모집 대상입니다")
+			.isMentorNeeded(true)
+			.canJoinOnlyActiveGeneration(false)
+			.createdGeneration(34)
+			.targetActiveGeneration(null)
+			.joinableParts(MeetingJoinablePart.values())
+			.build();
+
+		// when
+		Boolean isHost1 = meeting.checkMeetingLeader(1);
+		Boolean isHost2 = meeting.checkMeetingLeader(2);
+
+		// then
+		Assertions.assertThat(isHost1).isEqualTo(true);
+		Assertions.assertThat(isHost2).isEqualTo(false);
+	}
+
+	@Test
+	void 신청기간_이전에_모임_모집상태_확인(){
+		// given
+		User hostFixture = createHostFixture();
+
+		Meeting meeting = Meeting.builder()
+			.user(hostFixture)
+			.userId(1)
+			.title("모임 제목입니다")
+			.category(MeetingCategory.EVENT)
+			.startDate(LocalDateTime.of(2024,4,24,0,0,0))
+			.endDate(LocalDateTime.of(2024,4,29,23,59,59))
+			.capacity(20)
+			.desc("모임 소개입니다")
+			.processDesc("진행방식 소개입니다")
+			.mStartDate(LocalDateTime.of(2024,5,24,0,0,0))
+			.mEndDate(LocalDateTime.of(2024,6,24,0,0,0))
+			.leaderDesc("스장 소개입니다")
+			.targetDesc("모집 대상입니다")
+			.isMentorNeeded(true)
+			.canJoinOnlyActiveGeneration(false)
+			.createdGeneration(34)
+			.targetActiveGeneration(null)
+			.joinableParts(MeetingJoinablePart.values())
+			.build();
+
+		// when
+		Integer beforeRecruitment = meeting.getMeetingStatus(LocalDateTime.of(2024, 4, 23, 23, 59, 59));
+		Integer recruiting = meeting.getMeetingStatus(LocalDateTime.of(2024, 4, 24, 0, 0, 0));
+		Integer closeRecruitment = meeting.getMeetingStatus(LocalDateTime.of(2024, 4, 30, 0, 0, 0));
+		Integer active = meeting.getMeetingStatus(LocalDateTime.of(2024, 5, 24, 0, 0, 0));
+		Integer activityEnd = meeting.getMeetingStatus(LocalDateTime.of(2024, 6, 24, 0, 0, 1));
+
+
+		// then
+		Assertions.assertThat(beforeRecruitment).isEqualTo(EnMeetingStatus.BEFORE_START.getValue());
+		Assertions.assertThat(recruiting).isEqualTo(EnMeetingStatus.APPLY_ABLE.getValue());
+		Assertions.assertThat(closeRecruitment).isEqualTo(EnMeetingStatus.RECRUITMENT_COMPLETE.getValue());
+		Assertions.assertThat(active).isEqualTo(EnMeetingStatus.RECRUITMENT_COMPLETE.getValue());
+		Assertions.assertThat(activityEnd).isEqualTo(EnMeetingStatus.RECRUITMENT_COMPLETE.getValue());
+
+	}
+
+	private User createHostFixture(){
+		return User.builder().name("김철수")
+			.orgId(1)
+			.activities(List.of(new UserActivityVO("웹", 31)))
+			.profileImage(null)
+			.phone("010-2222-2222")
+			.build();
+	}
+
+}

--- a/server/src/meeting/v0/meeting-v0.controller.ts
+++ b/server/src/meeting/v0/meeting-v0.controller.ts
@@ -117,6 +117,7 @@ export class MeetingV0Controller {
   @ApiOperation({
     summary: '모임 상세 조회',
     description: '모임 상세 조회',
+    deprecated: true,
   })
   @ApiOkResponseCommon(MeetingV0GetMeetingByIdResponseDto)
   @ApiResponse({


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 모임 상세 조회 API를 마이그레이션 했습니다.
<img width="774" alt="스크린샷 2024-08-24 오후 9 51 00" src="https://github.com/user-attachments/assets/c177869f-ec38-4df8-8fda-a949af374ca2">

## 📝 Review Note
### 일급컬렉션
- `List<Apply>` 부분을 `Applies` 라는 일급컬렉션을 만들어 관련 로직을 해당 클래스 내에 넣었습니다. 개인적으로 이런식으로 하는게 객체지향적이다 싶어서 추가해봤는데요! 변수명부터 시작해서 더 좋은 의견있으시면 말씀주세요!
- 참고링크 : https://jojoldu.tistory.com/412

### 서비스레이어에 `Time` 클래스 추가
- `now()` 라는 값이 Testability 를 많이 낮춘다고 생각했습니다!
- 그래서 의존성 주입으로 풀어내봤습니다. 테스트 코드 작성시에는 `MockTime` 클래스를 만들어서 테스트 코드를 작성했습니다!
- 참고링크 : https://jojoldu.tistory.com/676?category=1036934

### API 응답값
- 현재 FE 의 마이그레이션 부담이 크기 때문에 이전 응답값과 동일하게 유지하기로 했습니다!

### 양방향 연관관계 제거 -> 적용완료
* **논의하게된 계기**
    - 서비스 레이어쪽 테스트코드를 작성하려고 했었는데 알 수 없는 쿼리가 계속 발생하고, 이로 인해 테스트가 자꾸 실패했습니다..! 
    - 조회임에도 불구하고 계속 user쪽에서 update문이 발생하고, 이로 인해 충돌이 발생하더라고요..
    - 원인찾는게 어려울것 같아서 일단 제외하고 PR 올렸는데요! 개인적인 생각으론 양방향 매핑이 문제라는 생각이 들더라고요..!
* 제안
    - 그래서 앞으로 연관관계 사용을 지양하고, 제가 필요하지 않는 연관관계 끊는 작업을 해도 괜찮을지 여쭤보고 싶었습니다!
    - 예를 들어, `User` 엔티티의 `@OneToMany` 는 모두 다 필요하지 않다고 생각했습니다!
    - 사실 테스트 코드를 떠나서 저는 양방향 매핑을 지양하자는 주의여서 말씀드린 맥락이기도 합니다...!
    - 참고 링크1 : https://www.youtube.com/watch?v=vgNHW_nb2mg
    - 참고 링크2 : https://www.youtube.com/watch?v=dJ5C4qRqAgA&t=1398s (8분 1초)

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #318 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?