### PR TITLE
fix: 모임장은 공동모임장이 될 수 없다.

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/CoLeader.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/CoLeader.java
@@ -1,7 +1,12 @@
 package org.sopt.makers.crew.main.entity.meeting;
 
+import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
+
+import java.util.Objects;
+
 import org.sopt.makers.crew.main.entity.common.BaseTimeEntity;
 import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.global.exception.BadRequestException;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -38,6 +43,9 @@ public class CoLeader extends BaseTimeEntity {
 
 	@Builder
 	private CoLeader(Meeting meeting, User user) {
+		if (Objects.equals(meeting.getUserId(), user.getId())) {
+			throw new BadRequestException(LEADER_CANNOT_BE_CO_LEADER_APPLY.getErrorCode());
+		}
 		this.meeting = meeting;
 		this.user = user;
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
@@ -36,6 +36,7 @@ public enum ErrorStatus {
     MAX_IMAGE_UPLOAD_EXCEEDED("이미지는 최대 10개까지만 업로드 가능합니다."),
     LEADER_CANNOT_APPLY("모임장은 신청할 수 없습니다."),
     CO_LEADER_CANNOT_APPLY("공동 모임장은 신청할 수 없습니다."),
+    LEADER_CANNOT_BE_CO_LEADER_APPLY("모임장은 공동 모임장이 될 수 없습니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -301,6 +301,58 @@ public class MeetingV2ServiceTest {
 		}
 
 		@Test
+		@DisplayName("모임장은 공동모임장이 될 수 없다.")
+		void setLeaderCoLeader_createMeeting_throwException() {
+			// given
+			User user = User.builder()
+				.name("홍길동")
+				.orgId(1)
+				.activities(List.of(new UserActivityVO("서버", 33), new UserActivityVO("iOS", 34)))
+				.profileImage("image-url1")
+				.phone("010-1234-5678")
+				.build();
+			User savedUser = userRepository.save(user);
+
+			// 모임 이미지 리스트
+			List<String> files = Arrays.asList(
+				"https://example.com/image1.jpg"
+			);
+
+			// 대상 파트 목록
+			MeetingJoinablePart[] joinableParts = {
+				MeetingJoinablePart.SERVER,
+				MeetingJoinablePart.IOS
+			};
+
+			// DTO 생성
+			MeetingV2CreateMeetingBodyDto meetingDto = new MeetingV2CreateMeetingBodyDto(
+				"알고보면 쓸데있는 개발 프로세스", // title
+				files, // files (모임 이미지 리스트)
+				"스터디", // category
+				"2024.10.01", // startDate (모집 시작 날짜)
+				"2024.10.15", // endDate (모집 끝 날짜)
+				10, // capacity (모집 인원)
+				"백엔드 개발에 관심 있는 사람들을 위한 스터디입니다.", // desc (모집 정보)
+				"매주 온라인으로 진행되며, 발표와 토론이 포함됩니다.", // processDesc (진행 방식 소개)
+				"2024.10.16", // mStartDate (모임 활동 시작 날짜)
+				"2024.12.30", // mEndDate (모임 활동 종료 날짜)
+				"5년차 백엔드 개발자입니다.", // leaderDesc (개설자 소개)
+				"준비물은 노트북과 열정입니다.", // note (유의할 사항)
+				false, // isMentorNeeded (멘토 필요 여부)
+				true, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
+				joinableParts, // joinableParts (대상 파트 목록)
+				List.of(savedUser.getId())
+			);
+
+			// when, then
+			Assertions.assertThatThrownBy(() -> meetingV2Service.createMeeting((meetingDto),
+					savedUser.getId()))
+				.isInstanceOf(BadRequestException.class)
+				.hasMessageContaining(LEADER_CANNOT_BE_CO_LEADER_APPLY.getErrorCode());
+
+		}
+
+		@Test
 		@DisplayName("모임 개설자의 활동기수 정보가 없을 경우, 예외가 발생한다.")
 		void userHasNotActivities_createMeeting_exception() {
 			// given


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 모임장은 공동모임장이 될 수 없도록 구현했습니다.
<img width="802" alt="스크린샷 2024-11-07 오후 3 35 55" src="https://github.com/user-attachments/assets/fb79da18-9884-4118-8c28-d0704b80cb56">

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #475

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?