### PR TITLE
[FEAT] 게시글 좋아요 토글 및 게시글 신고 API V2 구현

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
@@ -277,7 +277,6 @@ public class CommentV2ServiceImpl implements CommentV2Service {
                                                                      Integer userId) {
 
         Comment comment = commentRepository.findByIdOrThrow(commentId);
-        User user = userRepository.findByIdOrThrow(userId);
 
         boolean isLike = likeRepository.existsByUserIdAndCommentId(userId, commentId);
 
@@ -288,9 +287,7 @@ public class CommentV2ServiceImpl implements CommentV2Service {
         }
 
         Like like = Like.builder()
-                .user(user)
                 .userId(userId)
-                .comment(comment)
                 .commentId(commentId)
                 .build();
 

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
@@ -1,15 +1,15 @@
 package org.sopt.makers.crew.main.comment.v2.service;
 
-import static org.sopt.makers.crew.main.internal.notification.PushNotificationEnums.*;
+import static org.sopt.makers.crew.main.internal.notification.PushNotificationEnums.NEW_COMMENT_MENTION_PUSH_NOTIFICATION_TITLE;
+import static org.sopt.makers.crew.main.internal.notification.PushNotificationEnums.NEW_COMMENT_PUSH_NOTIFICATION_TITLE;
+import static org.sopt.makers.crew.main.internal.notification.PushNotificationEnums.PUSH_NOTIFICATION_CATEGORY;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
 import lombok.RequiredArgsConstructor;
-
 import org.sopt.makers.crew.main.comment.v2.dto.CommentMapper;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2CreateCommentBodyDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2MentionUserInCommentRequestDto;
@@ -21,10 +21,10 @@ import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2SwitchCommentL
 import org.sopt.makers.crew.main.comment.v2.dto.response.CommentV2UpdateCommentResponseDto;
 import org.sopt.makers.crew.main.comment.v2.dto.response.ReplyDto;
 import org.sopt.makers.crew.main.common.exception.BadRequestException;
+import org.sopt.makers.crew.main.common.exception.ErrorStatus;
 import org.sopt.makers.crew.main.common.exception.ForbiddenException;
 import org.sopt.makers.crew.main.common.pagination.dto.PageMetaDto;
 import org.sopt.makers.crew.main.common.pagination.dto.PageOptionsDto;
-import org.sopt.makers.crew.main.common.exception.ErrorStatus;
 import org.sopt.makers.crew.main.common.util.MentionSecretStringRemover;
 import org.sopt.makers.crew.main.common.util.Time;
 import org.sopt.makers.crew.main.entity.comment.Comment;
@@ -50,256 +50,253 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class CommentV2ServiceImpl implements CommentV2Service {
 
-	private static final int IS_REPLY_COMMENT = 1;
+    private static final int IS_REPLY_COMMENT = 1;
 
-	private final PostRepository postRepository;
-	private final UserRepository userRepository;
-	private final CommentRepository commentRepository;
-	private final ReportRepository reportRepository;
-	private final LikeRepository likeRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
+    private final ReportRepository reportRepository;
+    private final LikeRepository likeRepository;
 
-	private final PushNotificationService pushNotificationService;
+    private final PushNotificationService pushNotificationService;
 
-	private final CommentMapper commentMapper;
+    private final CommentMapper commentMapper;
 
-	@Value("${push-notification.web-url}")
-	private String pushWebUrl;
+    @Value("${push-notification.web-url}")
+    private String pushWebUrl;
 
-	private final Time time;
+    private final Time time;
 
-	/**
-	 * 모임 게시글 댓글 작성
-	 *
-	 * @throws 400 존재하지 않는 게시글일 떄
-	 * @apiNote 모임에 속한 유저만 작성 가능
-	 */
-	@Override
-	@Transactional
-	public CommentV2CreateCommentResponseDto createComment(
-		CommentV2CreateCommentBodyDto requestBody,
-		Integer userId) {
-		Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
-		User writer = userRepository.findByIdOrThrow(userId);
+    /**
+     * 모임 게시글 댓글 작성
+     *
+     * @throws 400 존재하지 않는 게시글일 떄
+     * @apiNote 모임에 속한 유저만 작성 가능
+     */
+    @Override
+    @Transactional
+    public CommentV2CreateCommentResponseDto createComment(
+            CommentV2CreateCommentBodyDto requestBody,
+            Integer userId) {
+        Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
+        User writer = userRepository.findByIdOrThrow(userId);
 
-		int depth = 0;
-		int order = 0;
-		Integer parentId = 0;
+        int depth = 0;
+        int order = 0;
+        Integer parentId = 0;
 
-		boolean isReplyComment = !requestBody.getIsParent();
-		if (isReplyComment) {
-			validateParentCommentId(requestBody);
-			depth = 1;
-			parentId = requestBody.getParentCommentId();
-			order = getOrder(parentId);
-		}
+        boolean isReplyComment = !requestBody.getIsParent();
+        if (isReplyComment) {
+            validateParentCommentId(requestBody);
+            depth = 1;
+            parentId = requestBody.getParentCommentId();
+            order = getOrder(parentId);
+        }
 
-		Comment comment = commentMapper.toComment(requestBody, post, writer, depth, order,
-			parentId);
+        Comment comment = commentMapper.toComment(requestBody, post, writer, depth, order,
+                parentId);
 
-		Comment savedComment = commentRepository.save(comment);
-		post.increaseCommentCount();
+        Comment savedComment = commentRepository.save(comment);
+        post.increaseCommentCount();
 
-		sendPushNotification(requestBody, post, writer);
+        sendPushNotification(requestBody, post, writer);
 
-		return CommentV2CreateCommentResponseDto.of(savedComment.getId());
-	}
+        return CommentV2CreateCommentResponseDto.of(savedComment.getId());
+    }
 
-	private void sendPushNotification(CommentV2CreateCommentBodyDto requestBody, Post post,
-		User user) {
-		User PostWriter = post.getUser();
-		String[] userIds = {String.valueOf(PostWriter.getOrgId())};
-		String secretStringRemovedContent = MentionSecretStringRemover.removeSecretString(
-			requestBody.getContents());
-		String pushNotificationContent = String.format("[%s의 댓글] : \"%s\"",
-			user.getName(), secretStringRemovedContent);
-		String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
+    private void sendPushNotification(CommentV2CreateCommentBodyDto requestBody, Post post,
+                                      User user) {
+        User PostWriter = post.getUser();
+        String[] userIds = {String.valueOf(PostWriter.getOrgId())};
+        String secretStringRemovedContent = MentionSecretStringRemover.removeSecretString(
+                requestBody.getContents());
+        String pushNotificationContent = String.format("[%s의 댓글] : \"%s\"",
+                user.getName(), secretStringRemovedContent);
+        String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
 
-		PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(userIds,
-			NEW_COMMENT_PUSH_NOTIFICATION_TITLE.getValue(),
-			pushNotificationContent,
-			PUSH_NOTIFICATION_CATEGORY.getValue(), pushNotificationWeblink);
+        PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(userIds,
+                NEW_COMMENT_PUSH_NOTIFICATION_TITLE.getValue(),
+                pushNotificationContent,
+                PUSH_NOTIFICATION_CATEGORY.getValue(), pushNotificationWeblink);
 
-		pushNotificationService.sendPushNotification(pushRequestDto);
-	}
+        pushNotificationService.sendPushNotification(pushRequestDto);
+    }
 
-	private void validateParentCommentId(CommentV2CreateCommentBodyDto requestBody) {
-		commentRepository.findByIdAndPostIdOrThrow(requestBody.getParentCommentId(),
-			requestBody.getPostId());
-	}
+    private void validateParentCommentId(CommentV2CreateCommentBodyDto requestBody) {
+        commentRepository.findByIdAndPostIdOrThrow(requestBody.getParentCommentId(),
+                requestBody.getPostId());
+    }
 
-	private int getOrder(Integer parentId) {
-		Optional<Comment> recentComment = commentRepository.findFirstByParentIdOrderByOrderDesc(
-			parentId);
-		return recentComment.map(comment -> comment.getOrder() + 1).orElse(1);
-	}
+    private int getOrder(Integer parentId) {
+        Optional<Comment> recentComment = commentRepository.findFirstByParentIdOrderByOrderDesc(
+                parentId);
+        return recentComment.map(comment -> comment.getOrder() + 1).orElse(1);
+    }
 
-	/**
-	 * 모임 게시글 댓글 수정
-	 *
-	 * @param commentId 수정할 댓글 ID
-	 * @param contents  수정할 내용
-	 * @param userId    수정하는 유저 ID
-	 * @return 수정된 댓글 정보
-	 */
-	@Override
-	@Transactional
-	public CommentV2UpdateCommentResponseDto updateComment(Integer commentId,
-		String contents, Integer userId) {
-		// 1. id를 기반으로 comment를 찾는다.
-		Comment comment = commentRepository.findByIdOrThrow(commentId);
+    /**
+     * 모임 게시글 댓글 수정
+     *
+     * @param commentId 수정할 댓글 ID
+     * @param contents  수정할 내용
+     * @param userId    수정하는 유저 ID
+     * @return 수정된 댓글 정보
+     */
+    @Override
+    @Transactional
+    public CommentV2UpdateCommentResponseDto updateComment(Integer commentId,
+                                                           String contents, Integer userId) {
+        // 1. id를 기반으로 comment를 찾는다.
+        Comment comment = commentRepository.findByIdOrThrow(commentId);
 
-		// 2. comment의 user_id와 userId가 같은지 확인한다.
-		comment.validateWriter(userId);
+        // 2. comment의 user_id와 userId가 같은지 확인한다.
+        comment.validateWriter(userId);
 
-		// 3. comment의 contents를 수정한다.
-		comment.updateContents(contents);
+        // 3. comment의 contents를 수정한다.
+        comment.updateContents(contents);
 
-		// 4. 수정된 comment의 id, contents, updatedDate를 반환한다.
-		return CommentV2UpdateCommentResponseDto.of(comment.getId(), comment.getContents(),
-			String.valueOf(time.now()));
-	}
+        // 4. 수정된 comment의 id, contents, updatedDate를 반환한다.
+        return CommentV2UpdateCommentResponseDto.of(comment.getId(), comment.getContents(),
+                String.valueOf(time.now()));
+    }
 
-	@Override
-	public CommentV2GetCommentsResponseDto getComments(Integer postId, Integer page, Integer take,
-		Integer userId) {
-		// TODO : 페이지네이션 구현
+    @Override
+    public CommentV2GetCommentsResponseDto getComments(Integer postId, Integer page, Integer take,
+                                                       Integer userId) {
+        // TODO : 페이지네이션 구현
 
-		List<Comment> comments = commentRepository.findAllByPostIdOrderByCreatedDate(postId);
+        List<Comment> comments = commentRepository.findAllByPostIdOrderByCreatedDate(postId);
 
-		MyLikes myLikes = new MyLikes(likeRepository.findAllByUserIdAndCommentIdNotNull(userId));
+        MyLikes myLikes = new MyLikes(likeRepository.findAllByUserIdAndCommentIdNotNull(userId));
 
-		Map<Integer, List<ReplyDto>> replyMap = new HashMap<>();
-		comments.stream()
-			.filter(comment -> !comment.isParentComment())
-			.forEach(
-				comment -> replyMap.computeIfAbsent(comment.getParentId(), k -> new ArrayList<>())
-					.add(ReplyDto.of(comment, myLikes.isLikeComment(comment.getId()),
-						comment.isWriter(userId))));
+        Map<Integer, List<ReplyDto>> replyMap = new HashMap<>();
+        comments.stream()
+                .filter(comment -> !comment.isParentComment())
+                .forEach(
+                        comment -> replyMap.computeIfAbsent(comment.getParentId(), k -> new ArrayList<>())
+                                .add(ReplyDto.of(comment, myLikes.isLikeComment(comment.getId()),
+                                        comment.isWriter(userId))));
 
-		List<CommentDto> commentDtos = comments.stream()
-			.filter(Comment::isParentComment)
-			.map(comment -> CommentDto.of(comment, myLikes.isLikeComment(comment.getId()),
-				comment.isWriter(userId),
-				replyMap.get(comment.getId())))
-			.toList();
+        List<CommentDto> commentDtos = comments.stream()
+                .filter(Comment::isParentComment)
+                .map(comment -> CommentDto.of(comment, myLikes.isLikeComment(comment.getId()),
+                        comment.isWriter(userId),
+                        replyMap.get(comment.getId())))
+                .toList();
 
-		PageMetaDto pageMetaDto = new PageMetaDto(new PageOptionsDto(1, 12), 30);
+        PageMetaDto pageMetaDto = new PageMetaDto(new PageOptionsDto(1, 12), 30);
 
-		return CommentV2GetCommentsResponseDto.of(commentDtos, pageMetaDto);
-	}
+        return CommentV2GetCommentsResponseDto.of(commentDtos, pageMetaDto);
+    }
 
-	/**
-	 * 댓글 신고하기
-	 *
-	 * @param commentId 댓글 신고할 댓글 id
-	 * @param userId    신고하는 유저 id
-	 * @return 신고 ID
-	 * @throws BadRequestException 이미 신고한 댓글일 때
-	 * @apiNote 댓글 신고는 한 댓글당 한번만 가능
-	 */
-	@Override
-	@Transactional
-	public CommentV2ReportCommentResponseDto reportComment(Integer commentId, Integer userId)
-		throws BadRequestException {
-		Comment comment = commentRepository.findByIdOrThrow(commentId);
-		User user = userRepository.findByIdOrThrow(userId);
+    /**
+     * 댓글 신고하기
+     *
+     * @param commentId 댓글 신고할 댓글 id
+     * @param userId    신고하는 유저 id
+     * @return 신고 ID
+     * @throws BadRequestException 이미 신고한 댓글일 때
+     * @apiNote 댓글 신고는 한 댓글당 한번만 가능
+     */
+    @Override
+    @Transactional
+    public CommentV2ReportCommentResponseDto reportComment(Integer commentId, Integer userId) {
+        Comment comment = commentRepository.findByIdOrThrow(commentId);
 
-		Optional<Report> existingReport = reportRepository.findByCommentAndUser(comment, user);
+        if (reportRepository.existsByCommentIdAndUserId(commentId, userId)) {
+            throw new BadRequestException(ErrorStatus.ALREADY_REPORTED_COMMENT.getErrorCode());
+        }
 
-		if (existingReport.isPresent()) {
-			throw new BadRequestException(ErrorStatus.ALREADY_REPORTED_COMMENT.getErrorCode());
-		}
+        Report report = Report.builder()
+                .userId(userId)
+                .comment(comment)
+                .commentId(commentId)
+                .build();
 
-		Report report = Report.builder()
-			.comment(comment)
-			.user(user)
-			.build();
+        Report savedReport = reportRepository.save(report);
 
-		Report savedReport = reportRepository.save(report);
+        return CommentV2ReportCommentResponseDto.of(savedReport.getId());
+    }
 
-		return CommentV2ReportCommentResponseDto.of(savedReport.getId());
-	}
+    /**
+     * 모임 게시글 댓글 삭제
+     *
+     * @throws ForbiddenException 댓글 작성자가 아닐 때
+     * @apiNote 댓글 삭제시 게시글의 댓글 수를 1 감소시킴
+     */
+    @Override
+    @Transactional
+    public void deleteComment(Integer commentId, Integer userId) {
+        Comment comment = commentRepository.findByIdOrThrow(commentId);
+        comment.validateWriter(userId);
+        User user = comment.getUser();
 
-	/**
-	 * 모임 게시글 댓글 삭제
-	 *
-	 * @throws ForbiddenException 댓글 작성자가 아닐 때
-	 * @apiNote 댓글 삭제시 게시글의 댓글 수를 1 감소시킴
-	 */
-	@Override
-	@Transactional
-	public void deleteComment(Integer commentId, Integer userId) {
-		Comment comment = commentRepository.findByIdOrThrow(commentId);
-		comment.validateWriter(userId);
-		User user = comment.getUser();
+        Post post = postRepository.findByIdOrThrow(comment.getPostId());
+        post.decreaseCommentCount();
 
-		Post post = postRepository.findByIdOrThrow(comment.getPostId());
-		post.decreaseCommentCount();
+        Comments childComments = new Comments(commentRepository.findAllByParentIdOrderByOrderDesc(comment.getId()));
 
-		Comments childComments = new Comments(commentRepository.findAllByParentIdOrderByOrderDesc(comment.getId()));
+        if (comment.getDepth() == IS_REPLY_COMMENT || !childComments.hasChild()) {
+            commentRepository.delete(comment);
+            return;
+        }
 
-		if (comment.getDepth() == IS_REPLY_COMMENT || !childComments.hasChild()) {
-			commentRepository.delete(comment);
-			return;
-		}
+        comment.deleteParentComment();
+        childComments.deleteMention(user.getName(), user.getOrgId().toString());
+    }
 
-		comment.deleteParentComment();
-		childComments.deleteMention(user.getName(), user.getOrgId().toString());
-	}
+    @Override
+    public void mentionUserInComment(CommentV2MentionUserInCommentRequestDto requestBody,
+                                     Integer userId) {
+        User user = userRepository.findByIdOrThrow(userId);
+        Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
 
-	@Override
-	public void mentionUserInComment(CommentV2MentionUserInCommentRequestDto requestBody,
-		Integer userId) {
-		User user = userRepository.findByIdOrThrow(userId);
-		Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
+        String pushNotificationContent = "\"" + requestBody.getContent() + "\"";
+        String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
 
-		String pushNotificationContent = "\"" + requestBody.getContent() + "\"";
-		String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
+        String[] userOrgIds = requestBody.getOrgIds().stream()
+                .map(Object::toString)
+                .toArray(String[]::new);
 
-		String[] userOrgIds = requestBody.getOrgIds().stream()
-			.map(Object::toString)
-			.toArray(String[]::new);
+        String newCommentMentionPushNotificationTitle = String.format(
+                NEW_COMMENT_MENTION_PUSH_NOTIFICATION_TITLE.getValue(), user.getName());
 
-		String newCommentMentionPushNotificationTitle = String.format(
-			NEW_COMMENT_MENTION_PUSH_NOTIFICATION_TITLE.getValue(), user.getName());
+        PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(
+                userOrgIds,
+                newCommentMentionPushNotificationTitle,
+                pushNotificationContent,
+                PUSH_NOTIFICATION_CATEGORY.getValue(),
+                pushNotificationWeblink
+        );
 
-		PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(
-			userOrgIds,
-			newCommentMentionPushNotificationTitle,
-			pushNotificationContent,
-			PUSH_NOTIFICATION_CATEGORY.getValue(),
-			pushNotificationWeblink
-		);
+        pushNotificationService.sendPushNotification(pushRequestDto);
+    }
 
-		pushNotificationService.sendPushNotification(pushRequestDto);
-	}
+    @Override
+    @Transactional
+    public CommentV2SwitchCommentLikeResponseDto switchCommentToggle(Integer commentId,
+                                                                     Integer userId) {
 
-	@Override
-	@Transactional
-	public CommentV2SwitchCommentLikeResponseDto switchCommentToggle(Integer commentId,
-		Integer userId) {
+        Comment comment = commentRepository.findByIdOrThrow(commentId);
+        User user = userRepository.findByIdOrThrow(userId);
 
-		Comment comment = commentRepository.findByIdOrThrow(commentId);
-		User user = userRepository.findByIdOrThrow(userId);
+        boolean isLike = likeRepository.existsByUserIdAndCommentId(userId, commentId);
 
-		boolean isLike = likeRepository.existsByUserIdAndCommentId(userId, commentId);
+        if (isLike) {
+            likeRepository.deleteByUserIdAndCommentId(userId, commentId);
+            comment.decreaseLikeCount();
+            return CommentV2SwitchCommentLikeResponseDto.of(false);
+        }
 
-		if (isLike) {
-			likeRepository.deleteByUserIdAndCommentId(userId, commentId);
-			comment.decreaseLikeCount();
-			return CommentV2SwitchCommentLikeResponseDto.of(false);
-		}
+        Like like = Like.builder()
+                .user(user)
+                .userId(userId)
+                .comment(comment)
+                .commentId(commentId)
+                .build();
 
-		Like like = Like.builder()
-			.user(user)
-			.userId(userId)
-			.comment(comment)
-			.commentId(commentId)
-			.build();
+        likeRepository.save(like);
+        comment.increaseLikeCount();
 
-		likeRepository.save(like);
-		comment.increaseLikeCount();
-
-		return CommentV2SwitchCommentLikeResponseDto.of(true);
-	}
+        return CommentV2SwitchCommentLikeResponseDto.of(true);
+    }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceImpl.java
@@ -9,7 +9,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
+
 import org.sopt.makers.crew.main.comment.v2.dto.CommentMapper;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2CreateCommentBodyDto;
 import org.sopt.makers.crew.main.comment.v2.dto.request.CommentV2MentionUserInCommentRequestDto;
@@ -50,250 +52,250 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class CommentV2ServiceImpl implements CommentV2Service {
 
-    private static final int IS_REPLY_COMMENT = 1;
+	private static final int IS_REPLY_COMMENT = 1;
 
-    private final PostRepository postRepository;
-    private final UserRepository userRepository;
-    private final CommentRepository commentRepository;
-    private final ReportRepository reportRepository;
-    private final LikeRepository likeRepository;
+	private final PostRepository postRepository;
+	private final UserRepository userRepository;
+	private final CommentRepository commentRepository;
+	private final ReportRepository reportRepository;
+	private final LikeRepository likeRepository;
 
-    private final PushNotificationService pushNotificationService;
+	private final PushNotificationService pushNotificationService;
 
-    private final CommentMapper commentMapper;
+	private final CommentMapper commentMapper;
 
-    @Value("${push-notification.web-url}")
-    private String pushWebUrl;
+	@Value("${push-notification.web-url}")
+	private String pushWebUrl;
 
-    private final Time time;
+	private final Time time;
 
-    /**
-     * 모임 게시글 댓글 작성
-     *
-     * @throws 400 존재하지 않는 게시글일 떄
-     * @apiNote 모임에 속한 유저만 작성 가능
-     */
-    @Override
-    @Transactional
-    public CommentV2CreateCommentResponseDto createComment(
-            CommentV2CreateCommentBodyDto requestBody,
-            Integer userId) {
-        Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
-        User writer = userRepository.findByIdOrThrow(userId);
+	/**
+	 * 모임 게시글 댓글 작성
+	 *
+	 * @throws 400 존재하지 않는 게시글일 떄
+	 * @apiNote 모임에 속한 유저만 작성 가능
+	 */
+	@Override
+	@Transactional
+	public CommentV2CreateCommentResponseDto createComment(
+		CommentV2CreateCommentBodyDto requestBody,
+		Integer userId) {
+		Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
+		User writer = userRepository.findByIdOrThrow(userId);
 
-        int depth = 0;
-        int order = 0;
-        Integer parentId = 0;
+		int depth = 0;
+		int order = 0;
+		Integer parentId = 0;
 
-        boolean isReplyComment = !requestBody.getIsParent();
-        if (isReplyComment) {
-            validateParentCommentId(requestBody);
-            depth = 1;
-            parentId = requestBody.getParentCommentId();
-            order = getOrder(parentId);
-        }
+		boolean isReplyComment = !requestBody.getIsParent();
+		if (isReplyComment) {
+			validateParentCommentId(requestBody);
+			depth = 1;
+			parentId = requestBody.getParentCommentId();
+			order = getOrder(parentId);
+		}
 
-        Comment comment = commentMapper.toComment(requestBody, post, writer, depth, order,
-                parentId);
+		Comment comment = commentMapper.toComment(requestBody, post, writer, depth, order,
+			parentId);
 
-        Comment savedComment = commentRepository.save(comment);
-        post.increaseCommentCount();
+		Comment savedComment = commentRepository.save(comment);
+		post.increaseCommentCount();
 
-        sendPushNotification(requestBody, post, writer);
+		sendPushNotification(requestBody, post, writer);
 
-        return CommentV2CreateCommentResponseDto.of(savedComment.getId());
-    }
+		return CommentV2CreateCommentResponseDto.of(savedComment.getId());
+	}
 
-    private void sendPushNotification(CommentV2CreateCommentBodyDto requestBody, Post post,
-                                      User user) {
-        User PostWriter = post.getUser();
-        String[] userIds = {String.valueOf(PostWriter.getOrgId())};
-        String secretStringRemovedContent = MentionSecretStringRemover.removeSecretString(
-                requestBody.getContents());
-        String pushNotificationContent = String.format("[%s의 댓글] : \"%s\"",
-                user.getName(), secretStringRemovedContent);
-        String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
+	private void sendPushNotification(CommentV2CreateCommentBodyDto requestBody, Post post,
+		User user) {
+		User PostWriter = post.getUser();
+		String[] userIds = {String.valueOf(PostWriter.getOrgId())};
+		String secretStringRemovedContent = MentionSecretStringRemover.removeSecretString(
+			requestBody.getContents());
+		String pushNotificationContent = String.format("[%s의 댓글] : \"%s\"",
+			user.getName(), secretStringRemovedContent);
+		String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
 
-        PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(userIds,
-                NEW_COMMENT_PUSH_NOTIFICATION_TITLE.getValue(),
-                pushNotificationContent,
-                PUSH_NOTIFICATION_CATEGORY.getValue(), pushNotificationWeblink);
+		PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(userIds,
+			NEW_COMMENT_PUSH_NOTIFICATION_TITLE.getValue(),
+			pushNotificationContent,
+			PUSH_NOTIFICATION_CATEGORY.getValue(), pushNotificationWeblink);
 
-        pushNotificationService.sendPushNotification(pushRequestDto);
-    }
+		pushNotificationService.sendPushNotification(pushRequestDto);
+	}
 
-    private void validateParentCommentId(CommentV2CreateCommentBodyDto requestBody) {
-        commentRepository.findByIdAndPostIdOrThrow(requestBody.getParentCommentId(),
-                requestBody.getPostId());
-    }
+	private void validateParentCommentId(CommentV2CreateCommentBodyDto requestBody) {
+		commentRepository.findByIdAndPostIdOrThrow(requestBody.getParentCommentId(),
+			requestBody.getPostId());
+	}
 
-    private int getOrder(Integer parentId) {
-        Optional<Comment> recentComment = commentRepository.findFirstByParentIdOrderByOrderDesc(
-                parentId);
-        return recentComment.map(comment -> comment.getOrder() + 1).orElse(1);
-    }
+	private int getOrder(Integer parentId) {
+		Optional<Comment> recentComment = commentRepository.findFirstByParentIdOrderByOrderDesc(
+			parentId);
+		return recentComment.map(comment -> comment.getOrder() + 1).orElse(1);
+	}
 
-    /**
-     * 모임 게시글 댓글 수정
-     *
-     * @param commentId 수정할 댓글 ID
-     * @param contents  수정할 내용
-     * @param userId    수정하는 유저 ID
-     * @return 수정된 댓글 정보
-     */
-    @Override
-    @Transactional
-    public CommentV2UpdateCommentResponseDto updateComment(Integer commentId,
-                                                           String contents, Integer userId) {
-        // 1. id를 기반으로 comment를 찾는다.
-        Comment comment = commentRepository.findByIdOrThrow(commentId);
+	/**
+	 * 모임 게시글 댓글 수정
+	 *
+	 * @param commentId 수정할 댓글 ID
+	 * @param contents  수정할 내용
+	 * @param userId    수정하는 유저 ID
+	 * @return 수정된 댓글 정보
+	 */
+	@Override
+	@Transactional
+	public CommentV2UpdateCommentResponseDto updateComment(Integer commentId,
+		String contents, Integer userId) {
+		// 1. id를 기반으로 comment를 찾는다.
+		Comment comment = commentRepository.findByIdOrThrow(commentId);
 
-        // 2. comment의 user_id와 userId가 같은지 확인한다.
-        comment.validateWriter(userId);
+		// 2. comment의 user_id와 userId가 같은지 확인한다.
+		comment.validateWriter(userId);
 
-        // 3. comment의 contents를 수정한다.
-        comment.updateContents(contents);
+		// 3. comment의 contents를 수정한다.
+		comment.updateContents(contents);
 
-        // 4. 수정된 comment의 id, contents, updatedDate를 반환한다.
-        return CommentV2UpdateCommentResponseDto.of(comment.getId(), comment.getContents(),
-                String.valueOf(time.now()));
-    }
+		// 4. 수정된 comment의 id, contents, updatedDate를 반환한다.
+		return CommentV2UpdateCommentResponseDto.of(comment.getId(), comment.getContents(),
+			String.valueOf(time.now()));
+	}
 
-    @Override
-    public CommentV2GetCommentsResponseDto getComments(Integer postId, Integer page, Integer take,
-                                                       Integer userId) {
-        // TODO : 페이지네이션 구현
+	@Override
+	public CommentV2GetCommentsResponseDto getComments(Integer postId, Integer page, Integer take,
+		Integer userId) {
+		// TODO : 페이지네이션 구현
 
-        List<Comment> comments = commentRepository.findAllByPostIdOrderByCreatedDate(postId);
+		List<Comment> comments = commentRepository.findAllByPostIdOrderByCreatedDate(postId);
 
-        MyLikes myLikes = new MyLikes(likeRepository.findAllByUserIdAndCommentIdNotNull(userId));
+		MyLikes myLikes = new MyLikes(likeRepository.findAllByUserIdAndCommentIdNotNull(userId));
 
-        Map<Integer, List<ReplyDto>> replyMap = new HashMap<>();
-        comments.stream()
-                .filter(comment -> !comment.isParentComment())
-                .forEach(
-                        comment -> replyMap.computeIfAbsent(comment.getParentId(), k -> new ArrayList<>())
-                                .add(ReplyDto.of(comment, myLikes.isLikeComment(comment.getId()),
-                                        comment.isWriter(userId))));
+		Map<Integer, List<ReplyDto>> replyMap = new HashMap<>();
+		comments.stream()
+			.filter(comment -> !comment.isParentComment())
+			.forEach(
+				comment -> replyMap.computeIfAbsent(comment.getParentId(), k -> new ArrayList<>())
+					.add(ReplyDto.of(comment, myLikes.isLikeComment(comment.getId()),
+						comment.isWriter(userId))));
 
-        List<CommentDto> commentDtos = comments.stream()
-                .filter(Comment::isParentComment)
-                .map(comment -> CommentDto.of(comment, myLikes.isLikeComment(comment.getId()),
-                        comment.isWriter(userId),
-                        replyMap.get(comment.getId())))
-                .toList();
+		List<CommentDto> commentDtos = comments.stream()
+			.filter(Comment::isParentComment)
+			.map(comment -> CommentDto.of(comment, myLikes.isLikeComment(comment.getId()),
+				comment.isWriter(userId),
+				replyMap.get(comment.getId())))
+			.toList();
 
-        PageMetaDto pageMetaDto = new PageMetaDto(new PageOptionsDto(1, 12), 30);
+		PageMetaDto pageMetaDto = new PageMetaDto(new PageOptionsDto(1, 12), 30);
 
-        return CommentV2GetCommentsResponseDto.of(commentDtos, pageMetaDto);
-    }
+		return CommentV2GetCommentsResponseDto.of(commentDtos, pageMetaDto);
+	}
 
-    /**
-     * 댓글 신고하기
-     *
-     * @param commentId 댓글 신고할 댓글 id
-     * @param userId    신고하는 유저 id
-     * @return 신고 ID
-     * @throws BadRequestException 이미 신고한 댓글일 때
-     * @apiNote 댓글 신고는 한 댓글당 한번만 가능
-     */
-    @Override
-    @Transactional
-    public CommentV2ReportCommentResponseDto reportComment(Integer commentId, Integer userId) {
-        Comment comment = commentRepository.findByIdOrThrow(commentId);
+	/**
+	 * 댓글 신고하기
+	 *
+	 * @param commentId 댓글 신고할 댓글 id
+	 * @param userId    신고하는 유저 id
+	 * @return 신고 ID
+	 * @throws BadRequestException 이미 신고한 댓글일 때
+	 * @apiNote 댓글 신고는 한 댓글당 한번만 가능
+	 */
+	@Override
+	@Transactional
+	public CommentV2ReportCommentResponseDto reportComment(Integer commentId, Integer userId) {
+		Comment comment = commentRepository.findByIdOrThrow(commentId);
 
-        if (reportRepository.existsByCommentIdAndUserId(commentId, userId)) {
-            throw new BadRequestException(ErrorStatus.ALREADY_REPORTED_COMMENT.getErrorCode());
-        }
+		if (reportRepository.existsByCommentIdAndUserId(commentId, userId)) {
+			throw new BadRequestException(ErrorStatus.ALREADY_REPORTED_COMMENT.getErrorCode());
+		}
 
-        Report report = Report.builder()
-                .userId(userId)
-                .comment(comment)
-                .commentId(commentId)
-                .build();
+		Report report = Report.builder()
+			.userId(userId)
+			.comment(comment)
+			.commentId(commentId)
+			.build();
 
-        Report savedReport = reportRepository.save(report);
+		Report savedReport = reportRepository.save(report);
 
-        return CommentV2ReportCommentResponseDto.of(savedReport.getId());
-    }
+		return CommentV2ReportCommentResponseDto.of(savedReport.getId());
+	}
 
-    /**
-     * 모임 게시글 댓글 삭제
-     *
-     * @throws ForbiddenException 댓글 작성자가 아닐 때
-     * @apiNote 댓글 삭제시 게시글의 댓글 수를 1 감소시킴
-     */
-    @Override
-    @Transactional
-    public void deleteComment(Integer commentId, Integer userId) {
-        Comment comment = commentRepository.findByIdOrThrow(commentId);
-        comment.validateWriter(userId);
-        User user = comment.getUser();
+	/**
+	 * 모임 게시글 댓글 삭제
+	 *
+	 * @throws ForbiddenException 댓글 작성자가 아닐 때
+	 * @apiNote 댓글 삭제시 게시글의 댓글 수를 1 감소시킴
+	 */
+	@Override
+	@Transactional
+	public void deleteComment(Integer commentId, Integer userId) {
+		Comment comment = commentRepository.findByIdOrThrow(commentId);
+		comment.validateWriter(userId);
+		User user = comment.getUser();
 
-        Post post = postRepository.findByIdOrThrow(comment.getPostId());
-        post.decreaseCommentCount();
+		Post post = postRepository.findByIdOrThrow(comment.getPostId());
+		post.decreaseCommentCount();
 
-        Comments childComments = new Comments(commentRepository.findAllByParentIdOrderByOrderDesc(comment.getId()));
+		Comments childComments = new Comments(commentRepository.findAllByParentIdOrderByOrderDesc(comment.getId()));
 
-        if (comment.getDepth() == IS_REPLY_COMMENT || !childComments.hasChild()) {
-            commentRepository.delete(comment);
-            return;
-        }
+		if (comment.getDepth() == IS_REPLY_COMMENT || !childComments.hasChild()) {
+			commentRepository.delete(comment);
+			return;
+		}
 
-        comment.deleteParentComment();
-        childComments.deleteMention(user.getName(), user.getOrgId().toString());
-    }
+		comment.deleteParentComment();
+		childComments.deleteMention(user.getName(), user.getOrgId().toString());
+	}
 
-    @Override
-    public void mentionUserInComment(CommentV2MentionUserInCommentRequestDto requestBody,
-                                     Integer userId) {
-        User user = userRepository.findByIdOrThrow(userId);
-        Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
+	@Override
+	public void mentionUserInComment(CommentV2MentionUserInCommentRequestDto requestBody,
+		Integer userId) {
+		User user = userRepository.findByIdOrThrow(userId);
+		Post post = postRepository.findByIdOrThrow(requestBody.getPostId());
 
-        String pushNotificationContent = "\"" + requestBody.getContent() + "\"";
-        String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
+		String pushNotificationContent = "\"" + requestBody.getContent() + "\"";
+		String pushNotificationWeblink = pushWebUrl + "/post?id=" + post.getId();
 
-        String[] userOrgIds = requestBody.getOrgIds().stream()
-                .map(Object::toString)
-                .toArray(String[]::new);
+		String[] userOrgIds = requestBody.getOrgIds().stream()
+			.map(Object::toString)
+			.toArray(String[]::new);
 
-        String newCommentMentionPushNotificationTitle = String.format(
-                NEW_COMMENT_MENTION_PUSH_NOTIFICATION_TITLE.getValue(), user.getName());
+		String newCommentMentionPushNotificationTitle = String.format(
+			NEW_COMMENT_MENTION_PUSH_NOTIFICATION_TITLE.getValue(), user.getName());
 
-        PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(
-                userOrgIds,
-                newCommentMentionPushNotificationTitle,
-                pushNotificationContent,
-                PUSH_NOTIFICATION_CATEGORY.getValue(),
-                pushNotificationWeblink
-        );
+		PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(
+			userOrgIds,
+			newCommentMentionPushNotificationTitle,
+			pushNotificationContent,
+			PUSH_NOTIFICATION_CATEGORY.getValue(),
+			pushNotificationWeblink
+		);
 
-        pushNotificationService.sendPushNotification(pushRequestDto);
-    }
+		pushNotificationService.sendPushNotification(pushRequestDto);
+	}
 
-    @Override
-    @Transactional
-    public CommentV2SwitchCommentLikeResponseDto switchCommentToggle(Integer commentId,
-                                                                     Integer userId) {
+	@Override
+	@Transactional
+	public CommentV2SwitchCommentLikeResponseDto switchCommentToggle(Integer commentId,
+		Integer userId) {
 
-        Comment comment = commentRepository.findByIdOrThrow(commentId);
+		Comment comment = commentRepository.findByIdOrThrow(commentId);
 
-        boolean isLike = likeRepository.existsByUserIdAndCommentId(userId, commentId);
+		boolean isLike = likeRepository.existsByUserIdAndCommentId(userId, commentId);
 
-        if (isLike) {
-            likeRepository.deleteByUserIdAndCommentId(userId, commentId);
-            comment.decreaseLikeCount();
-            return CommentV2SwitchCommentLikeResponseDto.of(false);
-        }
+		if (isLike) {
+			likeRepository.deleteByUserIdAndCommentId(userId, commentId);
+			comment.decreaseLikeCount();
+			return CommentV2SwitchCommentLikeResponseDto.of(false);
+		}
 
-        Like like = Like.builder()
-                .userId(userId)
-                .commentId(commentId)
-                .build();
+		Like like = Like.builder()
+			.userId(userId)
+			.commentId(commentId)
+			.build();
 
-        likeRepository.save(like);
-        comment.increaseLikeCount();
+		likeRepository.save(like);
+		comment.increaseLikeCount();
 
-        return CommentV2SwitchCommentLikeResponseDto.of(true);
-    }
+		return CommentV2SwitchCommentLikeResponseDto.of(true);
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/common/exception/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/exception/ErrorStatus.java
@@ -23,6 +23,7 @@ public enum ErrorStatus {
     FULL_MEETING_CAPACITY("정원이 꽉 찼습니다."),
     ALREADY_APPLIED_MEETING("이미 지원한 모임입니다."),
     ALREADY_REPORTED_COMMENT("이미 신고한 댓글입니다."),
+    ALREADY_REPORTED_POST("이미 신고한 게시글입니다."),
     NOT_IN_APPLY_PERIOD("모임 지원 기간이 아닙니다."),
     MISSING_GENERATION_PART("내 프로필에서 기수/파트 정보를 입력해주세요."),
     NOT_ACTIVE_GENERATION("활동 기수가 아닙니다."),
@@ -30,7 +31,7 @@ public enum ErrorStatus {
     NOT_FOUND_APPLY("신청상태가 아닌 모임입니다."),
     ALREADY_PROCESSED_APPLY("이미 해당 상태로 처리된 신청 정보입니다."),
     MAX_IMAGE_UPLOAD_EXCEEDED("이미지는 최대 10개까지만 업로드 가능합니다."),
-    
+
     /**
      * 401 UNAUTHORIZED
      */

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/like/Like.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/like/Like.java
@@ -3,24 +3,15 @@ package org.sopt.makers.crew.main.entity.like;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-
 import java.time.LocalDateTime;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import org.sopt.makers.crew.main.entity.comment.Comment;
-import org.sopt.makers.crew.main.entity.post.Post;
-import org.sopt.makers.crew.main.entity.user.User;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -31,68 +22,43 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public class Like {
 
-	/**
-	 * Primary key
-	 */
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private int id;
+    /**
+     * Primary key
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
 
-	/**
-	 * 좋아요 누른 날짜
-	 */
-	@Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
-	@CreatedDate
-	private LocalDateTime createdDate;
+    /**
+     * 좋아요 누른 날짜
+     */
+    @Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
+    @CreatedDate
+    private LocalDateTime createdDate;
 
-	/**
-	 * 신고자
-	 */
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "userId", nullable = false)
-	private User user;
+    /**
+     * 좋아요 누른사람 id
+     */
+    @Column
+    private int userId;
 
-	/**
-	 * 좋아요 누른사람 id
-	 */
-	@Column(insertable = false, nullable = false, updatable = false)
-	private int userId;
+    /**
+     * 게시글 id - 게시글 좋아요가 아닐 경우 null
+     */
+    @Column
+    private Integer postId;
 
-	/**
-	 * 게시글
-	 */
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "postId")
-	private Post post;
+    /**
+     * 댓글 id - 댓글 좋아요가 아닐 경우 null
+     */
+    @Column
+    private Integer commentId;
 
-	/**
-	 * 게시글 id - 게시글 좋아요가 아닐 경우 null
-	 */
-	@Column(insertable = false, updatable = false)
-	private Integer postId;
-
-	/**
-	 * 댓글
-	 */
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "commentId")
-	private Comment comment;
-
-	/**
-	 * 댓글 id - 댓글 좋아요가 아닐 경우 null
-	 */
-	@Column(insertable = false, updatable = false)
-	private Integer commentId;
-
-	@Builder
-	public Like(Integer userId, Integer postId, Integer commentId, User user, Post post,
-		Comment comment) {
-		this.userId = userId;
-		this.user = user;
-		this.post = post;
-		this.postId = postId;
-		this.comment = comment;
-		this.commentId = commentId;
-	}
+    @Builder
+    public Like(Integer userId, Integer postId, Integer commentId) {
+        this.userId = userId;
+        this.postId = postId;
+        this.commentId = commentId;
+    }
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/like/Like.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/like/Like.java
@@ -7,11 +7,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+
 import java.time.LocalDateTime;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -22,43 +25,43 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public class Like {
 
-    /**
-     * Primary key
-     */
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int id;
+	/**
+	 * Primary key
+	 */
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private int id;
 
-    /**
-     * 좋아요 누른 날짜
-     */
-    @Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
-    @CreatedDate
-    private LocalDateTime createdDate;
+	/**
+	 * 좋아요 누른 날짜
+	 */
+	@Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
+	@CreatedDate
+	private LocalDateTime createdDate;
 
-    /**
-     * 좋아요 누른사람 id
-     */
-    @Column
-    private int userId;
+	/**
+	 * 좋아요 누른사람 id
+	 */
+	@Column
+	private int userId;
 
-    /**
-     * 게시글 id - 게시글 좋아요가 아닐 경우 null
-     */
-    @Column
-    private Integer postId;
+	/**
+	 * 게시글 id - 게시글 좋아요가 아닐 경우 null
+	 */
+	@Column
+	private Integer postId;
 
-    /**
-     * 댓글 id - 댓글 좋아요가 아닐 경우 null
-     */
-    @Column
-    private Integer commentId;
+	/**
+	 * 댓글 id - 댓글 좋아요가 아닐 경우 null
+	 */
+	@Column
+	private Integer commentId;
 
-    @Builder
-    public Like(Integer userId, Integer postId, Integer commentId) {
-        this.userId = userId;
-        this.postId = postId;
-        this.commentId = commentId;
-    }
+	@Builder
+	public Like(Integer userId, Integer postId, Integer commentId) {
+		this.userId = userId;
+		this.postId = postId;
+		this.commentId = commentId;
+	}
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
@@ -1,7 +1,6 @@
 package org.sopt.makers.crew.main.entity.like;
 
 import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -26,11 +25,14 @@ public interface LikeRepository extends JpaRepository<Like, Integer> {
     @Query("DELETE FROM Like l WHERE l.commentId IN :commentIds")
     void deleteAllByCommentIdsInQuery(List<Integer> commentIds);
 
-	boolean existsByUserIdAndCommentId(Integer userId, Integer commentId);
+    boolean existsByUserIdAndCommentId(Integer userId, Integer commentId);
 
-	void deleteByUserIdAndCommentId(Integer userId, Integer commentId);
+    void deleteByUserIdAndCommentId(Integer userId, Integer commentId);
+
+    int deleteByUserIdAndPostId(Integer userId, Integer postId);
 
     List<Like> findAllByPostIdIsIn(List<Integer> postIds);
+
     List<Like> findAllByCommentIdIsIn(List<Integer> commentIds);
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/like/LikeRepository.java
@@ -1,6 +1,7 @@
 package org.sopt.makers.crew.main.entity.like;
 
 import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -8,31 +9,31 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface LikeRepository extends JpaRepository<Like, Integer> {
 
-    List<Like> findAllByUserIdAndCommentIdNotNull(Integer userId);
+	List<Like> findAllByUserIdAndCommentIdNotNull(Integer userId);
 
-    @Modifying(clearAutomatically = true)
-    @Transactional
-    @Query("DELETE FROM Like l WHERE l.postId = :postId")
-    void deleteAllByPostId(Integer postId);
+	@Modifying(clearAutomatically = true)
+	@Transactional
+	@Query("DELETE FROM Like l WHERE l.postId = :postId")
+	void deleteAllByPostId(Integer postId);
 
-    @Modifying(clearAutomatically = true)
-    @Transactional
-    @Query("DELETE FROM Like l WHERE l.postId IN :postIds")
-    void deleteAllByPostIdsInQuery(List<Integer> postIds);
+	@Modifying(clearAutomatically = true)
+	@Transactional
+	@Query("DELETE FROM Like l WHERE l.postId IN :postIds")
+	void deleteAllByPostIdsInQuery(List<Integer> postIds);
 
-    @Modifying(clearAutomatically = true)
-    @Transactional
-    @Query("DELETE FROM Like l WHERE l.commentId IN :commentIds")
-    void deleteAllByCommentIdsInQuery(List<Integer> commentIds);
+	@Modifying(clearAutomatically = true)
+	@Transactional
+	@Query("DELETE FROM Like l WHERE l.commentId IN :commentIds")
+	void deleteAllByCommentIdsInQuery(List<Integer> commentIds);
 
-    boolean existsByUserIdAndCommentId(Integer userId, Integer commentId);
+	boolean existsByUserIdAndCommentId(Integer userId, Integer commentId);
 
-    void deleteByUserIdAndCommentId(Integer userId, Integer commentId);
+	void deleteByUserIdAndCommentId(Integer userId, Integer commentId);
 
-    int deleteByUserIdAndPostId(Integer userId, Integer postId);
+	int deleteByUserIdAndPostId(Integer userId, Integer postId);
 
-    List<Like> findAllByPostIdIsIn(List<Integer> postIds);
+	List<Like> findAllByPostIdIsIn(List<Integer> postIds);
 
-    List<Like> findAllByCommentIdIsIn(List<Integer> commentIds);
+	List<Like> findAllByCommentIdIsIn(List<Integer> commentIds);
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/post/Post.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/post/Post.java
@@ -139,6 +139,14 @@ public class Post {
         this.commentCount--;
     }
 
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        this.likeCount--;
+    }
+
     public void isWriter(Integer userId) {
         if (!this.userId.equals(userId)) {
             throw new ForbiddenException(FORBIDDEN_EXCEPTION.getErrorCode());

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/report/Report.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/report/Report.java
@@ -10,11 +10,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+
 import java.time.LocalDateTime;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import org.sopt.makers.crew.main.entity.comment.Comment;
 import org.sopt.makers.crew.main.entity.post.Post;
 import org.springframework.data.annotation.CreatedDate;
@@ -26,59 +29,59 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(name = "report")
 @EntityListeners(AuditingEntityListener.class)
 public class Report {
-    /**
-     * Primary key
-     */
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int id;
+	/**
+	 * Primary key
+	 */
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private int id;
 
-    /**
-     * 작성일
-     */
-    @Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
-    @CreatedDate
-    private LocalDateTime createdDate;
+	/**
+	 * 작성일
+	 */
+	@Column(name = "createdDate", nullable = false, columnDefinition = "TIMESTAMP")
+	@CreatedDate
+	private LocalDateTime createdDate;
 
-    /**
-     * 신고자 id
-     */
-    @Column(updatable = false)
-    private Integer userId;
+	/**
+	 * 신고자 id
+	 */
+	@Column(updatable = false)
+	private Integer userId;
 
-    /**
-     * 게시글
-     */
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "postId")
-    private Post post;
+	/**
+	 * 게시글
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "postId")
+	private Post post;
 
-    /**
-     * 게시글 id - 게시글 좋아요가 아닐 경우 null
-     */
-    @Column(insertable = false, updatable = false)
-    private Integer postId;
+	/**
+	 * 게시글 id - 게시글 좋아요가 아닐 경우 null
+	 */
+	@Column(insertable = false, updatable = false)
+	private Integer postId;
 
-    /**
-     * 댓글
-     */
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "commentId")
-    private Comment comment;
+	/**
+	 * 댓글
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "commentId")
+	private Comment comment;
 
-    /**
-     * 댓글 id - 댓글 좋아요가 아닐 경우 null
-     */
-    @Column(insertable = false, updatable = false)
-    private Integer commentId;
+	/**
+	 * 댓글 id - 댓글 좋아요가 아닐 경우 null
+	 */
+	@Column(insertable = false, updatable = false)
+	private Integer commentId;
 
-    @Builder
-    public Report(Integer userId, Post post, Integer postId, Comment comment,
-                  Integer commentId) {
-        this.userId = userId;
-        this.post = post;
-        this.postId = postId;
-        this.comment = comment;
-        this.commentId = commentId;
-    }
+	@Builder
+	public Report(Integer userId, Post post, Integer postId, Comment comment,
+		Integer commentId) {
+		this.userId = userId;
+		this.post = post;
+		this.postId = postId;
+		this.comment = comment;
+		this.commentId = commentId;
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/report/Report.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/report/Report.java
@@ -17,7 +17,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.makers.crew.main.entity.comment.Comment;
 import org.sopt.makers.crew.main.entity.post.Post;
-import org.sopt.makers.crew.main.entity.user.User;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -42,17 +41,10 @@ public class Report {
     private LocalDateTime createdDate;
 
     /**
-     * 신고자
-     */
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userId", nullable = false)
-    private User user;
-
-    /**
      * 신고자 id
      */
-    @Column(insertable = false, updatable = false)
-    private int userId;
+    @Column(updatable = false)
+    private Integer userId;
 
     /**
      * 게시글
@@ -78,12 +70,11 @@ public class Report {
      * 댓글 id - 댓글 좋아요가 아닐 경우 null
      */
     @Column(insertable = false, updatable = false)
-    private int commentId;
+    private Integer commentId;
 
     @Builder
-    public Report(User user, int userId, Post post, int postId, Comment comment,
-            int commentId) {
-        this.user = user;
+    public Report(Integer userId, Post post, Integer postId, Comment comment,
+                  Integer commentId) {
         this.userId = userId;
         this.post = post;
         this.postId = postId;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/report/ReportRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/report/ReportRepository.java
@@ -1,11 +1,10 @@
 package org.sopt.makers.crew.main.entity.report;
 
-import java.util.Optional;
-import org.sopt.makers.crew.main.entity.comment.Comment;
-import org.sopt.makers.crew.main.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportRepository extends JpaRepository<Report, Integer> {
 
-  Optional<Report> findByCommentAndUser(Comment comment, User user);
+    boolean existsByCommentIdAndUserId(Integer commentId, Integer userId);
+
+    boolean existsByPostIdAndUserId(Integer postId, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/report/ReportRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/report/ReportRepository.java
@@ -4,7 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportRepository extends JpaRepository<Report, Integer> {
 
-    boolean existsByCommentIdAndUserId(Integer commentId, Integer userId);
+	boolean existsByCommentIdAndUserId(Integer commentId, Integer userId);
 
-    boolean existsByPostIdAndUserId(Integer postId, Integer userId);
+	boolean existsByPostIdAndUserId(Integer postId, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
@@ -88,4 +88,11 @@ public interface PostV2Api {
     ResponseEntity<PostV2UpdatePostResponseDto> updatePost(@PathVariable Integer postId,
                                                            @RequestBody PostV2UpdatePostBodyDto requestBody,
                                                            Principal principal);
+
+    @Operation(summary = "모임 게시글 신고")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "\"게시글이 없습니다.\" or \"이미 신고한 게시글입니다.\"")
+    })
+    ResponseEntity<PostV2ReportResponseDto> reportPost(@PathVariable Integer postId, Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
@@ -19,6 +19,7 @@ import org.sopt.makers.crew.main.post.v2.dto.response.PostV2CreatePostResponseDt
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostCountResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2ReportResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostV2SwitchPostLikeResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2UpdatePostResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -96,4 +97,8 @@ public interface PostV2Api {
             @ApiResponse(responseCode = "400", description = "\"게시글이 없습니다.\" or \"이미 신고한 게시글입니다.\"", content = @Content)
     })
     ResponseEntity<PostV2ReportResponseDto> reportPost(@PathVariable Integer postId, Principal principal);
+
+    @Operation(summary = "모임 게시글 좋아요 토글")
+    @ApiResponse(responseCode = "201", description = "성공")
+    ResponseEntity<PostV2SwitchPostLikeResponseDto> switchPostLike(@PathVariable Integer postId, Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
@@ -18,6 +18,7 @@ import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailBaseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2CreatePostResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostCountResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostV2ReportResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2UpdatePostResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -82,8 +83,8 @@ public interface PostV2Api {
     @Operation(summary = "모임 게시글 수정")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "400", description = "\"게시글이 없습니다.\" or \"이미지는 최대 10개까지만 업로드 가능합니다.\""),
-            @ApiResponse(responseCode = "403", description = "권한이 없습니다.")
+            @ApiResponse(responseCode = "400", description = "\"게시글이 없습니다.\" or \"이미지는 최대 10개까지만 업로드 가능합니다.\"", content = @Content),
+            @ApiResponse(responseCode = "403", description = "권한이 없습니다.", content = @Content)
     })
     ResponseEntity<PostV2UpdatePostResponseDto> updatePost(@PathVariable Integer postId,
                                                            @RequestBody PostV2UpdatePostBodyDto requestBody,
@@ -91,8 +92,8 @@ public interface PostV2Api {
 
     @Operation(summary = "모임 게시글 신고")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "400", description = "\"게시글이 없습니다.\" or \"이미 신고한 게시글입니다.\"")
+            @ApiResponse(responseCode = "201", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "\"게시글이 없습니다.\" or \"이미 신고한 게시글입니다.\"", content = @Content)
     })
     ResponseEntity<PostV2ReportResponseDto> reportPost(@PathVariable Integer postId, Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
@@ -14,6 +14,7 @@ import org.sopt.makers.crew.main.post.v2.dto.response.PostV2CreatePostResponseDt
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostCountResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2ReportResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostV2SwitchPostLikeResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2UpdatePostResponseDto;
 import org.sopt.makers.crew.main.post.v2.service.PostV2Service;
 import org.springframework.http.HttpStatus;
@@ -106,6 +107,15 @@ public class PostV2Controller implements PostV2Api {
     public ResponseEntity<PostV2ReportResponseDto> reportPost(@PathVariable Integer postId, Principal principal) {
         Integer userId = UserUtil.getUserId(principal);
         return ResponseEntity.status(HttpStatus.CREATED).body(postV2Service.reportPost(postId, userId));
+    }
+
+    @Override
+    @PostMapping("/{postId}/like")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ResponseEntity<PostV2SwitchPostLikeResponseDto> switchPostLike(@PathVariable Integer postId,
+                                                                          Principal principal) {
+        Integer userId = UserUtil.getUserId(principal);
+        return ResponseEntity.status(HttpStatus.CREATED).body(postV2Service.switchPostLike(postId, userId));
     }
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
@@ -98,4 +98,13 @@ public class PostV2Controller implements PostV2Api {
         Integer userId = UserUtil.getUserId(principal);
         return ResponseEntity.ok(postV2Service.updatePost(postId, requestBody, userId));
     }
+
+    @Override
+    @PostMapping("/{postId}/report")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ResponseEntity<PostV2ReportResponseDto> reportPost(@PathVariable Integer postId, Principal principal) {
+        Integer userId = UserUtil.getUserId(principal);
+        return ResponseEntity.status(HttpStatus.CREATED).body(postV2Service.reportPost(postId, userId));
+    }
+
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
@@ -13,6 +13,7 @@ import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailBaseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2CreatePostResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostCountResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostV2ReportResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2UpdatePostResponseDto;
 import org.sopt.makers.crew.main.post.v2.service.PostV2Service;
 import org.springframework.http.HttpStatus;

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostV2ReportResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostV2ReportResponseDto.java
@@ -1,0 +1,16 @@
+package org.sopt.makers.crew.main.post.v2.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+@Schema(name = "PostV2ReportResponseDto", description = "게시글 신고 응답 Dto")
+public class PostV2ReportResponseDto {
+
+    @Schema(description = "생성된 신고 id", example = "1")
+    @NotNull
+    private final Integer reportId;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostV2SwitchPostLikeResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostV2SwitchPostLikeResponseDto.java
@@ -1,2 +1,16 @@
-package org.sopt.makers.crew.main.post.v2.dto.response;public class PostV2SwitchPostLikeResponseDto {
+package org.sopt.makers.crew.main.post.v2.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+@Schema(name = "PostV2SwitchPostLikeResponseDto", description = "모임 게시글 좋아요 토글 응답 Dto")
+public class PostV2SwitchPostLikeResponseDto {
+
+    @Schema(description = "본인이 게시글 좋아요를 눌렀는지 여부", example = "true")
+    @NotNull
+    private final Boolean isLiked;
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostV2SwitchPostLikeResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostV2SwitchPostLikeResponseDto.java
@@ -1,0 +1,2 @@
+package org.sopt.makers.crew.main.post.v2.dto.response;public class PostV2SwitchPostLikeResponseDto {
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2Service.java
@@ -8,6 +8,7 @@ import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailBaseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2CreatePostResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostCountResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostV2ReportResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2UpdatePostResponseDto;
 
 public interface PostV2Service {
@@ -25,4 +26,6 @@ public interface PostV2Service {
     void deletePost(Integer postId, Integer userId);
 
     PostV2UpdatePostResponseDto updatePost(Integer postId, PostV2UpdatePostBodyDto requestBody, Integer userId);
+
+    PostV2ReportResponseDto reportPost(Integer postId, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2Service.java
@@ -9,6 +9,7 @@ import org.sopt.makers.crew.main.post.v2.dto.response.PostV2CreatePostResponseDt
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostCountResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2ReportResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostV2SwitchPostLikeResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2UpdatePostResponseDto;
 
 public interface PostV2Service {
@@ -28,4 +29,6 @@ public interface PostV2Service {
     PostV2UpdatePostResponseDto updatePost(Integer postId, PostV2UpdatePostBodyDto requestBody, Integer userId);
 
     PostV2ReportResponseDto reportPost(Integer postId, Integer userId);
+
+    PostV2SwitchPostLikeResponseDto switchPostLike(Integer postId, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
@@ -1,6 +1,7 @@
 package org.sopt.makers.crew.main.post.v2.service;
 
 import static java.util.stream.Collectors.toList;
+import static org.sopt.makers.crew.main.common.exception.ErrorStatus.ALREADY_REPORTED_POST;
 import static org.sopt.makers.crew.main.common.exception.ErrorStatus.FORBIDDEN_EXCEPTION;
 import static org.sopt.makers.crew.main.common.exception.ErrorStatus.MAX_IMAGE_UPLOAD_EXCEEDED;
 import static org.sopt.makers.crew.main.internal.notification.PushNotificationEnums.NEW_POST_MENTION_PUSH_NOTIFICATION_TITLE;
@@ -24,6 +25,8 @@ import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
 import org.sopt.makers.crew.main.entity.post.Post;
 import org.sopt.makers.crew.main.entity.post.PostRepository;
+import org.sopt.makers.crew.main.entity.report.Report;
+import org.sopt.makers.crew.main.entity.report.ReportRepository;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.entity.user.UserRepository;
 import org.sopt.makers.crew.main.internal.notification.PushNotificationService;
@@ -37,6 +40,7 @@ import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2CreatePostResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostCountResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostV2ReportResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2UpdatePostResponseDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -55,6 +59,7 @@ public class PostV2ServiceImpl implements PostV2Service {
     private final ApplyRepository applyRepository;
     private final CommentRepository commentRepository;
     private final LikeRepository likeRepository;
+    private final ReportRepository reportRepository;
 
     private final PushNotificationService pushNotificationService;
 
@@ -225,5 +230,35 @@ public class PostV2ServiceImpl implements PostV2Service {
         return PostV2UpdatePostResponseDto.of(post.getId(), post.getTitle(), post.getContents(),
                 String.valueOf(time.now()),
                 post.getImages());
+    }
+
+    /**
+     * 모임 게시글 신고
+     *
+     * @param postId 신고할 게시글 id
+     * @param userId 신고하는 유저 id
+     * @return 신고 ID
+     * @throws 400 존재하지 않는 게시글인 경우
+     * @throws 400 이미 신고한 게시글인 경우
+     * @apiNote 중복 신고는 되지 않음
+     */
+    @Override
+    @Transactional
+    public PostV2ReportResponseDto reportPost(Integer postId, Integer userId) {
+        Post post = postRepository.findByIdOrThrow(postId);
+
+        if (reportRepository.existsByPostIdAndUserId(postId, userId)) {
+            throw new BadRequestException(ALREADY_REPORTED_POST.getErrorCode());
+        }
+
+        Report report = Report.builder()
+                .post(post)
+                .postId(postId)
+                .userId(userId)
+                .build();
+
+        Report savedReport = reportRepository.save(report);
+        
+        return PostV2ReportResponseDto.of(savedReport.getId());
     }
 }

--- a/main/src/test/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/comment/v2/service/CommentV2ServiceTest.java
@@ -96,7 +96,7 @@ public class CommentV2ServiceTest {
                 .user(user)
                 .userId(1).build();
 
-        this.report = Report.builder().comment(comment).user(user).build();
+        this.report = Report.builder().comment(comment).userId(user.getId()).build();
     }
 
     @Nested
@@ -173,8 +173,7 @@ public class CommentV2ServiceTest {
         void 댓글_신고_성공() {
             // given
             doReturn(comment).when(commentRepository).findByIdOrThrow(any());
-            doReturn(user).when(userRepository).findByIdOrThrow(any());
-            doReturn(Optional.empty()).when(reportRepository).findByCommentAndUser(any(), any());
+            doReturn(false).when(reportRepository).existsByCommentIdAndUserId(any(), any());
             doReturn(report).when(reportRepository).save(any());
 
             // when
@@ -189,8 +188,7 @@ public class CommentV2ServiceTest {
         void 댓글_신고_실패_이미_신고한_댓글() {
             // given
             doReturn(comment).when(commentRepository).findByIdOrThrow(any());
-            doReturn(user).when(userRepository).findByIdOrThrow(any());
-            doReturn(Optional.of(report)).when(reportRepository).findByCommentAndUser(any(), any());
+            doReturn(true).when(reportRepository).existsByCommentIdAndUserId(any(), any());
 
             // when & then
             assertThrows(BadRequestException.class, () -> {

--- a/main/src/test/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.makers.crew.main.common.exception.BadRequestException;
 import org.sopt.makers.crew.main.common.exception.ForbiddenException;
 import org.sopt.makers.crew.main.common.util.Time;
 import org.sopt.makers.crew.main.entity.comment.CommentRepository;
@@ -23,10 +24,13 @@ import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.post.Post;
 import org.sopt.makers.crew.main.entity.post.PostRepository;
+import org.sopt.makers.crew.main.entity.report.Report;
+import org.sopt.makers.crew.main.entity.report.ReportRepository;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.entity.user.UserFixture;
 import org.sopt.makers.crew.main.entity.user.UserRepository;
 import org.sopt.makers.crew.main.post.v2.dto.request.PostV2UpdatePostBodyDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostV2ReportResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2UpdatePostResponseDto;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,6 +46,8 @@ public class PostV2ServiceTest {
     private PostRepository postRepository;
     @Mock
     private CommentRepository commentRepository;
+    @Mock
+    private ReportRepository reportRepository;
 
     @Mock
     private Time time;
@@ -51,6 +57,8 @@ public class PostV2ServiceTest {
     private Meeting meeting;
 
     private Post post;
+
+    private Report report;
 
     @BeforeEach
     void init() {
@@ -81,6 +89,7 @@ public class PostV2ServiceTest {
 
         String[] images = {"image1", "image2", "image3"};
         post = Post.builder().user(user).title("title").contents("contents").images(images).meeting(meeting).build();
+        report = Report.builder().post(post).postId(post.getId()).userId(user.getId()).build();
 
     }
 
@@ -118,6 +127,37 @@ public class PostV2ServiceTest {
             assertThrows(ForbiddenException.class, () -> {
                 postV2Service.updatePost(post.getId(), requestDto,
                         post.getUser().getId() + 1);
+            });
+        }
+    }
+
+    @Nested
+    class 게시글_신고 {
+
+        @Test
+        void 게시글_신고_성공() {
+            // given
+            doReturn(post).when(postRepository).findByIdOrThrow(any());
+            doReturn(false).when(reportRepository).existsByPostIdAndUserId(any(), any());
+            doReturn(report).when(reportRepository).save(any());
+
+            // when
+            PostV2ReportResponseDto result = postV2Service.reportPost(post.getId(),
+                    user.getId());
+
+            // then
+            Assertions.assertThat(result.getReportId()).isEqualTo(report.getId());
+        }
+
+        @Test
+        void 댓글_신고_실패_이미_신고한_댓글() {
+            // given
+            doReturn(post).when(postRepository).findByIdOrThrow(any());
+            doReturn(true).when(reportRepository).existsByPostIdAndUserId(any(), any());
+
+            // when & then
+            assertThrows(BadRequestException.class, () -> {
+                postV2Service.reportPost(post.getId(), user.getId());
             });
         }
     }

--- a/server/src/post/v1/post-v1.controller.ts
+++ b/server/src/post/v1/post-v1.controller.ts
@@ -124,6 +124,7 @@ export class PostV1Controller {
 
   @ApiOperation({
     summary: '게시글 좋아요 토글',
+    deprecated: true,
   })
   @ApiOkResponseCommon(PostV1SwitchPostLikeResponseDto)
   @ApiBearerAuth()

--- a/server/src/post/v1/post-v1.controller.ts
+++ b/server/src/post/v1/post-v1.controller.ts
@@ -138,6 +138,7 @@ export class PostV1Controller {
 
   @ApiOperation({
     summary: '모임 게시글 신고',
+    deprecated: true,
   })
   @ApiOkResponseCommon(PostV1ReportPostResponseDto)
   @ApiResponse({


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 게시글 좋아요 토글 및 게시글 신고 API V2를 구현했습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

- Like에 묶여있던 ManyToOne 연관 관계를 최대한 제거해서 예상치 못한 쿼리 발생을 줄이고자 했습니다.
- 그 과정에서 댓글 좋아요 토글 api 관련 코드에 약간씩 수정이 있었습니다.

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #328 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?