### PR TITLE
chore: 모임 관련 API 스웨거에 보이는 응답값 수정

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/common/dto/MeetingResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/dto/MeetingResponseDto.java
@@ -44,7 +44,7 @@ public class MeetingResponseDto {
 	@Schema(example = "false", description = "활동기수만 지원 가능 여부")
 	@NotNull
 	private final Boolean canJoinOnlyActiveGeneration;
-	@Schema(example = "2", description = "모임 활동 상태")
+	@Schema(example = "2", description = "모임 활동 상태", type = "number", allowableValues = {"0", "1", "2"})
 	@NotNull
 	private final Integer status;
 	/**

--- a/main/src/main/java/org/sopt/makers/crew/main/common/dto/MeetingResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/dto/MeetingResponseDto.java
@@ -44,9 +44,9 @@ public class MeetingResponseDto {
 	@Schema(example = "false", description = "활동기수만 지원 가능 여부")
 	@NotNull
 	private final Boolean canJoinOnlyActiveGeneration;
-	@Schema(example = "2", description = "모임 활동 상태", type = "number", allowableValues = {"0", "1", "2"})
+	@Schema(example = "2", description = "모임 활동 상태", type = "integer", allowableValues = {"0", "1", "2"})
 	@NotNull
-	private final Integer status;
+	private final int status;
 	/**
 	 * 썸네일 이미지
 	 *

--- a/main/src/main/java/org/sopt/makers/crew/main/common/dto/MeetingResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/common/dto/MeetingResponseDto.java
@@ -58,10 +58,10 @@ public class MeetingResponseDto {
 	@Schema(example = "false", description = "멘토 필요 여부")
 	@NotNull
 	private final Boolean isMentorNeeded;
-	@Schema(description = "모임 활동 시작일", example = "2024-07-31T15:30:00")
+	@Schema(description = "모임 활동 시작일", example = "2024-07-31T15:30:00", name = "mStartDate")
 	@NotNull
 	private final LocalDateTime mStartDate;
-	@Schema(description = "모임 활동 종료일", example = "2024-08-25T15:30:00")
+	@Schema(description = "모임 활동 종료일", example = "2024-08-25T15:30:00", name = "mEndDate")
 	@NotNull
 	private final LocalDateTime mEndDate;
 	@Schema(description = "모집 인원", example = "20")
@@ -101,7 +101,15 @@ public class MeetingResponseDto {
 		this.appliedCount = appliedCount;
 	}
 
-	public static MeetingResponseDto of(Meeting meeting, User meetingCreator, int appliedCount, LocalDateTime now){
+	public LocalDateTime getmStartDate() {
+		return mStartDate;
+	}
+
+	public LocalDateTime getmEndDate() {
+		return mEndDate;
+	}
+
+	public static MeetingResponseDto of(Meeting meeting, User meetingCreator, int appliedCount, LocalDateTime now) {
 		MeetingCreatorDto creatorDto = MeetingCreatorDto.of(meetingCreator);
 		boolean canJoinOnlyActiveGeneration = meeting.getTargetActiveGeneration() == CrewConst.ACTIVE_GENERATION
 			&& meeting.getCanJoinOnlyActiveGeneration();
@@ -109,6 +117,7 @@ public class MeetingResponseDto {
 		return new MeetingResponseDto(meeting.getId(), meeting.getTitle(),
 			meeting.getTargetActiveGeneration(), meeting.getJoinableParts(), meeting.getCategory(),
 			canJoinOnlyActiveGeneration, meeting.getMeetingStatus(now), meeting.getImageURL(),
-			meeting.getIsMentorNeeded(), meeting.getMStartDate(), meeting.getMEndDate(), meeting.getCapacity(), creatorDto, appliedCount);
+			meeting.getIsMentorNeeded(), meeting.getMStartDate(), meeting.getMEndDate(), meeting.getCapacity(),
+			creatorDto, appliedCount);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/query/MeetingV2GetAllMeetingQueryDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/query/MeetingV2GetAllMeetingQueryDto.java
@@ -13,15 +13,15 @@ import lombok.Setter;
 @Setter
 public class MeetingV2GetAllMeetingQueryDto extends PageOptionsDto {
 
-
 	List<String> category;
 
 	List<String> status;
+
 	@NotNull
 	Boolean isOnlyActiveGeneration;
-	@NotNull
+
 	MeetingJoinablePart[] joinableParts;
-	@NotNull
+
 	String query;
 
 	public MeetingV2GetAllMeetingQueryDto(Integer page, Integer take) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
@@ -106,9 +106,9 @@ public class MeetingV2GetMeetingByIdResponseDto {
 	@NotNull
 	private final MeetingJoinablePart[] joinableParts;
 
-	@Schema(description = "모임 상태, 0: 모집전, 1: 모집중, 2: 모집종료", example = "1", type = "number", allowableValues = {"0", "1", "2"})
+	@Schema(description = "모임 상태, 0: 모집전, 1: 모집중, 2: 모집종료", example = "1", type = "integer", allowableValues = {"0", "1", "2"})
 	@NotNull
-	private final Integer status;
+	private final int status;
 
 	@Schema(description = "승인된 신청 수", example = "7")
 	@NotNull

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
@@ -106,7 +106,7 @@ public class MeetingV2GetMeetingByIdResponseDto {
 	@NotNull
 	private final MeetingJoinablePart[] joinableParts;
 
-	@Schema(description = "모임 상태, 0: 모집전, 1: 모집중, 2: 모집종료", example = "1")
+	@Schema(description = "모임 상태, 0: 모집전, 1: 모집중, 2: 모집종료", example = "1", type = "number", allowableValues = {"1", "2", "3"})
 	@NotNull
 	private final Integer status;
 

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
@@ -106,7 +106,7 @@ public class MeetingV2GetMeetingByIdResponseDto {
 	@NotNull
 	private final MeetingJoinablePart[] joinableParts;
 
-	@Schema(description = "모임 상태, 0: 모집전, 1: 모집중, 2: 모집종료", example = "1", type = "number", allowableValues = {"1", "2", "3"})
+	@Schema(description = "모임 상태, 0: 모집전, 1: 모집중, 2: 모집종료", example = "1", type = "number", allowableValues = {"0", "1", "2"})
 	@NotNull
 	private final Integer status;
 

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/ApplyV2GetAppliedMeetingByUserResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/ApplyV2GetAppliedMeetingByUserResponseDto.java
@@ -8,9 +8,9 @@ public record ApplyV2GetAppliedMeetingByUserResponseDto(
 	@Schema(description = "신청 id", example = "130")
 	@NotNull
 	Integer id,
-	@Schema(description = "신청 상태", example = "1", type = "number", allowableValues = {"0", "1", "2"})
+	@Schema(description = "신청 상태", example = "1", type = "integer", allowableValues = {"0", "1", "2"})
 	@NotNull
-	Integer status,
+	int status,
 	@Schema(description = "신청 모임 정보")
 	@NotNull
 	MeetingV2GetCreatedMeetingByUserResponseDto meeting

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/ApplyV2GetAppliedMeetingByUserResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/ApplyV2GetAppliedMeetingByUserResponseDto.java
@@ -8,7 +8,7 @@ public record ApplyV2GetAppliedMeetingByUserResponseDto(
 	@Schema(description = "신청 id", example = "130")
 	@NotNull
 	Integer id,
-	@Schema(description = "신청 상태", example = "1")
+	@Schema(description = "신청 상태", example = "1", type = "number", allowableValues = {"1", "2", "3"})
 	@NotNull
 	Integer status,
 	@Schema(description = "신청 모임 정보")

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/ApplyV2GetAppliedMeetingByUserResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/ApplyV2GetAppliedMeetingByUserResponseDto.java
@@ -8,7 +8,7 @@ public record ApplyV2GetAppliedMeetingByUserResponseDto(
 	@Schema(description = "신청 id", example = "130")
 	@NotNull
 	Integer id,
-	@Schema(description = "신청 상태", example = "1", type = "number", allowableValues = {"1", "2", "3"})
+	@Schema(description = "신청 상태", example = "1", type = "number", allowableValues = {"0", "1", "2"})
 	@NotNull
 	Integer status,
 	@Schema(description = "신청 모임 정보")

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
@@ -36,7 +36,7 @@ public record MeetingV2GetCreatedMeetingByUserResponseDto(
 	@Schema(example = "false", description = "활동기수만 지원 가능 여부")
 	@NotNull
 	Boolean canJoinOnlyActiveGeneration,
-	@Schema(example = "2", description = "모임 활동 상태", type = "number", allowableValues = {"1", "2", "3"})
+	@Schema(example = "2", description = "모임 활동 상태", type = "number", allowableValues = {"0", "1", "2"})
 	@NotNull
 	Integer status,
 	/**

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
@@ -36,7 +36,7 @@ public record MeetingV2GetCreatedMeetingByUserResponseDto(
 	@Schema(example = "false", description = "활동기수만 지원 가능 여부")
 	@NotNull
 	Boolean canJoinOnlyActiveGeneration,
-	@Schema(example = "2", description = "모임 활동 상태")
+	@Schema(example = "2", description = "모임 활동 상태", type = "number", allowableValues = {"1", "2", "3"})
 	@NotNull
 	Integer status,
 	/**
@@ -66,7 +66,8 @@ public record MeetingV2GetCreatedMeetingByUserResponseDto(
 	@NotNull
 	int appliedCount
 ) {
-	public static MeetingV2GetCreatedMeetingByUserResponseDto of(Meeting meeting, User meetingCreator, int appliedCount, LocalDateTime now) {
+	public static MeetingV2GetCreatedMeetingByUserResponseDto of(Meeting meeting, User meetingCreator, int appliedCount,
+		LocalDateTime now) {
 		MeetingCreatorDto creatorDto = MeetingCreatorDto.of(meetingCreator);
 		boolean canJoinOnlyActiveGeneration = meeting.getTargetActiveGeneration() == CrewConst.ACTIVE_GENERATION
 			&& meeting.getCanJoinOnlyActiveGeneration();
@@ -74,7 +75,8 @@ public record MeetingV2GetCreatedMeetingByUserResponseDto(
 		return new MeetingV2GetCreatedMeetingByUserResponseDto(meeting.getId(), meeting.getTitle(),
 			meeting.getTargetActiveGeneration(), meeting.getJoinableParts(), meeting.getCategory().getValue(),
 			canJoinOnlyActiveGeneration, meeting.getMeetingStatus(now), meeting.getImageURL(),
-			meeting.getIsMentorNeeded(), meeting.getMStartDate(), meeting.getMEndDate(), meeting.getCapacity(), creatorDto, appliedCount);
+			meeting.getIsMentorNeeded(), meeting.getMStartDate(), meeting.getMEndDate(), meeting.getCapacity(),
+			creatorDto, appliedCount);
 	}
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
@@ -36,9 +36,9 @@ public record MeetingV2GetCreatedMeetingByUserResponseDto(
 	@Schema(example = "false", description = "활동기수만 지원 가능 여부")
 	@NotNull
 	Boolean canJoinOnlyActiveGeneration,
-	@Schema(example = "2", description = "모임 활동 상태", type = "number", allowableValues = {"0", "1", "2"})
+	@Schema(example = "2", description = "모임 활동 상태", type = "integer", allowableValues = {"0", "1", "2"})
 	@NotNull
-	Integer status,
+	int status,
 	/**
 	 * 썸네일 이미지
 	 *


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->

### mStartDate, mEndDate로 변경
<img width="319" alt="스크린샷 2024-09-07 오전 9 58 45" src="https://github.com/user-attachments/assets/755af04a-7921-4a50-aaf8-abdd5dec498c">
</br>
* 기존에 스웨거 상에서 mstartDate 로 보이는 문제가 있었습니다. 실제 응답에서는 그렇게 응답이 되지 않지만 스웨거 상에서만 보이는 것이었는데요! 프론트측에서 스웨거에 의존해 타입이나 변수명 같은 것을 정하고 있어서 올바르게 수정했습니다.

### 스웨거 타입 Enum 으로 변경
<img width="328" alt="스크린샷 2024-09-07 오전 10 00 19" src="https://github.com/user-attachments/assets/90912f70-a8be-4169-af2f-ead832ad861e">
</br>
* 현재는 number 타입으로 되어있었는데 프론트측에서 Enum 으로 요청주셔서 수정했습니다!

### @NotNull 오류 수정
* 이건 따로 이슈파서 하는게 맞지만 수정 범위가 작아서 같이 올려봅니다...!
* `NotNull`이 아닌데 제가 `NotNull` 로 validation 을 걸어놔서 수정했습니다...!

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #360 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?