### PR TITLE
refactor: 광고 구좌 조회 응답 DTO에서 isSponsoredContent 필드 제거

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/advertisement/dto/AdvertisementsGetResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/advertisement/dto/AdvertisementsGetResponseDto.java
@@ -35,12 +35,7 @@ public record AdvertisementsGetResponseDto(
 
 		@Schema(description = "광고 게시 시작일", example = "2024-07-31T00:00:00")
 		@NotNull
-		LocalDateTime advertisementStartDate,
-
-		@Schema(description = "광고성 컨텐츠 여부", example = "true")
-		@NotNull
-		boolean isSponsoredContent
-
+		LocalDateTime advertisementStartDate
 	) {
 		public static AdvertisementGetDto of(Advertisement advertisement) {
 			return new AdvertisementGetDto(
@@ -48,8 +43,7 @@ public record AdvertisementsGetResponseDto(
 				advertisement.getAdvertisementDesktopImageUrl(),
 				advertisement.getAdvertisementMobileImageUrl(),
 				advertisement.getAdvertisementLink(),
-				advertisement.getAdvertisementStartDate(),
-				advertisement.isSponsoredContent()
+				advertisement.getAdvertisementStartDate()
 			);
 		}
 	}


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- FE 측에서 isSponsoredContent 필드를 추가함으로서 불필요한 리소스가 들게 되기 때문에, 삭제해달라는 요청을 받아 해당 필드를 삭제했습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

<img width="339" alt="image" src="https://github.com/user-attachments/assets/7adea5af-24be-4802-a9f0-ece2652c5256">

- 필드를 삭제한 후 광고 구좌 조회 시 isSponsoredContent 필드가 포함되지 않고 잘 작동하는 것을 확인했습니다.


## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #418 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?