### PR TITLE
fix: 모임상세조회 스웨거 명시 오류 해결

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
@@ -59,11 +59,11 @@ public class MeetingV2GetMeetingByIdResponseDto {
 	@NotNull
 	private final String processDesc;
 
-	@Schema(description = "모임 활동 시작 시간", example = "2024-08-13T15:30:00")
+	@Schema(description = "모임 활동 시작 시간", example = "2024-08-13T15:30:00",  name = "mStartDate")
 	@NotNull
 	private final LocalDateTime mStartDate;
 
-	@Schema(description = "모임 활동 종료 시간", example = "2024-10-13T23:59:59")
+	@Schema(description = "모임 활동 종료 시간", example = "2024-10-13T23:59:59",  name = "mEndDate")
 	@NotNull
 	private final LocalDateTime mEndDate;
 


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 모임 상세 조회 API 스웨거상 표기 오류가 있었습니다.

### AS-IS
![스크린샷 2024-10-02 오후 2 19 18](https://github.com/user-attachments/assets/dc1c93de-af71-495c-b08f-20e1a188a4c7)

### TO-BE

![스크린샷 2024-10-02 오후 2 18 54](https://github.com/user-attachments/assets/48b26c01-0bba-4b39-a6f5-b07da04ab69c)

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #435 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?