### PR TITLE
feat: 로그 출력용 AOP 구현

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/global/aop/ExecutionLoggingAop.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/aop/ExecutionLoggingAop.java
@@ -1,9 +1,7 @@
 package org.sopt.makers.crew.main.global.aop;
 
-import jakarta.servlet.http.HttpServletRequest;
-
 import java.util.Objects;
-import lombok.extern.log4j.Log4j2;
+
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -15,56 +13,67 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.log4j.Log4j2;
+
 @Aspect
 @Component
 @Log4j2
 public class ExecutionLoggingAop {
 
-    // 모든 패키지 내의 controller package에 존재하는 클래스
-    @Around("execution(* org.sopt.makers.crew..*Controller.*(..))")
-    public Object logExecutionTrace(ProceedingJoinPoint pjp) throws Throwable {
-        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
-        RequestMethod httpMethod = RequestMethod.valueOf(request.getMethod());
+	/**
+	 * @implNote : 일부 클래스를 제외하고, 모든 클래스의 메서드의 시작과 끝을 로깅한다.
+	 * @implNote : 제외 클래스 - global 패키지, config 관련 패키지
+	 * */
+	@Around("execution(* org.sopt.makers.crew..*(..)) "
+		+ "&& !within(org.sopt.makers.crew.main.global..*) "
+		+ "&& !within(org.sopt.makers.crew.main.external.s3.config..*)")
+	public Object logExecutionTrace(ProceedingJoinPoint pjp) throws Throwable {
+		HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.currentRequestAttributes()).getRequest();
+		RequestMethod httpMethod = RequestMethod.valueOf(request.getMethod());
 
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Object userId = authentication.getPrincipal().toString();
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		Object userId = authentication.getPrincipal().toString();
 
-        String className = pjp.getSignature().getDeclaringType().getSimpleName();
-        String methodName = pjp.getSignature().getName();
-        String task = className + "." + methodName;
+		String className = pjp.getSignature().getDeclaringType().getSimpleName();
+		String methodName = pjp.getSignature().getName();
+		String task = className + "." + methodName;
 
-        log.info("[Call Method] " + httpMethod.toString() + ": " + task + " | Request userId=" + userId);
+		log.info("");
+		log.info("🚨 {} Start", className);
+		log.info("[Call Method] " + httpMethod + ": " + task + " | Request userId=" + userId);
 
-        Object[] paramArgs = pjp.getArgs();
-        for (Object object : paramArgs) {
-            if (Objects.nonNull(object)) {
-                log.info("[parameter type] {}", object.getClass().getSimpleName());
-                log.info("[parameter value] {}", object);
-            }
-        }
+		Object[] paramArgs = pjp.getArgs();
+		for (Object object : paramArgs) {
+			if (Objects.nonNull(object)) {
+				log.info("[Parameter Type ] {}", object.getClass().getSimpleName());
+				log.info("[Parameter Value] {}", object);
+			}
+		}
 
-        // 해당 클래스 처리 전의 시간
-        StopWatch sw = new StopWatch();
-        sw.start();
+		// 해당 클래스 처리 전의 시간
+		StopWatch sw = new StopWatch();
+		sw.start();
 
-        Object result = null;
+		Object result = null;
 
-        // 해당 클래스의 메소드 실행
-        try{
-            result = pjp.proceed();
-        }
-        catch (Exception e){
-            log.warn("[ERROR] " + task + " 메서드 예외 발생 : " + e.getMessage());
-            throw e;
-        }
+		// 해당 클래스의 메소드 실행
+		try {
+			result = pjp.proceed();
+		} catch (Exception e) {
+			log.warn("[ERROR] " + task + " 메서드 예외 발생 : " + e.getMessage());
+			throw e;
+		}
 
-        // 해당 클래스 처리 후의 시간
-        sw.stop();
-        long executionTime = sw.getTotalTimeMillis();
+		// 해당 클래스 처리 후의 시간
+		sw.stop();
+		long executionTime = sw.getTotalTimeMillis();
 
-        log.info("[ExecutionTime] " + task + " --> " + executionTime + " (ms)");
+		log.info("[ExecutionTime] " + task + " --> " + executionTime + " (ms)");
+		log.info("🚨 {} End", className);
+		log.info("");
 
-        return result;
-    }
+		return result;
+	}
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/global/aop/ExecutionLoggingAop.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/aop/ExecutionLoggingAop.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -19,15 +20,17 @@ import lombok.extern.log4j.Log4j2;
 @Aspect
 @Component
 @Log4j2
