### PR TITLE
feat: 전체 사용자 조회 API 구현

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Api.java
@@ -42,14 +42,6 @@ public interface UserV2Api {
 	})
 	ResponseEntity<UserV2GetUserOwnProfileResponseDto> getUserOwnProfile(Principal principal);
 
-	@Operation(summary = "[TEMP] 유저 본인 프로필 조회")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "성공"),
-		@ApiResponse(responseCode = "400", description = "해당 유저가 없는 경우", content = @Content),
-	})
-	ResponseEntity<TempResponseDto<UserV2GetUserOwnProfileResponseDto>> getUserOwnProfileTemp(Principal principal);
-
 	@Operation(summary = "내가 신청한 모임 조회")
 	@ResponseStatus(HttpStatus.OK)
 	@ApiResponses(value = {
@@ -58,28 +50,12 @@ public interface UserV2Api {
 	ResponseEntity<UserV2GetAppliedMeetingByUserResponseDto> getAppliedMeetingByUser(
 		Principal principal);
 
-	@Operation(summary = "[TEMP] 내가 신청한 모임 조회")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "성공")
-	})
-	ResponseEntity<TempResponseDto<UserV2GetAppliedMeetingByUserResponseDto>> getAppliedMeetingByUserTemp(
-		Principal principal);
-
 	@Operation(summary = "내가 만든 모임 조회")
 	@ResponseStatus(HttpStatus.OK)
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "성공")
 	})
 	ResponseEntity<UserV2GetCreatedMeetingByUserResponseDto> getCreatedMeetingByUser(
-		Principal principal);
-
-	@Operation(summary = "[TEMP] 내가 만든 모임 조회")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "성공")
-	})
-	ResponseEntity<TempResponseDto<UserV2GetCreatedMeetingByUserResponseDto>> getCreatedMeetingByUserTemp(
 		Principal principal);
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Api.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.sopt.makers.crew.main.global.dto.TempResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMeetingByUserMeetingDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMentionUserDto;
+import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllUserDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAppliedMeetingByUserResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetCreatedMeetingByUserResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetUserOwnProfileResponseDto;
@@ -33,6 +34,11 @@ public interface UserV2Api {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "성공")})
 	ResponseEntity<List<UserV2GetAllMentionUserDto>> getAllMentionUser(Principal principal);
+
+	@Operation(summary = "전체 사용자 조회")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "성공")})
+	ResponseEntity<List<UserV2GetAllUserDto>> getAllUser(Principal principal);
 
 	@Operation(summary = "유저 본인 프로필 조회")
 	@ResponseStatus(HttpStatus.OK)
@@ -57,5 +63,6 @@ public interface UserV2Api {
 	})
 	ResponseEntity<UserV2GetCreatedMeetingByUserResponseDto> getCreatedMeetingByUser(
 		Principal principal);
+
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 
-import org.sopt.makers.crew.main.global.dto.TempResponseDto;
 import org.sopt.makers.crew.main.global.util.UserUtil;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMeetingByUserMeetingDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMentionUserDto;
