### PR TITLE
refactor: redis를 활용한 조회 성능 최적화

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-22.04
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+  #  if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
       working-directory-spring: main
       working-directory-nestjs: server

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,10 +1,8 @@
 name: Makers_Crew Dev CD
 on:
-  workflow_run:
-    workflows: ["Makers_Crew CI"]
-    branches: ["develop", "refactor/#477"]
-    types: [completed]
-  workflow_dispatch:
+  push:
+    branches:
+      - refactor/#477
 
 jobs:
   deploy:

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,13 +1,14 @@
 name: Makers_Crew Dev CD
 on:
-  push:
-    branches:
-      - refactor/#477
+  workflow_run:
+    workflows: ["Makers_Crew CI"]
+    branches: ["develop"]
+    types: [completed]
 
 jobs:
   deploy:
     runs-on: ubuntu-22.04
-  #  if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
       working-directory-spring: main
       working-directory-nestjs: server

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -2,7 +2,7 @@ name: Makers_Crew Dev CD
 on:
   workflow_run:
     workflows: ["Makers_Crew CI"]
-    branches: ["develop"]
+    branches: ["develop", "refactor/#477"]
     types: [completed]
 
 jobs:

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -4,6 +4,7 @@ on:
     workflows: ["Makers_Crew CI"]
     branches: ["develop", "refactor/#477"]
     types: [completed]
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,28 +3,28 @@ version: "3.7"
 services:
   swagger:
     labels:
-      caddy: localhost
+      caddy: localhost crew.api.dev.sopt.org
 
   nestjs-green:
     environment:
       - NODE_ENV=dev
     labels:
-      caddy: localhost
+      caddy: localhost crew.api.dev.sopt.org
 
   spring-green:
     environment:
       - SPRING_PROFILES_ACTIVE=dev
     labels:
-      caddy: localhost
+      caddy: localhost crew.api.dev.sopt.org
 
   nestjs-blue:
     environment:
       - NODE_ENV=dev
     labels:
-      caddy: localhost
+      caddy: localhost crew.api.dev.sopt.org
 
   spring-blue:
     environment:
       - SPRING_PROFILES_ACTIVE=dev
     labels:
-      caddy: localhost
+      caddy: localhost crew.api.dev.sopt.org

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -311,29 +311,6 @@ services:
       caddy.route_16: /internal/*
       caddy.route_16.reverse_proxy: "{{ upstreams 4000 }}"
 
-  pinpoint-agent:
-    image: pinpointdocker/pinpoint-agent:2.5.3
-    container_name: pinpoint-agent
-    restart: always
-    networks:
-      - caddy
-    volumes:
-      - data-volume:/pinpoint-agent
-    environment:
-      - SPRING_PROFILES=release
-      - COLLECTOR_IP=13.125.50.135
-      - PROFILER_TRANSPORT_AGENT_COLLECTOR_PORT=9991
-      - PROFILER_TRANSPORT_METADATA_COLLECTOR_PORT=9991
-      - PROFILER_TRANSPORT_STAT_COLLECTOR_PORT=9992
-      - PROFILER_TRANSPORT_SPAN_COLLECTOR_PORT=9993
-      - PROFILER_SAMPLING_TYPE=COUNTING
-      - PROFILER_SAMPLING_COUNTING_SAMPLING_RATE=1
-      - PROFILER_SAMPLING_PERCENT_SAMPLING_RATE=100
-      - PROFILER_SAMPLING_NEW_THROUGHPUT=0
-      - PROFILER_SAMPLING_CONTINUE_THROUGHPUT=0
-      - DEBUG_LEVEL=INFO
-      - PROFILER_TRANSPORT_MODULE=GRPC
-
 volumes:
   data-volume:
 

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -88,6 +88,13 @@ dependencies {
 
     // prometheus
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate6'
+
 }
 
 tasks.named('test') {

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/Apply.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/Apply.java
@@ -24,9 +24,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Table(name = "apply")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Apply extends BaseTimeEntity {
 
 	/**
@@ -101,13 +106,6 @@ public class Apply extends BaseTimeEntity {
 		this.status = EnApplyStatus.WAITING;
 	}
 
-	protected Apply() {
-	}
-
-	public static ApplyBuilder builder() {
-		return new ApplyBuilder();
-	}
-
 	public void updateApplyStatus(EnApplyStatus status) {
 		this.status = status;
 	}
@@ -124,168 +122,5 @@ public class Apply extends BaseTimeEntity {
 		}
 
 		return this.content;
-	}
-
-	public Integer getId() {
-		return this.id;
-	}
-
-	public EnApplyType getType() {
-		return this.type;
-	}
-
-	public Meeting getMeeting() {
-		return this.meeting;
-	}
-
-	public Integer getMeetingId() {
-		return this.meetingId;
-	}
-
-	public User getUser() {
-		return this.user;
-	}
-
-	public Integer getUserId() {
-		return this.userId;
-	}
-
-	public String getContent() {
-		return this.content;
-	}
-
-	public LocalDateTime getAppliedDate() {
-		return this.appliedDate;
-	}
-
-	public EnApplyStatus getStatus() {
-		return this.status;
-	}
-
-	public boolean equals(final Object o) {
-		if (o == this)
-			return true;
-		if (!(o instanceof Apply))
-			return false;
-		final Apply other = (Apply)o;
-		if (!other.canEqual((Object)this))
-			return false;
-		final Object this$id = this.getId();
-		final Object other$id = other.getId();
-		if (this$id == null ? other$id != null : !this$id.equals(other$id))
-			return false;
-		final Object this$type = this.getType();
-		final Object other$type = other.getType();
-		if (this$type == null ? other$type != null : !this$type.equals(other$type))
-			return false;
-		final Object this$meeting = this.getMeeting();
-		final Object other$meeting = other.getMeeting();
-		if (this$meeting == null ? other$meeting != null : !this$meeting.equals(other$meeting))
-			return false;
-		final Object this$meetingId = this.getMeetingId();
-		final Object other$meetingId = other.getMeetingId();
-		if (this$meetingId == null ? other$meetingId != null : !this$meetingId.equals(other$meetingId))
-			return false;
-		final Object this$user = this.getUser();
-		final Object other$user = other.getUser();
-		if (this$user == null ? other$user != null : !this$user.equals(other$user))
-			return false;
-		final Object this$userId = this.getUserId();
-		final Object other$userId = other.getUserId();
-		if (this$userId == null ? other$userId != null : !this$userId.equals(other$userId))
-			return false;
-		final Object this$content = this.getContent();
-		final Object other$content = other.getContent();
-		if (this$content == null ? other$content != null : !this$content.equals(other$content))
-			return false;
-		final Object this$appliedDate = this.getAppliedDate();
-		final Object other$appliedDate = other.getAppliedDate();
-		if (this$appliedDate == null ? other$appliedDate != null : !this$appliedDate.equals(other$appliedDate))
-			return false;
-		final Object this$status = this.getStatus();
-		final Object other$status = other.getStatus();
-		if (this$status == null ? other$status != null : !this$status.equals(other$status))
-			return false;
-		return true;
-	}
-
-	protected boolean canEqual(final Object other) {
-		return other instanceof Apply;
-	}
-
-	public int hashCode() {
-		final int PRIME = 59;
-		int result = 1;
-		final Object $id = this.getId();
-		result = result * PRIME + ($id == null ? 43 : $id.hashCode());
-		final Object $type = this.getType();
-		result = result * PRIME + ($type == null ? 43 : $type.hashCode());
-		final Object $meeting = this.getMeeting();
-		result = result * PRIME + ($meeting == null ? 43 : $meeting.hashCode());
-		final Object $meetingId = this.getMeetingId();
-		result = result * PRIME + ($meetingId == null ? 43 : $meetingId.hashCode());
-		final Object $user = this.getUser();
-		result = result * PRIME + ($user == null ? 43 : $user.hashCode());
-		final Object $userId = this.getUserId();
-		result = result * PRIME + ($userId == null ? 43 : $userId.hashCode());
-		final Object $content = this.getContent();
-		result = result * PRIME + ($content == null ? 43 : $content.hashCode());
-		final Object $appliedDate = this.getAppliedDate();
-		result = result * PRIME + ($appliedDate == null ? 43 : $appliedDate.hashCode());
-		final Object $status = this.getStatus();
-		result = result * PRIME + ($status == null ? 43 : $status.hashCode());
-		return result;
-	}
-
-	public static class ApplyBuilder {
-		private EnApplyType type;
-		private Meeting meeting;
-		private Integer meetingId;
-		private User user;
-		private Integer userId;
-		private String content;
-
-		ApplyBuilder() {
-		}
-
-		public ApplyBuilder type(EnApplyType type) {
-			this.type = type;
-			return this;
-		}
-
-		public ApplyBuilder meeting(Meeting meeting) {
-			this.meeting = meeting;
-			return this;
-		}
-
-		public ApplyBuilder meetingId(Integer meetingId) {
-			this.meetingId = meetingId;
-			return this;
-		}
-
-		public ApplyBuilder user(User user) {
-			this.user = user;
-			return this;
-		}
-
-		public ApplyBuilder userId(Integer userId) {
-			this.userId = userId;
-			return this;
-		}
-
-		public ApplyBuilder content(String content) {
-			this.content = content;
-			return this;
-		}
-
-		public Apply build() {
-			return new Apply(this.type, this.meeting, this.meetingId, this.user, this.userId, this.content);
-		}
-
-		public String toString() {
-			return "Apply.ApplyBuilder(type=" + this.type + ", meeting=" + this.meeting + ", meetingId="
-				+ this.meetingId + ", user=" + this.user + ", userId=" + this.userId + ", content=" + this.content
-				+ ")";
-		}
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/Apply.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/Apply.java
@@ -25,6 +25,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -94,6 +95,7 @@ public class Apply extends BaseTimeEntity {
 	@Convert(converter = ApplyStatusConverter.class)
 	private EnApplyStatus status;
 
+	@Builder
 	public Apply(EnApplyType type, Meeting meeting, Integer meetingId, User user, Integer userId,
 		String content) {
 		this.type = type;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/common/BaseTimeEntity.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/common/BaseTimeEntity.java
@@ -6,6 +6,11 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
@@ -16,10 +21,14 @@ public abstract class BaseTimeEntity {
 
 	@CreatedDate
 	@Column(name = "createdTimestamp")
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	public LocalDateTime createdTimestamp;
 
 	@LastModifiedDate
 	@Column(name = "modifiedTimestamp")
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	public LocalDateTime modifiedTimestamp;
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/CoLeader.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/CoLeader.java
@@ -43,7 +43,7 @@ public class CoLeader extends BaseTimeEntity {
 
 	@Builder
 	private CoLeader(Meeting meeting, User user) {
-		if (Objects.equals(meeting.getUserId(), user.getId())) {
+		if (meeting != null && Objects.equals(meeting.getUserId(), user.getId())) {
 			throw new BadRequestException(LEADER_CANNOT_BE_CO_LEADER_APPLY.getErrorCode());
 		}
 		this.meeting = meeting;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/CoLeaderReader.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/CoLeaderReader.java
@@ -1,0 +1,21 @@
+package org.sopt.makers.crew.main.entity.meeting;
+
+import java.util.List;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional
+public class CoLeaderReader {
+	private final CoLeaderRepository coLeaderRepository;
+
+	@Cacheable(value = "coLeadersCache", key = "#meetingId")
+	public List<CoLeader> getCoLeaders(Integer meetingId) {
+		return coLeaderRepository.findAllByMeetingId(meetingId);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/CoLeaderReader.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/CoLeaderReader.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class CoLeaderReader {
 	private final CoLeaderRepository coLeaderRepository;
 

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/CoLeaderReader.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/CoLeaderReader.java
@@ -2,6 +2,7 @@ package org.sopt.makers.crew.main.entity.meeting;
 
 import java.util.List;
 
+import org.sopt.makers.crew.main.meeting.v2.dto.redis.CoLeadersRedisDto;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,7 +16,9 @@ public class CoLeaderReader {
 	private final CoLeaderRepository coLeaderRepository;
 
 	@Cacheable(value = "coLeadersCache", key = "#meetingId")
-	public List<CoLeader> getCoLeaders(Integer meetingId) {
-		return coLeaderRepository.findAllByMeetingId(meetingId);
+	public CoLeadersRedisDto getCoLeaders(Integer meetingId) {
+		List<CoLeader> coLeaders = coLeaderRepository.findAllByMeetingId(meetingId);
+
+		return new CoLeadersRedisDto(coLeaders);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/CoLeaderRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/CoLeaderRepository.java
@@ -16,4 +16,7 @@ public interface CoLeaderRepository extends JpaRepository<CoLeader, Integer> {
 
 	List<CoLeader> findAllByUserId(Integer userId);
 
+	@Query("SELECT c FROM CoLeader c JOIN FETCH c.meeting WHERE c.user.id =:userId")
+	List<CoLeader> findAllByUserIdWithMeeting(Integer userId);
+
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/CoLeaderRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/CoLeaderRepository.java
@@ -2,13 +2,14 @@ package org.sopt.makers.crew.main.entity.meeting;
 
 import java.util.List;
 
-import org.sopt.makers.crew.main.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CoLeaderRepository extends JpaRepository<CoLeader, Integer> {
 
 	void deleteAllByMeetingId(Integer meetingId);
 
+	@Query("SELECT c FROM CoLeader c JOIN FETCH c.user WHERE c.meeting.id =:meetingId")
 	List<CoLeader> findAllByMeetingId(Integer meetingId);
 
 	List<CoLeader> findAllByMeetingIdIn(List<Integer> meetingId);

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/CoLeaders.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/CoLeaders.java
@@ -25,6 +25,10 @@ public class CoLeaders {
 			.collect(Collectors.groupingBy(coLeader -> coLeader.getMeeting().getId()));
 	}
 
+	public CoLeaders(Map<Integer, List<CoLeader>> coLeadersMap) {
+		this.coLeadersMap = coLeadersMap;
+	}
+
 	public void validateCoLeader(Integer meetingId, Integer requestUserId) {
 		if (isCoLeader(meetingId, requestUserId)) {
 			throw new BadRequestException(CO_LEADER_CANNOT_APPLY.getErrorCode());

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -36,6 +36,7 @@ import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 import org.sopt.makers.crew.main.entity.user.User;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
@@ -45,7 +46,7 @@ import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "meeting")
-//@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class Meeting extends BaseTimeEntity {
 
 	@Id

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -125,12 +125,16 @@ public class Meeting extends BaseTimeEntity {
 	 * 모임 시작 기간
 	 */
 	@Column(name = "mStartDate", nullable = false, columnDefinition = "TIMESTAMP")
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	private LocalDateTime mStartDate;
 
 	/**
 	 * 모임 마감 기간
 	 */
 	@Column(name = "mEndDate", nullable = false, columnDefinition = "TIMESTAMP")
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	private LocalDateTime mEndDate;
 
 	/**

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -37,17 +37,10 @@ import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 import org.sopt.makers.crew.main.entity.user.User;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "meeting")
-@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class Meeting extends BaseTimeEntity {
 
 	@Id
@@ -91,16 +84,12 @@ public class Meeting extends BaseTimeEntity {
 	 * 모집 시작 기간
 	 */
 	@Column(name = "startDate", nullable = false, columnDefinition = "TIMESTAMP")