+@Profile("!test")
 public class ExecutionLoggingAop {
 
 	/**
 	 * @implNote : 일부 클래스를 제외하고, 모든 클래스의 메서드의 시작과 끝을 로깅한다.
-	 * @implNote : 제외 클래스 - global 패키지, config 관련 패키지
+	 * @implNote : 제외 클래스 - global 패키지, config 관련 패키지, Test 클래스
 	 * */
-	@Around("execution(* org.sopt.makers.crew..*(..)) "
+	@Around("execution(* org.sopt.makers.crew.main..*(..)) "
 		+ "&& !within(org.sopt.makers.crew.main.global..*) "
-		+ "&& !within(org.sopt.makers.crew.main.external.s3.config..*)")
+		+ "&& !within(org.sopt.makers.crew.main.external.s3.config..*)"
+	)
 	public Object logExecutionTrace(ProceedingJoinPoint pjp) throws Throwable {
 		HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.currentRequestAttributes()).getRequest();
 		RequestMethod httpMethod = RequestMethod.valueOf(request.getMethod());

--- a/main/src/main/java/org/sopt/makers/crew/main/global/aop/ExecutionLoggingAop.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/aop/ExecutionLoggingAop.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.crew.main.global.aop;
 
+import java.lang.reflect.Field;
 import java.util.Objects;
 
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -49,8 +50,23 @@ public class ExecutionLoggingAop {
 		Object[] paramArgs = pjp.getArgs();
 		for (Object object : paramArgs) {
 			if (Objects.nonNull(object)) {
-				log.info("[Parameter Type ] {}", object.getClass().getSimpleName());
-				log.info("[Parameter Value] {}", object);
+				log.info("[Parameter] {} {}", object.getClass().getSimpleName(), object);
+
+				String packageName = object.getClass().getPackage().getName();
+				if (packageName.contains("java")) {
+					break;
+				}
+
+				Field[] fields = object.getClass().getDeclaredFields();
+				for (Field field : fields) {
+					field.setAccessible(true); // private 필드에도 접근 가능하도록 설정
+					try {
+						Object value = field.get(object); // 필드값 가져오기
+						log.info("[Field] {} = {}", field.getName(), value);
+					} catch (IllegalAccessException e) {
+						log.warn("[Field Access Error] Cannot access field: " + field.getName());
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 로그 출력용 AOP 구현했습니다.
- 현재 버전은 실행되는 모든 메서드의 시작과 끝을 로깅하고 있습니다.
- 로깅에 필요없거나 추가/수정 원하시는 부분있으면 편하게 말씀주세요!
<img width="1388" alt="스크린샷 2024-09-30 오전 1 18 28" src="https://github.com/user-attachments/assets/840ef5fd-b520-4698-8fd0-dcb6acaa5947">
<img width="1436" alt="스크린샷 2024-09-30 오전 1 18 39" src="https://github.com/user-attachments/assets/91ef5067-a232-4011-9724-9c90f2cdaa91">
<img width="1408" alt="스크린샷 2024-09-30 오전 1 18 50" src="https://github.com/user-attachments/assets/266d08b6-365b-4425-8cd6-290bab8cf22e">
<img width="1460" alt="스크린샷 2024-09-30 오전 1 19 00" src="https://github.com/user-attachments/assets/dd9746b8-182c-4710-b0c0-46d3c36ed9bc">
<img width="1425" alt="스크린샷 2024-09-30 오전 1 19 10" src="https://github.com/user-attachments/assets/400331b1-c6d9-4215-b803-f7dba3dcab86">


### 배경
- 처음에는 Aspect 를 사용해서 구현하려고 했습니다.
- 하지만 메서드마다 어노테이션을 붙이는건 너무 번거롭다고 생각했습니다.
- 그래서 클래스마다 어노테이션을 붙이는 방식으로 변경해봤습니다.
- 하지만 클래스마다 어노테이션 붙이는 방식마저도 너무 번거롭다고 생각했습니다.
- 그래서 전역적으로 실행시키는 방식으로 변경하고자 했습니다.
- 그러다보니 결국 제가 예전에 구현했던 `ExecutionLoggingAop` 의 형태로 하는게 맞는거 같더라고요!
- 그래서 현재 구현형태가 되었습니다!

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 추가로 테스트 코드 돌릴때는 해당 AOP가 동작하지 않도록 설정했습니다. 이거에 대해서도 의견궁금합니다! 저는 단순히 굳이 필요하지 않은 것 같아서 그랬습니다!

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #429 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?