### PR TITLE
refactor: isBlockedComment를 Lombok getter에서 생략 후 직접 getter 구현 

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/response/CommentDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/response/CommentDto.java
@@ -2,16 +2,14 @@ package org.sopt.makers.crew.main.comment.v2.dto.response;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import org.sopt.makers.crew.main.entity.comment.Comment;
-import org.sopt.makers.crew.main.entity.user.User;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.querydsl.core.annotations.QueryProjection;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.Getter;
 
 @Getter
@@ -55,12 +53,13 @@ public class CommentDto {
 	private final List<ReplyDto> replies;
 
 	@Schema(description = "차단여부", example = "false")
+	@Getter(AccessLevel.NONE)
 	@NotNull
-	private final Boolean isBlockedComment;
+	private final boolean isBlockedComment;
 
 	@QueryProjection
 	public CommentDto(Integer id, String contents, CommentWriterDto user, LocalDateTime createdDate, int likeCount,
-		boolean isLiked, boolean isWriter, int order, List<ReplyDto> replies, Boolean isBlockedComment) {
+		boolean isLiked, boolean isWriter, int order, List<ReplyDto> replies, boolean isBlockedComment) {
 		this.id = id;
 		this.contents = contents;
 		this.user = user;
@@ -74,7 +73,7 @@ public class CommentDto {
 	}
 
 	public static CommentDto of(Comment comment, boolean isLiked, boolean isWriter, List<ReplyDto> replies,
-		Boolean isBlockedComment) {
+		boolean isBlockedComment) {
 		Integer userId = comment.getUser() == null ? null : comment.getUser().getId();
 		Integer orgId = comment.getUser() == null ? null : comment.getUser().getOrgId();
 		String userName = comment.getUser() == null ? null : comment.getUser().getName();
@@ -84,5 +83,9 @@ public class CommentDto {
 			new CommentWriterDto(userId, orgId, userName,
 				profileImage), comment.getCreatedDate(), comment.getLikeCount(),
 			isLiked, isWriter, comment.getOrder(), replies, isBlockedComment);
+	}
+
+	public boolean getIsBlockedComment() {
+		return isBlockedComment;
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/response/ReplyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/comment/v2/dto/response/ReplyDto.java
@@ -1,10 +1,14 @@
 package org.sopt.makers.crew.main.comment.v2.dto.response;
 
 import java.time.LocalDateTime;
+
 import org.sopt.makers.crew.main.entity.comment.Comment;
+
 import com.querydsl.core.annotations.QueryProjection;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.Getter;
 
 @Getter
@@ -44,12 +48,13 @@ public class ReplyDto {
 	private final int order;
 
 	@Schema(description = "차단여부", example = "false")
+	@Getter(AccessLevel.NONE)
 	@NotNull
-	private final Boolean isBlockedComment;
+	private final boolean isBlockedComment;
 
 	@QueryProjection
 	public ReplyDto(Integer id, String contents, CommentWriterDto user, LocalDateTime createdDate, int likeCount,
-		Boolean isLiked, Boolean isWriter, int order, Boolean isBlockedComment) {
+		Boolean isLiked, Boolean isWriter, int order, boolean isBlockedComment) {
 		this.id = id;
 		this.contents = contents;
 		this.user = user;
@@ -61,10 +66,14 @@ public class ReplyDto {
 		this.isBlockedComment = isBlockedComment;
 	}
 
-	public static ReplyDto of(Comment comment, boolean isLiked, boolean isWriter,  boolean isBlockedComment) {
+	public static ReplyDto of(Comment comment, boolean isLiked, boolean isWriter, boolean isBlockedComment) {
 		return new ReplyDto(comment.getId(), comment.getContents(),
 			new CommentWriterDto(comment.getUser().getId(), comment.getUser().getOrgId(), comment.getUser().getName(),
 				comment.getUser().getProfileImage()), comment.getCreatedDate(), comment.getLikeCount(),
 			isLiked, isWriter, comment.getOrder(), isBlockedComment);
+	}
+
+	public boolean getIsBlockedComment() {
+		return isBlockedComment;
 	}
 }


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
<img width="417" alt="image" src="https://github.com/user-attachments/assets/32545812-4090-4f27-91bd-b8e19a073a5c">

- isBlockedComment를 Lombok getter에서 생략 후 직접 getter 구현하도록 변경했습니다.
- 스웨거 명세에도 잘 적용이 된 것을 확인했습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #399 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?