-	@JsonSerialize(using = LocalDateTimeSerializer.class)
-	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	private LocalDateTime startDate;
 
 	/**
 	 * 모집 마감 기간
 	 */
 	@Column(name = "endDate", nullable = false, columnDefinition = "TIMESTAMP")
-	@JsonSerialize(using = LocalDateTimeSerializer.class)
-	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	private LocalDateTime endDate;
 
 	/**
@@ -125,16 +114,12 @@ public class Meeting extends BaseTimeEntity {
 	 * 모임 시작 기간
 	 */
 	@Column(name = "mStartDate", nullable = false, columnDefinition = "TIMESTAMP")
-	@JsonSerialize(using = LocalDateTimeSerializer.class)
-	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	private LocalDateTime mStartDate;
 
 	/**
 	 * 모임 마감 기간
 	 */
 	@Column(name = "mEndDate", nullable = false, columnDefinition = "TIMESTAMP")
-	@JsonSerialize(using = LocalDateTimeSerializer.class)
-	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	private LocalDateTime mEndDate;
 
 	/**

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -36,12 +36,18 @@ import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 import org.sopt.makers.crew.main.entity.user.User;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "meeting")
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class Meeting extends BaseTimeEntity {
 
 	@Id
@@ -85,12 +91,16 @@ public class Meeting extends BaseTimeEntity {
 	 * 모집 시작 기간
 	 */
 	@Column(name = "startDate", nullable = false, columnDefinition = "TIMESTAMP")
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	private LocalDateTime startDate;
 
 	/**
 	 * 모집 마감 기간
 	 */
 	@Column(name = "endDate", nullable = false, columnDefinition = "TIMESTAMP")
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	private LocalDateTime endDate;
 
 	/**
@@ -244,8 +254,8 @@ public class Meeting extends BaseTimeEntity {
 		this.capacity = updateMeeting.getCapacity();
 		this.desc = updateMeeting.getDesc();
 		this.processDesc = updateMeeting.getProcessDesc();
-		this.mStartDate = updateMeeting.mStartDate;
-		this.mEndDate = updateMeeting.getMEndDate();
+		this.mStartDate = updateMeeting.getmStartDate();
+		this.mEndDate = updateMeeting.getmEndDate();
 		this.leaderDesc = updateMeeting.getLeaderDesc();
 		this.note = updateMeeting.getNote();
 		this.isMentorNeeded = updateMeeting.getIsMentorNeeded();
@@ -253,5 +263,14 @@ public class Meeting extends BaseTimeEntity {
 		this.targetActiveGeneration = updateMeeting.getTargetActiveGeneration();
 		this.joinableParts = updateMeeting.getJoinableParts();
 	}
+
+	public LocalDateTime getmStartDate() {
+		return mStartDate;
+	}
+
+	public LocalDateTime getmEndDate() {
+		return mEndDate;
+	}
+
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -8,7 +8,6 @@ import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -37,7 +36,6 @@ import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 import org.sopt.makers.crew.main.entity.user.User;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
@@ -47,7 +45,7 @@ import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "meeting")
-@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+//@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class Meeting extends BaseTimeEntity {
 
 	@Id

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingReader.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingReader.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class MeetingReader {
 
 	private final MeetingRepository meetingRepository;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingReader.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingReader.java
@@ -1,0 +1,20 @@
+package org.sopt.makers.crew.main.entity.meeting;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional
+public class MeetingReader {
+
+	private final MeetingRepository meetingRepository;
+
+	@Cacheable(value = "meetingCache", key = "#meetingId")
+	public Meeting getMeetingById(Integer meetingId) {
+		return meetingRepository.findByIdOrThrow(meetingId);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingReader.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingReader.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.crew.main.entity.meeting;
 
+import org.sopt.makers.crew.main.meeting.v2.dto.redis.MeetingRedisDto;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,7 +15,8 @@ public class MeetingReader {
 	private final MeetingRepository meetingRepository;
 
 	@Cacheable(value = "meetingCache", key = "#meetingId")
-	public Meeting getMeetingById(Integer meetingId) {
-		return meetingRepository.findByIdOrThrow(meetingId);
+	public MeetingRedisDto getMeetingById(Integer meetingId) {
+		Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
+		return MeetingRedisDto.of(meeting);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/vo/ImageUrlVO.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/vo/ImageUrlVO.java
@@ -24,7 +24,7 @@ public class ImageUrlVO {
 		this.url = url;
 	}
 
-	private static void validateImageUrlVO(Integer id, String url) {
+	private void validateImageUrlVO(Integer id, String url) {
 		if (id == null || id < 0) {
 			throw new IllegalArgumentException(INVALID_INPUT_VALUE.getErrorCode()); // 커스텀 에러로 처리
 		}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/vo/ImageUrlVO.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/vo/ImageUrlVO.java
@@ -1,12 +1,17 @@
 package org.sopt.makers.crew.main.entity.meeting.vo;
 
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ImageUrlVO {
-  
-  private final Integer id;
-  private final String url;
+	private Integer id;
+	private String url;
+
+	public ImageUrlVO(Integer id, String url) {
+		this.id = id;
+		this.url = url;
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/vo/ImageUrlVO.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/vo/ImageUrlVO.java
@@ -1,17 +1,35 @@
 package org.sopt.makers.crew.main.entity.meeting.vo;
 
-import lombok.AccessLevel;
+import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
 public class ImageUrlVO {
-	private Integer id;
-	private String url;
+	private final Integer id;
+	private final String url;
 
-	public ImageUrlVO(Integer id, String url) {
+	@JsonCreator
+	public ImageUrlVO(
+		@JsonProperty("id") Integer id,
+		@JsonProperty("url") String url) {
+
+		validateImageUrlVO(id, url);
 		this.id = id;
 		this.url = url;
+	}
+
+	private static void validateImageUrlVO(Integer id, String url) {
+		if (id == null || id < 0) {
+			throw new IllegalArgumentException(INVALID_INPUT_VALUE.getErrorCode()); // 커스텀 에러로 처리
+		}
+		if (url == null || url.isBlank()) {
+			throw new IllegalArgumentException(INVALID_INPUT_VALUE.getErrorCode());  // 커스텀 에러로 처리
+		}
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
@@ -26,8 +26,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "user")
-@JsonIgnoreProperties({"recentActivityVO", "setUserIdForTest"})
-//@JsonIgnoreProperties({"recentActivityVO", "setUserIdForTest", "hibernateLazyInitializer", "handler", })
+//@JsonIgnoreProperties({"recentActivityVO", "setUserIdForTest"})
+@JsonIgnoreProperties({"recentActivityVO", "setUserIdForTest", "hibernateLazyInitializer", "handler"})
 public class User extends BaseTimeEntity {
 
     /**

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
@@ -20,10 +20,14 @@ import org.sopt.makers.crew.main.entity.common.BaseTimeEntity;
 import org.sopt.makers.crew.main.global.exception.ServerException;
 import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "user")
+@JsonIgnoreProperties({"recentActivityVO", "setUserIdForTest"})
+//@JsonIgnoreProperties({"recentActivityVO", "setUserIdForTest", "hibernateLazyInitializer", "handler", })
 public class User extends BaseTimeEntity {
 
     /**
@@ -94,5 +98,9 @@ public class User extends BaseTimeEntity {
         this.activities = activities;
         this.profileImage = profileImage;
         this.phone = phone;
+    }
+
+    public List<UserActivityVO> getActivities() {
+        return activities;
     }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
@@ -103,33 +103,69 @@ public class User extends BaseTimeEntity {
 	public boolean updateIfChanged(User playgroundUser) {
 		boolean isUpdated = false;
 
-		if (!Objects.equals(this.name, playgroundUser.getName())) {
-			this.name = playgroundUser.getName();
+		if (validateAndUpdateName(playgroundUser.getName())) {
 			isUpdated = true;
 		}
 
-		if (!Objects.equals(this.orgId, playgroundUser.getId())) {
-			this.orgId = playgroundUser.getId();
+		if (validateAndUpdateOrgId(playgroundUser.getId())) {
 			isUpdated = true;
 		}
 
-		if (!Objects.equals(this.activities, playgroundUser.getActivities())) {
-			this.activities = playgroundUser.getActivities();
+		if (validateAndUpdateActivities(playgroundUser.getActivities())) {
 			isUpdated = true;
 		}
 
-		if (!Objects.equals(this.profileImage, playgroundUser.getProfileImage())) {
-			this.profileImage = playgroundUser.getProfileImage();
+		if (validateAndUpdateProfileImage(playgroundUser.getProfileImage())) {
 			isUpdated = true;
 		}
 
-		if (!Objects.equals(this.phone, playgroundUser.getPhone())) {
-			this.phone = playgroundUser.getPhone();
+		if (validateAndUpdatePhone(playgroundUser.getPhone())) {
 			isUpdated = true;
 		}
 
 		return isUpdated;
 	}
+
+	private boolean validateAndUpdateName(String newName) {
+		if (!Objects.equals(this.name, newName)) {
+			this.name = newName;
+			return true;
+		}
+		return false;
+	}
+
+	private boolean validateAndUpdateOrgId(Integer newOrgId) {
+		if (!Objects.equals(this.orgId, newOrgId)) {
+			this.orgId = newOrgId;
+			return true;
+		}
+		return false;
+	}
+
+	private boolean validateAndUpdateActivities(List<UserActivityVO> newActivities) {
+		if (!Objects.equals(this.activities, newActivities)) {
+			this.activities = newActivities;
+			return true;
+		}
+		return false;
+	}
+
+	private boolean validateAndUpdateProfileImage(String newProfileImage) {
+		if (!Objects.equals(this.profileImage, newProfileImage)) {
+			this.profileImage = newProfileImage;
+			return true;
+		}
+		return false;
+	}
+
+	private boolean validateAndUpdatePhone(String newPhone) {
+		if (!Objects.equals(this.phone, newPhone)) {
+			this.phone = newPhone;
+			return true;
+		}
+		return false;
+	}
+
 
 	public List<UserActivityVO> getActivities() {
 		return activities;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "user")
-@JsonIgnoreProperties({"recentActivityVO", "setUserIdForTest", "hibernateLazyInitializer", "handler"})
 public class User extends BaseTimeEntity {
 
     /**
@@ -69,8 +68,9 @@ public class User extends BaseTimeEntity {
     private String phone;
 
     @Builder
-    public User(String name, Integer orgId, List<UserActivityVO> activities, String profileImage,
+    public User(Integer id, String name, Integer orgId, List<UserActivityVO> activities, String profileImage,
                 String phone) {
+        this.id = id;
         this.name = name;
         this.orgId = orgId;
         this.activities = activities;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
@@ -9,18 +9,21 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import org.hibernate.annotations.Type;
 import org.sopt.makers.crew.main.entity.common.BaseTimeEntity;
 import org.sopt.makers.crew.main.global.exception.ServerException;
 import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @Entity
 @Getter
@@ -28,78 +31,107 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @Table(name = "user")
 public class User extends BaseTimeEntity {
 
-    /**
-     * Primary Key
-     */
-    @Id
-    @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+	/**
+	 * Primary Key
+	 */
+	@Id
+	@Column(name = "id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
 
-    /**
-     * 사용자 이름
-     */
-    @Column(name = "name", nullable = false)
-    private String name;
+	/**
+	 * 사용자 이름
+	 */
+	@Column(name = "name", nullable = false)
+	private String name;
 
-    /**
-     * sopt org unique id
-     */
-    @Column(name = "orgId", nullable = false)
-    private Integer orgId;
+	/**
+	 * sopt org unique id
+	 */
+	@Column(name = "orgId", nullable = false)
+	private Integer orgId;
 
-    /**
-     * 활동 목록
-     */
-    @Column(name = "activities", columnDefinition = "jsonb")
-    @Type(JsonBinaryType.class)
-    private List<UserActivityVO> activities;
+	/**
+	 * 활동 목록
+	 */
+	@Column(name = "activities", columnDefinition = "jsonb")
+	@Type(JsonBinaryType.class)
+	private List<UserActivityVO> activities;
 
-    /**
-     * 프로필 이미지
-     */
-    @Column(name = "profileImage")
-    private String profileImage;
+	/**
+	 * 프로필 이미지
+	 */
+	@Column(name = "profileImage")
+	private String profileImage;
 
-    /**
-     * 핸드폰 번호
-     */
-    @Column(name = "phone")
-    private String phone;
+	/**
+	 * 핸드폰 번호
+	 */
+	@Column(name = "phone")
+	private String phone;
 
-    @Builder
-    public User(Integer id, String name, Integer orgId, List<UserActivityVO> activities, String profileImage,
-                String phone) {
-        this.id = id;
-        this.name = name;
-        this.orgId = orgId;
-        this.activities = activities;
-        this.profileImage = profileImage;
-        this.phone = phone;
-    }
+	@Builder
+	public User(String name, Integer orgId, List<UserActivityVO> activities, String profileImage,
+		String phone) {
+		this.name = name;
+		this.orgId = orgId;
+		this.activities = activities;
+		this.profileImage = profileImage;
+		this.phone = phone;
+	}
 
-    public void setUserIdForTest(Integer userId) {
-        this.id = userId;
-    }
+	public void setUserIdForTest(Integer userId) {
+		this.id = userId;
+	}
 
-    public UserActivityVO getRecentActivityVO(){
-        return activities.stream()
-                .filter(userActivityVO -> userActivityVO.getPart() != null)
-                .max(Comparator.comparingInt(UserActivityVO::getGeneration))
-                .orElseThrow(() -> new ServerException(INTERNAL_SERVER_ERROR.getErrorCode()));
-    }
+	/**
+	 * @implSpec : redis 에서 조회한 데이터를 엔티티로 변환할 때 사용하는 메서드
+	 *
+	 * **/
+	public User withUserIdForRedis(Integer id) {
+		this.id = id;
+		return this;
+	}
 
-    public void updateUser(String name, Integer orgId, List<UserActivityVO> activities, String profileImage,
-        String phone){
+	public UserActivityVO getRecentActivityVO() {
+		return activities.stream()
+			.filter(userActivityVO -> userActivityVO.getPart() != null)
+			.max(Comparator.comparingInt(UserActivityVO::getGeneration))
+			.orElseThrow(() -> new ServerException(INTERNAL_SERVER_ERROR.getErrorCode()));
+	}
 
-        this.name = name;
-        this.orgId = orgId;
-        this.activities = activities;
-        this.profileImage = profileImage;
-        this.phone = phone;
-    }
+	public boolean updateIfChanged(User playgroundUser) {
+		boolean isUpdated = false;
 
-    public List<UserActivityVO> getActivities() {
-        return activities;
-    }
+		if (!Objects.equals(this.name, playgroundUser.getName())) {
+			this.name = playgroundUser.getName();
+			isUpdated = true;
+		}
+
+		if (!Objects.equals(this.orgId, playgroundUser.getId())) {
+			this.orgId = playgroundUser.getId();
+			isUpdated = true;
+		}
+
+		if (!Objects.equals(this.activities, playgroundUser.getActivities())) {
+			this.activities = playgroundUser.getActivities();
+			isUpdated = true;
+		}
+
+		if (!Objects.equals(this.profileImage, playgroundUser.getProfileImage())) {
+			this.profileImage = playgroundUser.getProfileImage();
+			isUpdated = true;
+		}
+
+		if (!Objects.equals(this.phone, playgroundUser.getPhone())) {
+			this.phone = playgroundUser.getPhone();
+			isUpdated = true;
+		}
+
+		return isUpdated;
+	}
+
+	public List<UserActivityVO> getActivities() {
+		return activities;
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "user")
-//@JsonIgnoreProperties({"recentActivityVO", "setUserIdForTest"})
 @JsonIgnoreProperties({"recentActivityVO", "setUserIdForTest", "hibernateLazyInitializer", "handler"})
 public class User extends BaseTimeEntity {
 

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserReader.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserReader.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.crew.main.entity.user;
 
+import org.sopt.makers.crew.main.global.dto.MeetingCreatorDto;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,7 +14,7 @@ public class UserReader {
 	private final UserRepository userRepository;
 
 	@Cacheable(value = "meetingLeaderCache", key = "#userId")
-	public User getMeetingLeader(Integer userId) {
-		return userRepository.findByIdOrThrow(userId);
+	public MeetingCreatorDto getMeetingLeader(Integer userId) {
+		return MeetingCreatorDto.of(userRepository.findByIdOrThrow(userId));
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserReader.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserReader.java
@@ -1,0 +1,19 @@
+package org.sopt.makers.crew.main.entity.user;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional
+public class UserReader {
+	private final UserRepository userRepository;
+
+	@Cacheable(value = "meetingLeaderCache", key = "#userId")
+	public User getMeetingLeader(Integer userId) {
+		return userRepository.findByIdOrThrow(userId);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserReader.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserReader.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class UserReader {
 	private final UserRepository userRepository;
 

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/vo/UserActivityVO.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/vo/UserActivityVO.java
@@ -1,28 +1,32 @@
 package org.sopt.makers.crew.main.entity.user.vo;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
 @ToString
 @EqualsAndHashCode
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserActivityVO {
 
 	@Schema(description = "파트", example = "서버")
 	@NotNull
-	private String part;
+	private final String part;
 
 	@Schema(description = "기수", example = "36")
 	@NotNull
-	private int generation;
+	private final int generation;
 
-	public UserActivityVO(String part, int generation) {
+	@JsonCreator
+	public UserActivityVO(
+		@JsonProperty("part") String part,
+		@JsonProperty("generation") int generation) {
+
 		this.part = part;
 		this.generation = generation;
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/vo/UserActivityVO.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/vo/UserActivityVO.java
@@ -1,5 +1,7 @@
 package org.sopt.makers.crew.main.entity.user.vo;
 
+import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -27,7 +29,25 @@ public class UserActivityVO {
 		@JsonProperty("part") String part,
 		@JsonProperty("generation") int generation) {
 
+		validateUserActivityVO(part, generation);
 		this.part = part;
 		this.generation = generation;
+	}
+
+	private void validateUserActivityVO(String part, int generation) {
+		// Part validation: Ensure it's not null, empty, or contain invalid characters.
+		if (part == null || part.trim().isEmpty()) {
+			throw new IllegalArgumentException(INVALID_INPUT_VALUE.getErrorCode() + part);
+		}
+
+		// Validate that part only contains letters (and optionally spaces)
+		if (!part.matches("^[a-zA-Z가-힣\s]+$")) {
+			throw new IllegalArgumentException(INVALID_INPUT_VALUE.getErrorCode() + part);
+		}
+
+		// Generation validation: Must be a positive integer
+		if (generation <= 0) {
+			throw new IllegalArgumentException(INVALID_INPUT_VALUE.getErrorCode() + generation);
+		}
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/vo/UserActivityVO.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/vo/UserActivityVO.java
@@ -2,23 +2,28 @@ package org.sopt.makers.crew.main.entity.user.vo;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
-@RequiredArgsConstructor
 @ToString
 @EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserActivityVO {
 
-    @Schema(description = "파트", example = "서버")
-    @NotNull
-    private final String part;
+	@Schema(description = "파트", example = "서버")
+	@NotNull
+	private String part;
 
-    @Schema(description = "기수", example = "36")
-    @NotNull
-    private final int generation;
+	@Schema(description = "기수", example = "36")
+	@NotNull
+	private int generation;
 
+	public UserActivityVO(String part, int generation) {
+		this.part = part;
+		this.generation = generation;
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/vo/UserActivityVO.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/vo/UserActivityVO.java
@@ -2,6 +2,8 @@ package org.sopt.makers.crew.main.entity.user.vo;
 
 import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
 
+import org.sopt.makers.crew.main.global.exception.ServerException;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -37,17 +39,17 @@ public class UserActivityVO {
 	private void validateUserActivityVO(String part, int generation) {
 		// Part validation: Ensure it's not null, empty, or contain invalid characters.
 		if (part == null || part.trim().isEmpty()) {
-			throw new IllegalArgumentException(INVALID_INPUT_VALUE.getErrorCode() + part);
+			throw new ServerException(INTERNAL_SERVER_ERROR.getErrorCode() + part);
 		}
 
 		// Validate that part only contains letters (and optionally spaces)
 		if (!part.matches("^[a-zA-Z가-힣\s]+$")) {
-			throw new IllegalArgumentException(INVALID_INPUT_VALUE.getErrorCode() + part);
+			throw new IllegalArgumentException(INTERNAL_SERVER_ERROR.getErrorCode() + part);
 		}
 
 		// Generation validation: Must be a positive integer
 		if (generation <= 0) {
-			throw new IllegalArgumentException(INVALID_INPUT_VALUE.getErrorCode() + generation);
+			throw new IllegalArgumentException(INTERNAL_SERVER_ERROR.getErrorCode() + generation);
 		}
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/external/redis/RedisConfig.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/external/redis/RedisConfig.java
@@ -23,14 +23,9 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 @EnableCaching
 public class RedisConfig {
 
-	@Value("${spring.data.redis.host}")
-	private String redisHost;
-	@Value("${spring.data.redis.port}")
-	private int redisPort;
-
 	@Bean
-	public RedisConnectionFactory redisConnectionFactory() {
-		return new LettuceConnectionFactory(redisHost, redisPort);
+	public RedisConnectionFactory redisConnectionFactory(RedisProperties redisProperties) {
+		return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
 	}
 
 	@Bean

--- a/main/src/main/java/org/sopt/makers/crew/main/external/redis/RedisConfig.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/external/redis/RedisConfig.java
@@ -1,8 +1,6 @@
 package org.sopt.makers.crew.main.external.redis;
 
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;

--- a/main/src/main/java/org/sopt/makers/crew/main/external/redis/RedisConfig.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/external/redis/RedisConfig.java
@@ -10,7 +10,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
-import org.springframework.data.redis.cache.RedisCacheWriter;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -18,10 +17,8 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 @Configuration
@@ -39,49 +36,49 @@ public class RedisConfig {
 	}
 
 	@Bean
-	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+	public ObjectMapper objectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식
+		objectMapper.activateDefaultTyping(objectMapper.getPolymorphicTypeValidator(),
+			ObjectMapper.DefaultTyping.NON_FINAL); // 타입 정보 추가
+
+		return objectMapper;
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory,
+		ObjectMapper objectMapper) {
 		RedisTemplate<String, Object> template = new RedisTemplate<>();
 		template.setConnectionFactory(redisConnectionFactory);
 
-		// JSON 직렬화 설정
-		ObjectMapper objectMapper = new ObjectMapper();
-		objectMapper.findAndRegisterModules(); // 추가적으로 등록 가능한 모듈 자동 등록
-		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식 사용
-
-		GenericJackson2JsonRedisSerializer jsonRedisSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+		StringRedisSerializer stringSerializer = new StringRedisSerializer();
+		GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
 
 		// Key serializer 설정
-		template.setKeySerializer(new StringRedisSerializer());
-		template.setHashKeySerializer(new StringRedisSerializer());
+		template.setKeySerializer(stringSerializer);
+		template.setHashKeySerializer(stringSerializer);
 
 		// Value serializer 설정
-		template.setValueSerializer(jsonRedisSerializer);
-		template.setHashValueSerializer(jsonRedisSerializer);
+		template.setValueSerializer(jsonSerializer);
+		template.setHashValueSerializer(jsonSerializer);
 
 		template.afterPropertiesSet();
 		return template;
 	}
 
-
 	@Bean
-	public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
-		// 기본 CacheWriter 설정
-		RedisCacheWriter redisCacheWriter = RedisCacheWriter.nonLockingRedisCacheWriter(redisConnectionFactory);
+	public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory, ObjectMapper objectMapper) {
+		// 동일한 직렬화 설정 공유
+		GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
 
-		// 캐시별 설정을 저장할 Map
-		Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
-
-		// 기본 TTL 설정 (특정 캐시 이름이 없는 경우 적용)
 		RedisCacheConfiguration defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
-			.entryTtl(Duration.ofHours(24)) // 디폴트 TTL: 24시간
+			.entryTtl(Duration.ofHours(24))
 			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-			.serializeValuesWith(
-				RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+			.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer));
 
-		// RedisCacheManager 생성
-		return RedisCacheManager.builder(redisCacheWriter)
-			.cacheDefaults(defaultCacheConfig) // 기본 설정
-			.withInitialCacheConfigurations(cacheConfigurations) // 캐시별 설정
+		return RedisCacheManager.builder(redisConnectionFactory)
+			.cacheDefaults(defaultCacheConfig)
 			.build();
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/external/redis/RedisConfig.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/external/redis/RedisConfig.java
@@ -34,21 +34,15 @@ public class RedisConfig {
 	}
 
 	@Bean
-	public ObjectMapper objectMapper() {
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(redisConnectionFactory);
+
 		ObjectMapper objectMapper = new ObjectMapper();
 		objectMapper.registerModule(new JavaTimeModule());
 		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식
 		objectMapper.activateDefaultTyping(objectMapper.getPolymorphicTypeValidator(),
 			ObjectMapper.DefaultTyping.NON_FINAL); // 타입 정보 추가
-
-		return objectMapper;
-	}
-
-	@Bean
-	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory,
-		ObjectMapper objectMapper) {
-		RedisTemplate<String, Object> template = new RedisTemplate<>();
-		template.setConnectionFactory(redisConnectionFactory);
 
 		StringRedisSerializer stringSerializer = new StringRedisSerializer();
 		GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
@@ -66,8 +60,14 @@ public class RedisConfig {
 	}
 
 	@Bean
-	public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory, ObjectMapper objectMapper) {
+	public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
 		// 동일한 직렬화 설정 공유
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식
+		objectMapper.activateDefaultTyping(objectMapper.getPolymorphicTypeValidator(),
+			ObjectMapper.DefaultTyping.NON_FINAL); // 타입 정보 추가
+
 		GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
 
 		RedisCacheConfiguration defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()

--- a/main/src/main/java/org/sopt/makers/crew/main/external/redis/RedisConfig.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/external/redis/RedisConfig.java
@@ -1,0 +1,70 @@
+package org.sopt.makers.crew.main.external.redis;
+
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.cache.RedisCacheWriter;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.hibernate6.Hibernate6Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+	@Autowired
+	private RedisConnectionFactory redisConnectionFactory;
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate() {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(redisConnectionFactory);
+
+		// JSON 직렬화 설정
+		ObjectMapper objectMapper = new ObjectMapper();
+		// objectMapper.registerModule(new JavaTimeModule());
+		// objectMapper.registerModule(new Hibernate6Module());
+		objectMapper.activateDefaultTyping(
+			LaissezFaireSubTypeValidator.instance,
+			ObjectMapper.DefaultTyping.NON_FINAL,
+			JsonTypeInfo.As.PROPERTY
+		);
+		GenericJackson2JsonRedisSerializer jsonRedisSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+		// Key serializer 설정
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setHashKeySerializer(new StringRedisSerializer());
+
+		// Value serializer 설정
+		template.setValueSerializer(jsonRedisSerializer);
+		template.setHashValueSerializer(jsonRedisSerializer);
+
+		template.afterPropertiesSet();
+		return template;
+	}
+
+	@Bean
+	public RedisCacheManager cacheManager() {
+		RedisCacheWriter redisCacheWriter = RedisCacheWriter.nonLockingRedisCacheWriter(redisConnectionFactory);
+		RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+			.entryTtl(Duration.ofHours(5L)); // 캐시 TTL 설정
+
+		return new RedisCacheManager(redisCacheWriter, redisCacheConfiguration);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/external/redis/RedisProperties.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/external/redis/RedisProperties.java
@@ -1,0 +1,14 @@
+package org.sopt.makers.crew.main.external.redis;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@ConfigurationProperties(prefix = "spring.data.redis")
+@RequiredArgsConstructor
+public class RedisProperties {
+	private final String host;
+	private final int port;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/global/advice/ControllerExceptionAdvice.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/advice/ControllerExceptionAdvice.java
@@ -110,7 +110,7 @@ public class ControllerExceptionAdvice {
 
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ExceptionResponse> handleException(Exception e) {
-		log.error("{}", e.getMessage());
+		log.error("", e);
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(ExceptionResponse.fail(
 				ErrorStatus.INTERNAL_SERVER_ERROR.getErrorCode()));

--- a/main/src/main/java/org/sopt/makers/crew/main/global/aop/ExecutionLoggingAop.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/aop/ExecutionLoggingAop.java
@@ -26,11 +26,12 @@ public class ExecutionLoggingAop {
 
 	/**
 	 * @implNote : 일부 클래스를 제외하고, 모든 클래스의 메서드의 시작과 끝을 로깅한다.
-	 * @implNote : 제외 클래스 - global 패키지, config 관련 패키지, Test 클래스
+	 * @implNote : 제외 클래스 - global 패키지, config 관련 패키지, Test 클래스, redis 클래스
 	 * */
 	@Around("execution(* org.sopt.makers.crew.main..*(..)) "
 		+ "&& !within(org.sopt.makers.crew.main.global..*) "
 		+ "&& !within(org.sopt.makers.crew.main.external.s3.config..*)"
+		+ "&& !within(org.sopt.makers.crew.main.external.redis..*) "
 	)
 	public Object logExecutionTrace(ProceedingJoinPoint pjp) throws Throwable {
 		HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.currentRequestAttributes()).getRequest();

--- a/main/src/main/java/org/sopt/makers/crew/main/global/constant/PropertiesConfiguration.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/constant/PropertiesConfiguration.java
@@ -1,0 +1,11 @@
+package org.sopt.makers.crew.main.global.constant;
+
+import org.sopt.makers.crew.main.external.redis.RedisProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(RedisProperties.class)
+public class PropertiesConfiguration {
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/global/dto/MeetingCreatorDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/dto/MeetingCreatorDto.java
@@ -5,13 +5,14 @@ import java.util.List;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 @Schema(name = "MeetingCreatorDto", description = "모임 개설자 Dto")
 public class MeetingCreatorDto {
 	@Schema(description = "모임장 id, 크루에서 사용하는 userId", example = "1")
@@ -42,4 +43,20 @@ public class MeetingCreatorDto {
 			user.getActivities(), user.getPhone());
 	}
 
+	@JsonCreator // JSON 역직렬화를 위한 생성자
+	public MeetingCreatorDto(
+		@JsonProperty("id") Integer id,
+		@JsonProperty("name") String name,
+		@JsonProperty("orgId") Integer orgId,
+		@JsonProperty("profileImage") String profileImage,
+		@JsonProperty("activities") List<UserActivityVO> activities,
+		@JsonProperty("phone") String phone
+	) {
+		this.id = id;
+		this.name = name;
+		this.orgId = orgId;
+		this.profileImage = profileImage;
+		this.activities = activities;
+		this.phone = phone;
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/global/dto/MeetingResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/dto/MeetingResponseDto.java
@@ -92,7 +92,7 @@ public class MeetingResponseDto {
 		return new MeetingResponseDto(meeting.getId(), meeting.getTitle(),
 			meeting.getTargetActiveGeneration(), meeting.getJoinableParts(), meeting.getCategory().getValue(),
 			canJoinOnlyActiveGeneration, meeting.getMeetingStatus(now), meeting.getImageURL(),
-			meeting.getIsMentorNeeded(), meeting.getMStartDate(), meeting.getMEndDate(), meeting.getCapacity(),
+			meeting.getIsMentorNeeded(), meeting.getmStartDate(), meeting.getmEndDate(), meeting.getCapacity(),
 			creatorDto, approvedCount, approvedCount);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
@@ -17,7 +17,7 @@ public enum ErrorStatus {
 	 */
 	VALIDATION_EXCEPTION("CF-001"),
 	VALIDATION_REQUEST_MISSING_EXCEPTION("요청값이 입력되지 않았습니다."),
-	INVALID_INPUT_VALUE("요청값이 올바르지 않습니다."),
+	INVALID_INPUT_VALUE("요청값이 올바르지 않습니다. : "),
 	INVALID_INPUT_VALUE_FILTER("요청값 또는 토큰이 올바르지 않습니다."),
 	NOT_FOUND_MEETING("모임이 없습니다."),
 	NOT_FOUND_POST("존재하지 않는 게시글입니다."),

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/CoLeaderRedisDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/CoLeaderRedisDto.java
@@ -1,0 +1,44 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.redis;
+
+import org.sopt.makers.crew.main.entity.meeting.CoLeader;
+import org.sopt.makers.crew.main.entity.user.User;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import lombok.Getter;
+
+@Getter
+@JsonTypeName("CoLeaderRedisDto")
+public class CoLeaderRedisDto {
+	private final Integer userId;
+	private final Integer orgId;
+	private final String userName;
+	private final String userProfileImage;
+	private final Integer meetingId;
+
+	@JsonCreator
+	public CoLeaderRedisDto(
+		@JsonProperty("userId") Integer userId,
+		@JsonProperty("orgId") Integer orgId,
+		@JsonProperty("userName") String userName,
+		@JsonProperty("userProfileImage") String userProfileImage,
+		@JsonProperty("meetingId") Integer meetingId) {
+
+		this.userId = userId;
+		this.orgId = orgId;
+		this.userName = userName;
+		this.userProfileImage = userProfileImage;
+		this.meetingId = meetingId;
+	}
+
+	public CoLeader toEntity() {
+		User coLeader = new User(userId, userName, orgId, null, userProfileImage, null);
+		return CoLeader.builder()
+			.meeting(null)
+			.user(coLeader)
+			.build();
+	}
+}
+

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/CoLeaderRedisDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/CoLeaderRedisDto.java
@@ -34,7 +34,8 @@ public class CoLeaderRedisDto {
 	}
 
 	public CoLeader toEntity() {
-		User coLeader = new User(userId, userName, orgId, null, userProfileImage, null);
+		User coLeader = new User(userName, orgId, null, userProfileImage, null).withUserIdForRedis(userId);
+
 		return CoLeader.builder()
 			.meeting(null)
 			.user(coLeader)

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/CoLeadersRedisDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/CoLeadersRedisDto.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.crew.main.meeting.v2.dto.redis;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -18,7 +19,7 @@ public class CoLeadersRedisDto {
 	private final Map<Integer, List<CoLeaderRedisDto>> coLeadersMap;
 
 	public CoLeadersRedisDto() {
-		this.coLeadersMap = null; // 기본 값으로 설정하거나 필요시 초기화
+		this.coLeadersMap = new HashMap<>(); // 기본 값으로 설정하거나 필요시 초기화
 	}
 
 	public CoLeadersRedisDto(List<CoLeader> coLeaders) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/CoLeadersRedisDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/CoLeadersRedisDto.java
@@ -1,0 +1,44 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.redis;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.sopt.makers.crew.main.entity.meeting.CoLeader;
+import org.sopt.makers.crew.main.entity.meeting.CoLeaders;
+
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+
+import lombok.Getter;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@Getter
+public class CoLeadersRedisDto {
+	private final Map<Integer, List<CoLeaderRedisDto>> coLeadersMap;
+
+	public CoLeadersRedisDto() {
+		this.coLeadersMap = null; // 기본 값으로 설정하거나 필요시 초기화
+	}
+
+	public CoLeadersRedisDto(List<CoLeader> coLeaders) {
+		this.coLeadersMap = coLeaders.stream()
+			.map(coLeader -> new CoLeaderRedisDto(coLeader.getUser().getId(), coLeader.getUser().getOrgId(),
+				coLeader.getUser().getName(), coLeader.getUser().getProfileImage(), coLeader.getMeeting().getId()))
+			.collect(Collectors.groupingBy(CoLeaderRedisDto::getMeetingId));
+	}
+
+	public CoLeaders toEntity() {
+		Map<Integer, List<CoLeader>> coLeadersEntityMap = coLeadersMap.entrySet().stream()
+			.collect(Collectors.toMap(
+				Map.Entry::getKey,
+				entry -> entry.getValue().stream()
+					.map(CoLeaderRedisDto::toEntity) // CoLeaderRedisDto -> CoLeader 변환
+					.toList()
+			));
+
+		return new CoLeaders(coLeadersEntityMap);
+	}
+
+}
+

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/CoLeadersRedisDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/CoLeadersRedisDto.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.crew.main.meeting.v2.dto.redis;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +27,8 @@ public class CoLeadersRedisDto {
 				CoLeaderRedisDto coLeaderRedisDto = new CoLeaderRedisDto(coLeader.getUser().getId(),
 					coLeader.getUser().getOrgId(),
 					coLeader.getUser().getName(), coLeader.getUser().getProfileImage(), coLeader.getMeeting().getId());
-				List<CoLeaderRedisDto> coLeaderRedisDtos = coLeadersMap.get(coLeader.getMeeting().getId());
+				List<CoLeaderRedisDto> coLeaderRedisDtos = coLeadersMap.getOrDefault(coLeader.getMeeting().getId(),
+					new ArrayList<>());
 				coLeaderRedisDtos.add(coLeaderRedisDto);
 				coLeadersMap.put(coLeader.getMeeting().getId(), coLeaderRedisDtos);
 			});

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/CoLeadersRedisDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/CoLeadersRedisDto.java
@@ -8,25 +8,28 @@ import java.util.stream.Collectors;
 import org.sopt.makers.crew.main.entity.meeting.CoLeader;
 import org.sopt.makers.crew.main.entity.meeting.CoLeaders;
 
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CoLeadersRedisDto {
-	private final Map<Integer, List<CoLeaderRedisDto>> coLeadersMap;
-
-	public CoLeadersRedisDto() {
-		this.coLeadersMap = new HashMap<>(); // 기본 값으로 설정하거나 필요시 초기화
-	}
+	private final Map<Integer, List<CoLeaderRedisDto>> coLeadersMap = new HashMap<>();
 
 	public CoLeadersRedisDto(List<CoLeader> coLeaders) {
-		this.coLeadersMap = coLeaders.stream()
-			.map(coLeader -> new CoLeaderRedisDto(coLeader.getUser().getId(), coLeader.getUser().getOrgId(),
-				coLeader.getUser().getName(), coLeader.getUser().getProfileImage(), coLeader.getMeeting().getId()))
-			.collect(Collectors.groupingBy(CoLeaderRedisDto::getMeetingId));
+		coLeaders
+			.forEach(coLeader -> {
+				CoLeaderRedisDto coLeaderRedisDto = new CoLeaderRedisDto(coLeader.getUser().getId(),
+					coLeader.getUser().getOrgId(),
+					coLeader.getUser().getName(), coLeader.getUser().getProfileImage(), coLeader.getMeeting().getId());
+				List<CoLeaderRedisDto> coLeaderRedisDtos = coLeadersMap.get(coLeader.getMeeting().getId());
+				coLeaderRedisDtos.add(coLeaderRedisDto);
+				coLeadersMap.put(coLeader.getMeeting().getId(), coLeaderRedisDtos);
+			});
 	}
 
 	public CoLeaders toEntity() {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/MeetingRedisDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/MeetingRedisDto.java
@@ -1,0 +1,120 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.redis;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
+import lombok.Getter;
+
+@Getter
+public class MeetingRedisDto {
+	private final Integer id;
+	private final Integer userId;
+	private final String title;
+	private final MeetingCategory category;
+	private final List<ImageUrlVO> imageURL;
+
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
+	private final LocalDateTime startDate;
+
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
+	private final LocalDateTime endDate;
+
+	private final Integer capacity;
+	private final String desc;
+	private final String processDesc;
+
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
+	private final LocalDateTime mStartDate;
+
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
+	private final LocalDateTime mEndDate;
+
+	private final String leaderDesc;
+	private final String note;
+	private final Boolean isMentorNeeded;
+	private final Boolean canJoinOnlyActiveGeneration;
+	private final Integer createdGeneration;
+	private final Integer targetActiveGeneration;
+	private final MeetingJoinablePart[] joinableParts;
+
+	public Meeting toEntity() {
+		return new Meeting(null, userId, title, category, imageURL, startDate, endDate, capacity, desc, processDesc,
+			mStartDate, mEndDate, leaderDesc, null, note, isMentorNeeded, canJoinOnlyActiveGeneration,
+			createdGeneration, targetActiveGeneration, joinableParts);
+	}
+
+	public static MeetingRedisDto of(Meeting meeting) {
+		return new MeetingRedisDto(meeting.getId(), meeting.getUserId(), meeting.getTitle(), meeting.getCategory(),
+			meeting.getImageURL(), meeting.getStartDate(), meeting.getEndDate(), meeting.getCapacity(),
+			meeting.getDesc(), meeting.getProcessDesc(), meeting.getmStartDate(), meeting.getmEndDate(),
+			meeting.getLeaderDesc(), meeting.getNote(), meeting.getIsMentorNeeded(),
+			meeting.getCanJoinOnlyActiveGeneration(), meeting.getCreatedGeneration(),
+			meeting.getTargetActiveGeneration(), meeting.getJoinableParts());
+	}
+
+	@JsonCreator
+	public MeetingRedisDto(
+		@JsonProperty("id") Integer id,
+		@JsonProperty("userId") Integer userId,
+		@JsonProperty("title") String title,
+		@JsonProperty("category") MeetingCategory category,
+		@JsonProperty("imageURL") List<ImageUrlVO> imageURL,
+		@JsonProperty("startDate") LocalDateTime startDate,
+		@JsonProperty("endDate") LocalDateTime endDate,
+		@JsonProperty("capacity") Integer capacity,
+		@JsonProperty("desc") String desc,
+		@JsonProperty("processDesc") String processDesc,
+		@JsonProperty("mStartDate") LocalDateTime mStartDate,
+		@JsonProperty("mEndDate") LocalDateTime mEndDate,
+		@JsonProperty("leaderDesc") String leaderDesc,
+		@JsonProperty("note") String note,
+		@JsonProperty("isMentorNeeded") Boolean isMentorNeeded,
+		@JsonProperty("canJoinOnlyActiveGeneration") Boolean canJoinOnlyActiveGeneration,
+		@JsonProperty("createdGeneration") Integer createdGeneration,
+		@JsonProperty("targetActiveGeneration") Integer targetActiveGeneration,
+		@JsonProperty("joinableParts") MeetingJoinablePart[] joinableParts) {
+		this.id = id;
+		this.userId = userId;
+		this.title = title;
+		this.category = category;
+		this.imageURL = imageURL;
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.capacity = capacity;
+		this.desc = desc;
+		this.processDesc = processDesc;
+		this.mStartDate = mStartDate;
+		this.mEndDate = mEndDate;
+		this.leaderDesc = leaderDesc;
+		this.note = note;
+		this.isMentorNeeded = isMentorNeeded;
+		this.canJoinOnlyActiveGeneration = canJoinOnlyActiveGeneration;
+		this.createdGeneration = createdGeneration;
+		this.targetActiveGeneration = targetActiveGeneration;
+		this.joinableParts = joinableParts;
+	}
+
+	public LocalDateTime getmStartDate() {
+		return mStartDate;
+	}
+
+	public LocalDateTime getmEndDate() {
+		return mEndDate;
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingBannerResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingBannerResponseDto.java
@@ -115,7 +115,7 @@ public class MeetingV2GetMeetingBannerResponseDto {
 
 		return new MeetingV2GetMeetingBannerResponseDto(meeting.getId(), meeting.getUserId(), meeting.getTitle(),
 			meeting.getCategory(),
-			meeting.getImageURL(), meeting.getMStartDate(), meeting.getMEndDate(), meeting.getStartDate(),
+			meeting.getImageURL(), meeting.getmStartDate(), meeting.getmEndDate(), meeting.getStartDate(),
 			meeting.getEndDate(), meeting.getCapacity(), recentActivityDate, meeting.getTargetActiveGeneration(),
 			meeting.getJoinableParts(), applicantCount, approvedUserCount,
 			meetingCreator, meeting.getMeetingStatus(now));

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
@@ -142,10 +142,8 @@ public class MeetingV2GetMeetingByIdResponseDto {
 
 	public static MeetingV2GetMeetingByIdResponseDto of(Meeting meeting, List<CoLeader> coLeaders,
 		boolean isCoLeader, long approvedCount, Boolean isHost, Boolean isApply,
-		Boolean isApproved, User meetingCreator,
+		Boolean isApproved, MeetingCreatorDto meetingCreatorDto,
 		List<ApplyWholeInfoDto> appliedInfo, LocalDateTime now) {
-
-		MeetingCreatorDto meetingCreatorDto = MeetingCreatorDto.of(meetingCreator);
 
 		Integer meetingStatus = meeting.getMeetingStatus(now);
 
@@ -169,9 +167,5 @@ public class MeetingV2GetMeetingByIdResponseDto {
 
 	public LocalDateTime getmEndDate() {
 		return mEndDate;
-	}
-
-	public boolean getIsCoLeader() {
-		return this.isCoLeader;
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
@@ -8,7 +8,6 @@ import org.sopt.makers.crew.main.global.dto.MeetingCreatorDto;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
-import org.sopt.makers.crew.main.entity.user.User;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -140,7 +139,7 @@ public class MeetingV2GetMeetingByIdResponseDto {
 	@NotNull
 	private final List<ApplyWholeInfoDto> appliedInfo;
 
-	public static MeetingV2GetMeetingByIdResponseDto of(Meeting meeting, List<CoLeader> coLeaders,
+	public static MeetingV2GetMeetingByIdResponseDto of(Integer meetingId, Meeting meeting, List<CoLeader> coLeaders,
 		boolean isCoLeader, long approvedCount, Boolean isHost, Boolean isApply,
 		Boolean isApproved, MeetingCreatorDto meetingCreatorDto,
 		List<ApplyWholeInfoDto> appliedInfo, LocalDateTime now) {
@@ -151,7 +150,7 @@ public class MeetingV2GetMeetingByIdResponseDto {
 			.map(coLeader -> MeetingV2CoLeaderResponseDto.of(coLeader.getUser()))
 			.toList();
 
-		return new MeetingV2GetMeetingByIdResponseDto(meeting.getId(), meeting.getUserId(), meeting.getTitle(),
+		return new MeetingV2GetMeetingByIdResponseDto(meetingId, meeting.getUserId(), meeting.getTitle(),
 			meeting.getCategory().getValue(), meeting.getImageURL(), meeting.getStartDate(), meeting.getEndDate(),
 			meeting.getCapacity(), meeting.getDesc(), meeting.getProcessDesc(), meeting.getmStartDate(),
 			meeting.getmEndDate(), meeting.getLeaderDesc(), meeting.getNote(),

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
@@ -155,8 +155,8 @@ public class MeetingV2GetMeetingByIdResponseDto {
 
 		return new MeetingV2GetMeetingByIdResponseDto(meeting.getId(), meeting.getUserId(), meeting.getTitle(),
 			meeting.getCategory().getValue(), meeting.getImageURL(), meeting.getStartDate(), meeting.getEndDate(),
-			meeting.getCapacity(), meeting.getDesc(), meeting.getProcessDesc(), meeting.getMStartDate(),
-			meeting.getMEndDate(), meeting.getLeaderDesc(), meeting.getNote(),
+			meeting.getCapacity(), meeting.getDesc(), meeting.getProcessDesc(), meeting.getmStartDate(),
+			meeting.getmEndDate(), meeting.getLeaderDesc(), meeting.getNote(),
 			meeting.getIsMentorNeeded(), meeting.getCanJoinOnlyActiveGeneration(), meeting.getCreatedGeneration(),
 			meeting.getTargetActiveGeneration(), meeting.getJoinableParts(), coLeaderResponseDtos, isCoLeader,
 			meetingStatus,

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -31,6 +31,7 @@ import org.sopt.makers.crew.main.entity.meeting.CoLeaders;
 import org.sopt.makers.crew.main.entity.meeting.MeetingReader;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.user.UserReader;
+import org.sopt.makers.crew.main.global.dto.MeetingCreatorDto;
 import org.sopt.makers.crew.main.global.dto.MeetingResponseDto;
 import org.sopt.makers.crew.main.global.exception.BadRequestException;
 import org.sopt.makers.crew.main.global.exception.ServerException;
@@ -423,7 +424,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		User user = userRepository.findByIdOrThrow(userId);
 
 		Meeting meeting = meetingReader.getMeetingById(meetingId);
-		User meetingLeader = userReader.getMeetingLeader(meeting.getUserId());
+		MeetingCreatorDto meetingLeader = userReader.getMeetingLeader(meeting.getUserId());
 		CoLeaders coLeaders = new CoLeaders(coLeaderReader.getCoLeaders(meetingId));
 
 		Applies applies = new Applies(

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -423,9 +423,9 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 	public MeetingV2GetMeetingByIdResponseDto getMeetingById(Integer meetingId, Integer userId) {
 		User user = userRepository.findByIdOrThrow(userId);
 
-		Meeting meeting = meetingReader.getMeetingById(meetingId);
+		Meeting meeting = meetingReader.getMeetingById(meetingId).toEntity();
 		MeetingCreatorDto meetingLeader = userReader.getMeetingLeader(meeting.getUserId());
-		CoLeaders coLeaders = new CoLeaders(coLeaderReader.getCoLeaders(meetingId));
+		CoLeaders coLeaders = coLeaderReader.getCoLeaders(meetingId).toEntity();
 
 		Applies applies = new Applies(
 			applyRepository.findAllByMeetingIdWithUser(meetingId, List.of(WAITING, APPROVE, REJECT), ORDER_ASC));
@@ -443,7 +443,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 				.toList();
 		}
 
-		return MeetingV2GetMeetingByIdResponseDto.of(meeting, coLeaders.getCoLeaders(meetingId), isCoLeader,
+		return MeetingV2GetMeetingByIdResponseDto.of(meetingId, meeting, coLeaders.getCoLeaders(meetingId), isCoLeader,
 			approvedCount, isHost, isApply, isApproved,
 			meetingLeader, applyWholeInfoDtos, time.now());
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
@@ -84,7 +84,7 @@ public record MeetingV2GetCreatedMeetingByUserResponseDto(
 		return new MeetingV2GetCreatedMeetingByUserResponseDto(meeting.getId(), meeting.getTitle(),
 			meeting.getTargetActiveGeneration(), meeting.getJoinableParts(), meeting.getCategory().getValue(),
 			canJoinOnlyActiveGeneration, meeting.getMeetingStatus(now), isCoLeader, meeting.getImageURL(),
-			meeting.getIsMentorNeeded(), meeting.getMStartDate(), meeting.getMEndDate(), meeting.getCapacity(),
+			meeting.getIsMentorNeeded(), meeting.getmStartDate(), meeting.getmEndDate(), meeting.getCapacity(),
 			creatorDto, approvedCount, approvedCount);
 	}
 

--- a/main/src/main/resources/application-dev.yml
+++ b/main/src/main/resources/application-dev.yml
@@ -29,7 +29,7 @@ spring:
       storage_engine: innodb
   data:
     redis:
-      host: localhost
+      host: redis
       port: 6379
 
 jwt:

--- a/main/src/main/resources/application-dev.yml
+++ b/main/src/main/resources/application-dev.yml
@@ -27,6 +27,10 @@ spring:
         format_sql: ture
       dialect: org.hibernate.dialect.PostgreSQLDialect
       storage_engine: innodb
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 jwt:
   header: Authorization

--- a/main/src/main/resources/application-dev.yml
+++ b/main/src/main/resources/application-dev.yml
@@ -31,12 +31,6 @@ spring:
     redis:
       host: redis
       port: 6379
-      lettuce:
-        pool:
-            max-active: 10
-            max-idle: 10
-            min-idle: 1
-            enabled: true
 
 jwt:
   header: Authorization

--- a/main/src/main/resources/application-dev.yml
+++ b/main/src/main/resources/application-dev.yml
@@ -31,6 +31,12 @@ spring:
     redis:
       host: redis
       port: 6379
+      lettuce:
+        pool:
+            max-active: 10
+            max-idle: 10
+            min-idle: 1
+            enabled: true
 
 jwt:
   header: Authorization

--- a/main/src/main/resources/application-local.yml
+++ b/main/src/main/resources/application-local.yml
@@ -31,12 +31,6 @@ spring:
     redis:
       host: localhost
       port: 6379
-      lettuce:
-        pool:
-          max-active: 10
-          max-idle: 10
-          min-idle: 1
-          enabled: true
 
 jwt:
   header: Authorization

--- a/main/src/main/resources/application-local.yml
+++ b/main/src/main/resources/application-local.yml
@@ -29,7 +29,7 @@ spring:
       storage_engine: innodb
   data:
     redis:
-      host: redis
+      host: localhost
       port: 6379
 
 jwt:

--- a/main/src/main/resources/application-local.yml
+++ b/main/src/main/resources/application-local.yml
@@ -27,6 +27,10 @@ spring:
         format_sql: true
       dialect: org.hibernate.dialect.PostgreSQLDialect
       storage_engine: innodb
+  data:
+    redis:
+      host: redis
+      port: 6379
 
 jwt:
   header: Authorization

--- a/main/src/main/resources/application-local.yml
+++ b/main/src/main/resources/application-local.yml
@@ -31,6 +31,12 @@ spring:
     redis:
       host: localhost
       port: 6379
+      lettuce:
+        pool:
+          max-active: 10
+          max-idle: 10
+          min-idle: 1
+          enabled: true
 
 jwt:
   header: Authorization

--- a/main/src/main/resources/application-prod.yml
+++ b/main/src/main/resources/application-prod.yml
@@ -30,12 +30,6 @@ spring:
     redis:
       host: redis
       port: 6379
-      lettuce:
-        pool:
-          max-active: 10
-          max-idle: 10
-          min-idle: 1
-          enabled: true
 
 jwt:
   header: Authorization

--- a/main/src/main/resources/application-prod.yml
+++ b/main/src/main/resources/application-prod.yml
@@ -30,6 +30,12 @@ spring:
     redis:
       host: redis
       port: 6379
+      lettuce:
+        pool:
+          max-active: 10
+          max-idle: 10
+          min-idle: 1
+          enabled: true
 
 jwt:
   header: Authorization

--- a/main/src/main/resources/application-prod.yml
+++ b/main/src/main/resources/application-prod.yml
@@ -26,6 +26,10 @@ spring:
         format_sql: ture
       dialect: org.hibernate.dialect.PostgreSQLDialect
       storage_engine: innodb
+  data:
+    redis:
+      host: redis
+      port: 6379
 
 jwt:
   header: Authorization

--- a/main/src/main/resources/application-test.yml
+++ b/main/src/main/resources/application-test.yml
@@ -25,6 +25,10 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
       storage_engine: innodb
     defer-datasource-initialization: true
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 jwt:
   header: Authorization

--- a/main/src/test/java/org/sopt/makers/crew/main/entity/user/UserActivityVOTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/entity/user/UserActivityVOTest.java
@@ -1,0 +1,16 @@
+package org.sopt.makers.crew.main.entity.user;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
+import org.sopt.makers.crew.main.global.exception.ServerException;
+
+class UserActivityVOTest {
+	@Test
+	void 최근_기수_조회_잘못된_데이터가_저장된_경우_예외가_발생한다(){
+
+		// given, when, then
+		Assertions.assertThatThrownBy(() -> new UserActivityVO(null, 34))
+			.isInstanceOf(ServerException.class);
+	}
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/entity/user/UserEntityTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/entity/user/UserEntityTest.java
@@ -5,8 +5,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
 
-public class UserEntityTest {
-
+class UserEntityTest {
 
     @Test
     void 최근_기수_조회(){
@@ -27,25 +26,5 @@ public class UserEntityTest {
         Assertions.assertThat(recentActivityVO.getGeneration()).isEqualTo(34);
         Assertions.assertThat(recentActivityVO.getPart()).isEqualTo("iOS");
 
-    }
-
-    @Test
-    void 최근_기수_조회_잘못된_데이터가_저장된_경우_해당_데이터는_무시한다(){
-        // given
-        User user = User.builder()
-                .name("홍길동")
-                .orgId(1)
-                .activities(List.of(new UserActivityVO(null, 34), new UserActivityVO("서버", 33)))
-                .profileImage("image-url")
-                .phone("010-1234-5678")
-                .build();
-
-        // when
-        UserActivityVO recentActivityVO = user.getRecentActivityVO();
-
-        // then
-
-        Assertions.assertThat(recentActivityVO.getGeneration()).isEqualTo(33);
-        Assertions.assertThat(recentActivityVO.getPart()).isEqualTo("서버");
     }
 }

--- a/main/src/test/java/org/sopt/makers/crew/main/external/AbstractContainerBaseTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/external/AbstractContainerBaseTest.java
@@ -14,15 +14,14 @@ public abstract class AbstractContainerBaseTest {
 	static {
 		REDIS_CONTAINER = new GenericContainer<>(REDIS_IMAGE)
 			.withExposedPorts(6379)
-			.withReuse(true)
+			//.withReuse(true)
 			.waitingFor(Wait.forListeningPort());
 		REDIS_CONTAINER.start();
 	}
 
 	@DynamicPropertySource
 	public static void overrideProps(DynamicPropertyRegistry registry) {
-		Supplier<Object> getHost = REDIS_CONTAINER::getHost;
-		registry.add("spring.redis.host", getHost);
-		registry.add("spring.redis.port", () -> "" + REDIS_CONTAINER.getMappedPort(6379));
+		registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost);
+		registry.add("spring.data.redis.port", () -> String.valueOf(REDIS_CONTAINER.getMappedPort(6379)));
 	}
 }

--- a/main/src/test/java/org/sopt/makers/crew/main/external/AbstractContainerBaseTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/external/AbstractContainerBaseTest.java
@@ -1,0 +1,28 @@
+package org.sopt.makers.crew.main.external;
+
+import java.util.function.Supplier;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public abstract class AbstractContainerBaseTest {
+	static final String REDIS_IMAGE = "redis:6-alpine";
+	static final GenericContainer REDIS_CONTAINER;
+
+	static {
+		REDIS_CONTAINER = new GenericContainer<>(REDIS_IMAGE)
+			.withExposedPorts(6379)
+			.withReuse(true)
+			.waitingFor(Wait.forListeningPort());
+		REDIS_CONTAINER.start();
+	}
+
+	@DynamicPropertySource
+	public static void overrideProps(DynamicPropertyRegistry registry) {
+		Supplier<Object> getHost = REDIS_CONTAINER::getHost;
+		registry.add("spring.redis.host", getHost);
+		registry.add("spring.redis.port", () -> "" + REDIS_CONTAINER.getMappedPort(6379));
+	}
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/external/redisContainerBaseTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/external/redisContainerBaseTest.java
@@ -12,7 +12,7 @@ public abstract class redisContainerBaseTest {
 	static {
 		REDIS_CONTAINER = new GenericContainer<>(REDIS_IMAGE)
 			.withExposedPorts(6379)
-			//.withReuse(true)
+			.withReuse(true)
 			.waitingFor(Wait.forListeningPort());
 		REDIS_CONTAINER.start();
 	}

--- a/main/src/test/java/org/sopt/makers/crew/main/external/redisContainerBaseTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/external/redisContainerBaseTest.java
@@ -1,13 +1,11 @@
 package org.sopt.makers.crew.main.external;
 
-import java.util.function.Supplier;
-
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-public abstract class AbstractContainerBaseTest {
+public abstract class redisContainerBaseTest {
 	static final String REDIS_IMAGE = "redis:6-alpine";
 	static final GenericContainer REDIS_CONTAINER;
 

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -23,6 +23,7 @@ import org.sopt.makers.crew.main.entity.meeting.CoLeader;
 import org.sopt.makers.crew.main.entity.meeting.CoLeaderRepository;
 import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+import org.sopt.makers.crew.main.external.AbstractContainerBaseTest;
 import org.sopt.makers.crew.main.global.annotation.IntegratedTest;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
@@ -55,7 +56,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlGroup;
 
 @IntegratedTest
-public class MeetingV2ServiceTest {
+public class MeetingV2ServiceTest extends AbstractContainerBaseTest {
 
 	@Autowired
 	private MeetingV2Service meetingV2Service;

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -24,7 +24,7 @@ import org.sopt.makers.crew.main.entity.meeting.CoLeader;
 import org.sopt.makers.crew.main.entity.meeting.CoLeaderRepository;
 import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
-import org.sopt.makers.crew.main.external.AbstractContainerBaseTest;
+import org.sopt.makers.crew.main.external.redisContainerBaseTest;
 import org.sopt.makers.crew.main.global.annotation.IntegratedTest;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
@@ -57,7 +57,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlGroup;
 
 @IntegratedTest
-public class MeetingV2ServiceTest extends AbstractContainerBaseTest {
+public class MeetingV2ServiceTest extends redisContainerBaseTest {
 
 	@Autowired
 	private MeetingV2Service meetingV2Service;

--- a/main/src/test/java/org/sopt/makers/crew/main/user/v2/UserServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/user/v2/UserServiceTest.java
@@ -98,38 +98,6 @@ public class UserServiceTest {
 				.extracting("userName", "recentPart", "recentGeneration", "profileImageUrl")
 				.containsExactly("김철수", "안드로이드", 33, "image-url2");
 		}
-
-		@Test
-		void 멘션_사용자_조회시_db에_올바르지_않은_데이터_저장된_경우() {
-			// given
-			User user1 = User.builder()
-				.name("홍길동")
-				.orgId(1)
-				.activities(List.of(new UserActivityVO("서버", 33), new UserActivityVO("iOS", 34)))
-				.profileImage("image-url1")
-				.phone("010-1234-5678")
-				.build();
-			User user2 = User.builder()
-				.name("김철수")
-				.orgId(2)
-				.activities(List.of(new UserActivityVO(null, 30), new UserActivityVO("", 34)))
-				.profileImage("image-url2")
-				.phone("010-1111-2222")
-				.build();
-			userRepository.saveAll(List.of(user1, user2));
-
-			// when
-			List<UserV2GetAllUserDto> allMentionUsers = userV2Service.getAllUser();
-
-			// then
-			assertThat(allMentionUsers).hasSize(2);
-			assertThat(allMentionUsers.get(0))
-				.extracting("userName", "recentPart", "recentGeneration", "profileImageUrl")
-				.containsExactly("홍길동", "iOS", 34, "image-url1");
-			assertThat(allMentionUsers.get(1))
-				.extracting("userName", "recentPart", "recentGeneration", "profileImageUrl")
-				.containsExactly("김철수", "", 34, "image-url2");
-		}
 	}
 
 	@Nested


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
### 구현 오버뷰
- 레디스를 사용해서 변동성이 적은 데이터를 캐싱해봤습니다.
- 모임 정보, 모임장, 공동모임장 정보를 캐싱하여 캐싱된 경우에 쿼리를 3회 줄였습니다.

### Reader 레이어
- Repository와 service 레이어 사이에 Reader 레이어를 두었습니다.
- 해당 레이어의 역할은 캐싱된 데이터가 있다면 그 데이터를 반환하고, 캐싱되지 않았다면 repository 로 내려가서 해당 데이터를 조회합니다.

### 캐싱 방식
- 상세 모임 조회에서 캐싱을 저장합니다.
- 모임 수정 API에서 해당 모임이 캐시에 저장되어있으면 해당 캐시를 삭제합니다.

### 레디스 테스트 컨테이너
- 테스트 환경에서도 레디스를 어떻게 해야할지 고민이 많았습니다.
- local redis에 의존하는 것은 너무 불편하다고 생각이 들어 test container로 레디스를 띄어서 구현했습니다.
- 해당 구현은 `redisContainerBaseTest` 클래스 보시면 되겠습니다!
- 해당 방법은 아래 사진과 같습니다!
    - 참고자료 : https://loosie.tistory.com/813#3._Testcontainers%EB%A1%9C_%ED%86%B5%ED%95%A9_%ED%85%8C%EC%8A%A4%ED%8A%B8_%ED%99%98%EA%B2%BD_%EA%B5%AC%EC%B6%95%ED%95%98%EA%B8%B0
<img width="1085" alt="스크린샷 2024-11-14 오전 12 10 15" src="https://github.com/user-attachments/assets/08a06d37-db55-41cc-8563-b652a325a02f">

### 트러블슈팅 - 직렬화/역직렬화
- 이번에 구현하면서 가장 애먹은 부분이었습니다.
- 먼저 LocalDateTime은 직렬화가 되지 않는 문제가 있었습니다.
- 뿐만 아니라, UserActivityVO, ImageUrlVO, mStartDate 등과 같은 객체도 직렬화가 제대로 되지 않았습니다.
- 따라서 해당 데이터들을 직렬화 하기 위한 코드 수정이 있었습니다.

### 트러블 슈팅 - 하이버네이트 Lazy 로딩 객체 직렬화/역직렬화
<img width="1104" alt="스크린샷 2024-11-13 오후 10 20 15" src="https://github.com/user-attachments/assets/8967120c-aba0-4686-a8ff-db5db5c8ce22">

- Meeting 객체 내의 `User` 객체의 직렬화/역직렬화 문제도 있었습니다. 
- 연관관계가 있는 객체(`User`) 까지 레디스에 저장하려고 했지만 그게 잘 되지 않았습니다. 
- 그래서 Meeting 따로, User 따로 조회하고자 했습니다.
- 하지만 첨부사진에서 426번라인에서 `Meeting` 를 조회할 때, `Meeting` 객체 내에 있는 User 가 427번 라인의 `meetingLeader` 에도 저장되는 문제가 있었습니다. 하지만 `Meeting` 객체 내에 있는 `User`는 Lazy loading 방식이어서 `null`로 저장되어 있기 때문에 `meetingLeader`도 `null` 저장되는 문제가 있었습니다.
- 그래서 UserReader 에서 User 가 아닌 MeetingCreatorDTO를 캐시하도록 구현했습니다..! 이게 설명이 어려운데 같이 얘기해봐도 좋을 것 같아요!

### 유의사항
- 현재 인프라 테스트를 위해 github workflow를 변경한 상태입니다. 머지 전에 수정하고 머지하도록 하겠습니다.

### 추가적으로 했던 것들
- 서버 에러의 경우 에러 트레이스를 보는게 도움이 돼서 트레이스를 모두 출력하도록 수정해봤습니다!

## 성능 개선 (warm-up 제외하고 3회 3000번 요청 진행)
local - redis 전
639 ms
581 ms
625 ms

dev - redis 전
2233 ms
2008 ms
1655 ms

local - redis 후
290 ms
280 ms
281 ms

dev - redis 후
1715 ms
1503 ms
1101 ms

그래도 1.5배 정도 빨라진 것 같습니다!

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
### 인프라
- 저번에 레디스의 도커 컴포즈에 대해 얘기가 있었는데 의견여쭤보고 싶습니다!
- 현재는 컴포즈 내에 레디스를 넣어둔 상황입니다. 
- 그 이유로, 개발 하면서 경험했던 것을 말씀드려보겠습니다! 캐시에 저장된 데이터와 스프링 서버에서 불러오려는 객체 간의 차이가 발생하면 오류가 발생합니다. 이런 부분을 생각해봤을 때, 배포가 될 때 redis도 함께 새로 세팅하는게 좋겠다고 생각하여 함께 컴포즈로 묶어줬습니다. 이 부분에 대해 의견 궁금합니다!

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #477 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?