### PR TITLE
fix: isBlockedPost를 Lombok getter에서 생략 후 직접 getter 구현

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostDetailResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostDetailResponseDto.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -63,6 +64,7 @@ public class PostDetailResponseDto {
 
 	@Schema(description = "차단된 유저의 게시물인지 여부", example = "false")
 	@NotNull
+	@Getter(AccessLevel.NONE)
 	private final boolean isBlockedPost;
 
 	public static PostDetailResponseDto of(PostDetailBaseDto postDetail,
@@ -71,5 +73,9 @@ public class PostDetailResponseDto {
 			postDetail.getCreatedDate(), postDetail.getImages(), postDetail.getUser(), postDetail.getLikeCount(),
 			postDetail.getIsLiked(), postDetail.getViewCount(), postDetail.getCommentCount(), postDetail.getMeeting(),
 			postTopCommenterThumbnails.getCommenterThumbnails(), isBlockedPost);
+	}
+
+	public boolean getIsBlockedPost() {
+		return isBlockedPost;
 	}
 }


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
<img width="327" alt="image" src="https://github.com/user-attachments/assets/0f6f0436-25ae-416c-b653-70f9ba6ac7f2">

- 스웨거 명세에 boolean variable에 붙은 is prefix를 인식 못하는 문제를 해결했습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- boolean을 wrapper 타입인 Boolean으로 바꾸어줘서 is prefix를 인식을 하는 방법과, isBlockedPost를 Lombok getter에서 생략 후 직접 구현하는 방법이 있었습니다.
- 후자로 선택하게된 이유는 기존 boolean으로 필드를 구축했던건 null값을 허용하지 않으려는 의도였기 때문에, 명세를 위해 Boolean으로 바꾸는 것보다는 getter를 직접 구현하는게 더 의도에 맞다고 판단하였기 때문입니다.

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #396 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?