### PR TITLE
refactor: 승인된 신청자 수 필드 추가

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/global/dto/MeetingResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/dto/MeetingResponseDto.java
@@ -70,9 +70,12 @@ public class MeetingResponseDto {
 	@Schema(description = "모임장 정보", example = "")
 	@NotNull
 	private final MeetingCreatorDto user;
-	@Schema(description = "신청 승인 수", example = "7")
+	@Schema(description = "전체 신청자 수", example = "7")
 	@NotNull
 	private final int appliedCount;
+	@Schema(description = "승인된 신청자 수", example = "3")
+	@NotNull
+	private final int approvedCount;
 
 	@QueryProjection
 	public MeetingResponseDto(Integer id, String title, Integer targetActiveGeneration,
@@ -80,7 +83,7 @@ public class MeetingResponseDto {
 		Integer status,
 		List<ImageUrlVO> imageURL, Boolean isMentorNeeded, LocalDateTime mStartDate, LocalDateTime mEndDate,
 		int capacity,
-		MeetingCreatorDto user, int appliedCount) {
+		MeetingCreatorDto user, int approvedCount) {
 
 		boolean processedCanJoinOnlyActiveGeneration = canJoinOnlyActiveGeneration
 			&& (CrewConst.ACTIVE_GENERATION.equals(targetActiveGeneration));
@@ -98,7 +101,8 @@ public class MeetingResponseDto {
 		this.mEndDate = mEndDate;
 		this.capacity = capacity;
 		this.user = user;
-		this.appliedCount = appliedCount;
+		this.appliedCount = approvedCount;
+		this.approvedCount = approvedCount;
 	}
 
 	public LocalDateTime getmStartDate() {

--- a/main/src/main/java/org/sopt/makers/crew/main/global/dto/MeetingResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/dto/MeetingResponseDto.java
@@ -3,15 +3,13 @@ package org.sopt.makers.crew.main.global.dto;
 import java.time.LocalDateTime;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.sopt.makers.crew.main.global.constant.CrewConst;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
-import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 import org.sopt.makers.crew.main.entity.user.User;
-
-import com.querydsl.core.annotations.QueryProjection;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -28,7 +26,7 @@ public class MeetingResponseDto {
 	private final Integer id;
 	@Schema(description = "모임 제목", example = "모임 제목입니다")
 	@NotNull
-	String title;
+	private final String title;
 	@Schema(description = "대상 기수", example = "33")
 	@NotNull
 	private final Integer targetActiveGeneration;
@@ -70,40 +68,12 @@ public class MeetingResponseDto {
 	@Schema(description = "모임장 정보", example = "")
 	@NotNull
 	private final MeetingCreatorDto user;
-	@Schema(description = "전체 신청자 수", example = "7")
+	@Schema(description = "TODO: FE에서 수정 완료 후 삭제 ", example = "[DEPRECATED]")
 	@NotNull
 	private final int appliedCount;
 	@Schema(description = "승인된 신청자 수", example = "3")
 	@NotNull
 	private final int approvedCount;
-
-	@QueryProjection
-	public MeetingResponseDto(Integer id, String title, Integer targetActiveGeneration,
-		@NotNull MeetingJoinablePart[] joinableParts, MeetingCategory category, Boolean canJoinOnlyActiveGeneration,
-		Integer status,
-		List<ImageUrlVO> imageURL, Boolean isMentorNeeded, LocalDateTime mStartDate, LocalDateTime mEndDate,
-		int capacity,
-		MeetingCreatorDto user, int approvedCount) {
-
-		boolean processedCanJoinOnlyActiveGeneration = canJoinOnlyActiveGeneration
-			&& (CrewConst.ACTIVE_GENERATION.equals(targetActiveGeneration));
-
-		this.id = id;
-		this.title = title;
-		this.targetActiveGeneration = targetActiveGeneration;
-		this.joinableParts = joinableParts;
-		this.category = category.getValue();
-		this.canJoinOnlyActiveGeneration = processedCanJoinOnlyActiveGeneration;
-		this.status = status;
-		this.imageURL = imageURL;
-		this.isMentorNeeded = isMentorNeeded;
-		this.mStartDate = mStartDate;
-		this.mEndDate = mEndDate;
-		this.capacity = capacity;
-		this.user = user;
-		this.appliedCount = approvedCount;
-		this.approvedCount = approvedCount;
-	}
 
 	public LocalDateTime getmStartDate() {
 		return mStartDate;
@@ -113,15 +83,16 @@ public class MeetingResponseDto {
 		return mEndDate;
 	}
 
-	public static MeetingResponseDto of(Meeting meeting, User meetingCreator, int appliedCount, LocalDateTime now) {
+	public static MeetingResponseDto of(Meeting meeting, User meetingCreator, int approvedCount, LocalDateTime now) {
 		MeetingCreatorDto creatorDto = MeetingCreatorDto.of(meetingCreator);
-		boolean canJoinOnlyActiveGeneration = meeting.getTargetActiveGeneration() == CrewConst.ACTIVE_GENERATION
+		boolean canJoinOnlyActiveGeneration =
+			Objects.equals(meeting.getTargetActiveGeneration(), CrewConst.ACTIVE_GENERATION)
 			&& meeting.getCanJoinOnlyActiveGeneration();
 
 		return new MeetingResponseDto(meeting.getId(), meeting.getTitle(),
-			meeting.getTargetActiveGeneration(), meeting.getJoinableParts(), meeting.getCategory(),
+			meeting.getTargetActiveGeneration(), meeting.getJoinableParts(), meeting.getCategory().getValue(),
 			canJoinOnlyActiveGeneration, meeting.getMeetingStatus(now), meeting.getImageURL(),
 			meeting.getIsMentorNeeded(), meeting.getMStartDate(), meeting.getMEndDate(), meeting.getCapacity(),
-			creatorDto, appliedCount);
+			creatorDto, approvedCount, approvedCount);
 	}
 }

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -472,7 +472,7 @@ public class MeetingV2ServiceTest {
 					"title", "category", "canJoinOnlyActiveGeneration",
 					"mStartDate", "mEndDate",
 					"capacity", "isMentorNeeded", "targetActiveGeneration",
-					"joinableParts", "status", "appliedCount"
+					"joinableParts", "status", "approvedCount"
 				).containsExactly(
 					tuple("세미나 구합니다 - 신청후", "세미나", false,
 						LocalDateTime.of(2024, 5, 29, 0, 0),
@@ -542,7 +542,7 @@ public class MeetingV2ServiceTest {
 					"title", "category", "canJoinOnlyActiveGeneration",
 					"mStartDate", "mEndDate",
 					"capacity", "isMentorNeeded", "targetActiveGeneration",
-					"joinableParts", "status", "appliedCount"
+					"joinableParts", "status", "approvedCount"
 				).containsExactly(
 					tuple("스터디 구합니다1", "행사", true,
 						LocalDateTime.of(2024, 5, 29, 0, 0),
@@ -588,7 +588,7 @@ public class MeetingV2ServiceTest {
 					"title", "category", "canJoinOnlyActiveGeneration",
 					"mStartDate", "mEndDate",
 					"capacity", "isMentorNeeded", "targetActiveGeneration",
-					"joinableParts", "status", "appliedCount"
+					"joinableParts", "status", "approvedCount"
 				).containsExactly(
 					tuple("세미나 구합니다 - 신청후", "세미나", false,
 						LocalDateTime.of(2024, 5, 29, 0, 0),


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 예전에 말씀드린 작업진행했습니다! 
- 설명을 드리면, 모임 `신청 수`가 아니라 `승인된 신청 수`를 반환해야 했습니다! 하지만 제가 착각을 해서 옛날에 `신청 수`로 구현했었습니다! 그래서 최근에 `신청 수`가 아닌 `승인된 신청 수`를 반환하도록 로직을 변경했습니다. 하지만 변수명은 아직 `appliedCount (신청 수)`로 되어있습니다. 이게 자꾸 헷갈리게 만든다고 생각해서 개선하고자 했습니다!

- 원래는 meeting/v2/patch-1 이런식으로 새로운 API를 만들려고 했는데요!
- 그런 방식은 필드 하나 바꾸는 거에 비해 너무 수정 범위가 크다고 생각했습니다!
- 간단하게 해결할 방법 고민하다가 그냥 필드를 추가한 후에, 나중에 마이그레이션 끝나면 해당 필드 삭제 하는게 가장 효율적일 것 같아 그렇게 구현했습니다!
<img width="849" alt="스크린샷 2024-10-24 오후 2 06 59" src="https://github.com/user-attachments/assets/8159fa9a-def3-46a9-a166-2d0f19805d86">

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- QueryProjection 를 사용하지 않는데 남아있더라고요! 그래서 이 부분 삭제했습니다.
- 모임 제목 에만 private final 이 안되어 있더라고요?! 단순 실수인 것 같아 수정했습니다!

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #432 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?