### PR TITLE
feat: application-local.yml 구현

### DIFF
--- a/main/src/main/resources/application-local.yml
+++ b/main/src/main/resources/application-local.yml
@@ -1,0 +1,93 @@
+server:
+  port: 4000
+
+spring:
+  config:
+    activate:
+      on-profile: local
+    import: application-secret.properties
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${LOCAL_DB_HOST}:${LOCAL_DB_PORT}/${LOCAL_DB_NAME}?currentSchema=${LOCAL_DB_SCHEMA}
+    username: ${LOCAL_DB_USERNAME}
+    password: ${LOCAL_DB_PASSWORD}
+  jpa:
+    open-in-view: false
+    hibernate:
+      naming:
+        physical-strategy: org.sopt.makers.crew.main.common.config.CamelCaseNamingStrategy
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+      dialect: org.hibernate.dialect.PostgreSQLDialect
+      storage_engine: innodb
+
+jwt:
+  header: Authorization
+  secret: ${LOCAL_JWT_SECRET}
+  access-token:
+    expire-length: ${ACCESS_TOKEN_EXPIRED_TIME}
+
+aws-property:
+  aws-region: ${AWS_REGION}
+  s3-bucket-name: ${AWS_S3_BUCKET_NAME}
+  access-key: ${AWS_ACCESS_KEY_ID}
+  secret-key: ${AWS_SECRET_ACCESS_KEY}
+  file-min-size: ${AWS_FILE_MIN_SIZE}
+  file-max-size: ${AWS_FILE_MAX_SIZE}
+  algorithm: ${AWS_ALGORITHM}
+  content-type: ${AWS_CONTENT_TYPE}
+  request-type: ${AWS_REQUEST_TYPE}
+  object-url: ${AWS_OBJECT_URL}
+
+springdoc:
+  packages-to-scan: org.sopt.makers.crew
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    tags-sorter: alpha
+    operations-sorter: alpha
+  api-docs:
+    path: /api-docs/json
+    groups:
+      enabled: true
+
+push-notification:
+  web-url: ${LOCAL_WEB_PAGE_URL}
+  x-api-key: ${LOCAL_PUSH_API_KEY}
+  service: ${PUSH_NOTIFICATION_SERVICE}
+  push-server-url: ${LOCAL_PUSH_SERVER_URL}
+
+notice:
+  secret-key : ${NOTICE_SECRET_KEY}
+
+playground:
+  server:
+    url: ${LOCAL_PLAYGROUND_URL}
+    endpoint: ${PLAYGROUND_ENDPOINT}
+
+management:
+  server:
+    port: ${ACTUATOR_PORT}
+  endpoints:
+    enabled-by-default: false
+    jmx:
+      exposure:
+        exclude: "*"
+    web:
+      exposure:
+        include: info, health, prometheus
+      base-path: ${ACTUATOR_PATH}
+  endpoint:
+    health:
+      enabled: true
+    info:
+      enabled: true
+    prometheus:
+      enabled: true
+  prometheus:
+    metrics:
+      export:
+        enabled: true


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 기존에 local.yml이 구축되어 있지 않았기에 로컬 작업을 위한 application-local.yml을 구현했습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 현재 postgreSQL에서 Enum 배열 타입을 JPA와 Hibernate를 통해 매핑할 때, `ddl-auto: create` 설정을 사용할 경우 Enum 배열 타입을 제대로 인식하지 못하는 문제가 발생합니다.
- 이에 대한 해결방법은 노션으로 남겨놓았으니 확인부탁드릴게요!
https://www.notion.so/sopt-makers/JPA-6b53bcdd07cb4675b689a89c1c40567a?pvs=4
- 추가로 `application-secret-properties`에 변경내용 반영해 놓았습니다!

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #372 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?