@@ -30,9 +29,9 @@ public class UserV2Controller implements UserV2Api {
 	@GetMapping("/meeting/all")
 	@ResponseStatus(HttpStatus.OK)
 	public ResponseEntity<List<UserV2GetAllMeetingByUserMeetingDto>> getAllMeetingByUser(
-	        Principal principal) {
-	    Integer userId = UserUtil.getUserId(principal);
-	    return ResponseEntity.ok(userV2Service.getAllMeetingByUser(userId));
+		Principal principal) {
+		Integer userId = UserUtil.getUserId(principal);
+		return ResponseEntity.ok(userV2Service.getAllMeetingByUser(userId));
 	}
 
 	@Override
@@ -53,14 +52,6 @@ public class UserV2Controller implements UserV2Api {
 	}
 
 	@Override
-	@GetMapping("/profile/me/temp")
-	public ResponseEntity<TempResponseDto<UserV2GetUserOwnProfileResponseDto>> getUserOwnProfileTemp(
-		Principal principal) {
-		Integer userId = UserUtil.getUserId(principal);
-		return ResponseEntity.ok().body(TempResponseDto.of(userV2Service.getUserOwnProfile(userId)));
-	}
-
-	@Override
 	@GetMapping("/apply")
 	public ResponseEntity<UserV2GetAppliedMeetingByUserResponseDto> getAppliedMeetingByUser(Principal principal) {
 
@@ -69,27 +60,11 @@ public class UserV2Controller implements UserV2Api {
 	}
 
 	@Override
-	@GetMapping("/apply/temp")
-	public ResponseEntity<TempResponseDto<UserV2GetAppliedMeetingByUserResponseDto>> getAppliedMeetingByUserTemp(
-		Principal principal) {
-		Integer userId = UserUtil.getUserId(principal);
-		return ResponseEntity.ok().body(TempResponseDto.of(userV2Service.getAppliedMeetingByUser(userId)));
-	}
-
-	@Override
 	@GetMapping("/meeting")
 	public ResponseEntity<UserV2GetCreatedMeetingByUserResponseDto> getCreatedMeetingByUser(Principal principal) {
 
 		Integer userId = UserUtil.getUserId(principal);
 		return ResponseEntity.ok().body(userV2Service.getCreatedMeetingByUser(userId));
-	}
-
-	@Override
-	@GetMapping("/meeting/temp")
-	public ResponseEntity<TempResponseDto<UserV2GetCreatedMeetingByUserResponseDto>> getCreatedMeetingByUserTemp(
-		Principal principal) {
-		Integer userId = UserUtil.getUserId(principal);
-		return ResponseEntity.ok().body(TempResponseDto.of(userV2Service.getCreatedMeetingByUser(userId)));
 	}
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.makers.crew.main.global.util.UserUtil;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMeetingByUserMeetingDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMentionUserDto;
+import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllUserDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAppliedMeetingByUserResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetCreatedMeetingByUserResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetUserOwnProfileResponseDto;
@@ -41,6 +42,13 @@ public class UserV2Controller implements UserV2Api {
 
 		UserUtil.getUserId(principal);
 		return ResponseEntity.ok(userV2Service.getAllMentionUser());
+	}
+
+	@Override
+	@GetMapping
+	public ResponseEntity<List<UserV2GetAllUserDto>> getAllUser(Principal principal) {
+
+		return ResponseEntity.ok(userV2Service.getAllUser());
 	}
 
 	@Override

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
@@ -37,6 +37,7 @@ public class UserV2Controller implements UserV2Api {
 
 	@Override
 	@GetMapping("/mention")
+	@Deprecated
 	public ResponseEntity<List<UserV2GetAllMentionUserDto>> getAllMentionUser(
 		Principal principal) {
 

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/UserV2GetAllUserDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/UserV2GetAllUserDto.java
@@ -1,0 +1,36 @@
+package org.sopt.makers.crew.main.user.v2.dto.response;
+
+import org.sopt.makers.crew.main.entity.user.User;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(name = "UserV2GetAllUserDto", description = "전체 사용자 조회 응답 Dto")
+public record UserV2GetAllUserDto(
+	@Schema(description = "크루에서 사용하는 userId", example = "103")
+	@NotNull
+	Integer userId,
+	@Schema(description = "메이커스 프로덕트에서 범용적으로 사용하는 userId", example = "403")
+	@NotNull
+	Integer orgId,
+
+	@Schema(description = "유저 이름", example = "홍길동")
+	@NotNull
+	String userName,
+
+	@Schema(description = "최근 파트", example = "서버")
+	@NotNull
+	String recentPart,
+
+	@Schema(description = "최근 기수", example = "33")
+	@NotNull
+	int recentGeneration,
+
+	@Schema(description = "유저 프로필 사진", example = "[url] 형식")
+	String profileImageUrl
+) {
+	public static UserV2GetAllUserDto of(User user) {
+		return new UserV2GetAllUserDto(user.getId(), user.getOrgId(), user.getName(),
+			user.getRecentActivityVO().getPart(), user.getRecentActivityVO().getGeneration(), user.getProfileImage());
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2Service.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMeetingByUserMeetingDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMentionUserDto;
+import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllUserDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAppliedMeetingByUserResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetCreatedMeetingByUserResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetUserOwnProfileResponseDto;
@@ -14,6 +15,8 @@ public interface UserV2Service {
 	List<UserV2GetAllMeetingByUserMeetingDto> getAllMeetingByUser(Integer userId);
 
 	List<UserV2GetAllMentionUserDto> getAllMentionUser();
+
+	List<UserV2GetAllUserDto> getAllUser();
 
 	UserV2GetUserOwnProfileResponseDto getUserOwnProfile(Integer userId);
 

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
@@ -19,6 +19,7 @@ import org.sopt.makers.crew.main.user.v2.dto.response.ApplyV2GetAppliedMeetingBy
 import org.sopt.makers.crew.main.user.v2.dto.response.MeetingV2GetCreatedMeetingByUserResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMeetingByUserMeetingDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMentionUserDto;
+import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllUserDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAppliedMeetingByUserResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetCreatedMeetingByUserResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetUserOwnProfileResponseDto;
@@ -70,6 +71,17 @@ public class UserV2ServiceImpl implements UserV2Service {
 			.map(user -> UserV2GetAllMentionUserDto.of(user.getOrgId(), user.getName(),
 				user.getRecentActivityVO().getPart(), user.getRecentActivityVO().getGeneration(),
 				user.getProfileImage()))
+			.toList();
+	}
+
+	@Override
+	public List<UserV2GetAllUserDto> getAllUser() {
+
+		List<User> users = userRepository.findAll();
+
+		return users.stream()
+			.filter(user -> user.getActivities() != null)
+			.map(UserV2GetAllUserDto::of)
 			.toList();
 	}
 


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- `전체 사용자 조회 API` 구현했습니다.
- 해당 기능은 모임 생성할 때, 멘션할 사용자 검색할 때 쓰이는 API 입니다.
- 기존에 FE 에서 사용했던 `멘션 사용자 조회 API` 를 `전체 사용자 조회 API` 로 마이그레이션 요청 드렸습니다!

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?