### PR TITLE
fix: 회원가입 시 user 객체를 생성한 후 orgId에 접근할 수 있도록 수정

### DIFF
--- a/server/src/auth/v0/auth-v0.service.ts
+++ b/server/src/auth/v0/auth-v0.service.ts
@@ -1,97 +1,80 @@
-import {
-  HttpException,
-  HttpStatus,
-  Injectable,
-  UnauthorizedException,
-} from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { JwtService } from '@nestjs/jwt';
-import { PlaygroundService } from 'src/internal-api/playground/playground.service';
-import { UserActivity } from 'src/entity/user/interface/user-activity.interface';
-import { AuthV0TokenDto } from './dto/auth-v0-token.dto';
-import { UserRepository } from 'src/entity/user/user.repository';
-import { UserPart } from 'src/entity/user/enum/user-part.enum';
+import {HttpException, HttpStatus, Injectable, UnauthorizedException,} from '@nestjs/common';
+import {InjectRepository} from '@nestjs/typeorm';
+import {JwtService} from '@nestjs/jwt';
+import {PlaygroundService} from 'src/internal-api/playground/playground.service';
+import {UserActivity} from 'src/entity/user/interface/user-activity.interface';
+import {AuthV0TokenDto} from './dto/auth-v0-token.dto';
+import {UserRepository} from 'src/entity/user/user.repository';
+import {UserPart} from 'src/entity/user/enum/user-part.enum';
 
 @Injectable()
 export class AuthV0Service {
-  constructor(
-    @InjectRepository(UserRepository)
-    private userRepository: UserRepository,
-
-    private playgroundService: PlaygroundService,
-    private jwtService: JwtService,
-  ) {}
-
-  async loginUser(authTokenDTO: AuthV0TokenDto) {
-    const { authToken } = authTokenDTO;
-
-    try {
-      const { id, name, profileImage } = await this.playgroundService.getUser(
-        authToken,
-      );
-      const user = await this.userRepository.getUserByOrgId(id);
-      const userId: number = await (async () => {
-        if (!user) {
-          const newUser = await this.userRepository.save({
-            orgId: id,
-            name,
-            profileImage,
-          });
-
-          return newUser.id;
-        }
-
-        return user.id;
-      })();
-
-      const playgroundUserProfile = await this.playgroundService.getUserProfile(
-        authToken,
-      );
-
-    
-      const playgroundUserActivities = await this.playgroundService.getUserActivities(
-        authToken, user.orgId
-      );
-
-      const activities: UserActivity[] = playgroundUserActivities[0].activities.flatMap((activity) => {
-        const [generationString, partString] = activity.cardinalInfo.split(',');
-        const generation = parseInt(generationString);
-        const partKey = getKeyByValue(UserPart, partString);
-        const part = UserPart[partKey];
-
-        return {
-          generation: generation, 
-          part: part 
-        };
-    });
-      
-      const phone = playgroundUserProfile.phone
-        ? playgroundUserProfile.phone
-        : null;
-
-      await this.userRepository.update(
-        { id: userId },
-        { activities, profileImage, name, phone },
-      );
-
-      const payload = { name, id: userId };
-      const accessToken = this.jwtService.sign(payload);
-
-      return { accessToken };
-    } catch (error) {
-      console.log(error);
-      if (error.response?.status === HttpStatus.UNAUTHORIZED) {
-        throw new UnauthorizedException({ message: '유효하지 않은 토큰' });
-      }
-
-      throw new HttpException(
-        { message: '로그인 서버 에러' },
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
+    constructor(
+        @InjectRepository(UserRepository)
+        private userRepository: UserRepository,
+        private playgroundService: PlaygroundService,
+        private jwtService: JwtService,
+    ) {
     }
-  }
+
+    async loginUser(authTokenDTO: AuthV0TokenDto) {
+        const {authToken} = authTokenDTO;
+
+        try {
+            const {id, name, profileImage} = await this.playgroundService.getUser(authToken);
+
+            let user = await this.userRepository.getUserByOrgId(id);
+
+            if (!user) {
+                user = await this.userRepository.save({
+                    orgId: id,
+                    name,
+                    profileImage,
+                });
+            }
+
+            const playgroundUserProfile = await this.playgroundService.getUserProfile(authToken);
+            const playgroundUserActivities = await this.playgroundService.getUserActivities(authToken, user.orgId);
+
+            const activities: UserActivity[] = playgroundUserActivities[0].activities.flatMap((activity) => {
+                const [generationString, partString] = activity.cardinalInfo.split(',');
+                const generation = parseInt(generationString);
+                const partKey = getKeyByValue(UserPart, partString);
+                const part = UserPart[partKey];
+
+                return {
+                    generation: generation,
+                    part: part,
+                };
+            });
+
+            const phone = playgroundUserProfile.phone
+                ? playgroundUserProfile.phone
+                : null;
+
+            await this.userRepository.update(
+                {id: user.id},
+                {activities, profileImage, name, phone},
+            );
+
+            const payload = {name, id: user.id};
+            const accessToken = this.jwtService.sign(payload);
+
+            return {accessToken};
+        } catch (error) {
+            console.log(error);
+            if (error.response?.status === HttpStatus.UNAUTHORIZED) {
+                throw new UnauthorizedException({message: '유효하지 않은 토큰'});
+            }
+
+            throw new HttpException(
+                {message: '로그인 서버 에러'},
+                HttpStatus.INTERNAL_SERVER_ERROR,
+            );
+        }
+    }
 }
 
 function getKeyByValue(object: any, value: string) {
-  return Object.keys(object).find(key => object[key] === value);
+    return Object.keys(object).find(key => object[key] === value);
 }


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
### AS-IS
```javascript
const { id, name, profileImage } = await this.playgroundService.getUser(
  authToken,
);
const user = await this.userRepository.getUserByOrgId(id);
const userId: number = await (async () => {
  if (!user) {
    const newUser = await this.userRepository.save({
      orgId: id,
      name,
      profileImage,
    });

    return newUser.id;
  }

  return user.id;
})();
```
```javascript
const playgroundUserActivities = await this.playgroundService.getUserActivities(
  authToken, user.orgId
);
```
- 기존 코드는 user객체가 DB에 있는 지 조회 후 새롭게 newUser를 생성해 DB에 해당 정보를 저장하고 있었습니다.
- **문제가 되었던 부분은 user가 없을 때 새로운 유저(newUser)를 생성하고, 그 결과를 user 변수에 다시 할당하지 않았던 점입니다.** (회원가입 시 생성된 newUser를 user변수에 할당한 후 orgId에 접근해야 했지만, **할당하지 않고 원래 null이 였던 user 변수에 접근함으로서 TypeError가 발생!**)
- 에러 이후 두번째 요청때는 성공했었는데, 그 이유는 첫번재 호출 시점에서 이미 유저 정보가 DB에 저장된 상태이기 때문에 두번째 호출 시점에서는 user가 null이 아니기 때문입니다.

### TO-BE
```javascript
const {id, name, profileImage} = await this.playgroundService.getUser(authToken);

let user = await this.userRepository.getUserByOrgId(id);

if (!user) {
    user = await this.userRepository.save({
        orgId: id,
        name,
        profileImage,
    });
}
```
```javascript
const playgroundUserActivities = await this.playgroundService.getUserActivities(authToken, user.orgId);
```
- const를 let으로 선언하여 user가 없을 때 새로운 유저를 생성한 후 user 변수에 다시 할당할 수 있도록 변경하였습니다.
- 따라서 user가 반드시 존재하므로 user.orgId에 안전하게 접근할 수 있게 되었습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #425 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?