### PR TITLE
feat: app be를 위한 스터디 수 조회 API 구현

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
@@ -7,7 +7,6 @@ import java.util.List;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.global.exception.BadRequestException;
-import org.sopt.makers.crew.main.internal.dto.ApprovedStudyCountProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -59,12 +58,11 @@ public interface ApplyRepository extends JpaRepository<Apply, Integer>, ApplySea
 	@Query("DELETE FROM Apply a WHERE a.meetingId = :meetingId")
 	void deleteAllByMeetingIdQuery(Integer meetingId);
 
-	@Query("SELECT u.orgId AS orgId, COUNT(a.id) AS approvedStudyCount " +
+	@Query("SELECT COALESCE(COUNT(a.id), 0) " +
 		"FROM Apply a JOIN a.meeting m " +
 		"JOIN a.user u " +
-		"WHERE m.category = :category AND a.status = :status AND u.orgId = :orgId " +
-		"GROUP BY u.orgId")
-	List<ApprovedStudyCountProjection> findApprovedStudyCountByOrgId(
+		"WHERE m.category = :category AND a.status = :status AND u.orgId = :orgId")
+	Long findApprovedStudyCountByOrgId(
 		@Param("category") MeetingCategory category,
 		@Param("status") EnApplyStatus status,
 		@Param("orgId") Integer orgId);

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
@@ -1,11 +1,13 @@
 package org.sopt.makers.crew.main.entity.apply;
 
-import static org.sopt.makers.crew.main.global.exception.ErrorStatus.NOT_FOUND_APPLY;
+import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
 
 import java.util.List;
 
-import org.sopt.makers.crew.main.global.exception.BadRequestException;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
+import org.sopt.makers.crew.main.global.exception.BadRequestException;
+import org.sopt.makers.crew.main.internal.dto.ApprovedStudyCountProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -57,4 +59,13 @@ public interface ApplyRepository extends JpaRepository<Apply, Integer>, ApplySea
 	@Query("DELETE FROM Apply a WHERE a.meetingId = :meetingId")
 	void deleteAllByMeetingIdQuery(Integer meetingId);
 
+	@Query("SELECT u.orgId AS orgId, COUNT(a.id) AS approvedStudyCount " +
+		"FROM Apply a JOIN a.meeting m " +
+		"JOIN a.user u " +
+		"WHERE m.category = :category AND a.status = :status AND u.orgId = :orgId " + // orgId로 필터링
+		"GROUP BY u.orgId")
+	List<ApprovedStudyCountProjection> findApprovedStudyCountByOrgId(
+		@Param("category") MeetingCategory category,
+		@Param("status") EnApplyStatus status,
+		@Param("orgId") Integer orgId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
@@ -62,7 +62,7 @@ public interface ApplyRepository extends JpaRepository<Apply, Integer>, ApplySea
 	@Query("SELECT u.orgId AS orgId, COUNT(a.id) AS approvedStudyCount " +
 		"FROM Apply a JOIN a.meeting m " +
 		"JOIN a.user u " +
-		"WHERE m.category = :category AND a.status = :status AND u.orgId = :orgId " + // orgId로 필터링
+		"WHERE m.category = :category AND a.status = :status AND u.orgId = :orgId " +
 		"GROUP BY u.orgId")
 	List<ApprovedStudyCountProjection> findApprovedStudyCountByOrgId(
 		@Param("category") MeetingCategory category,

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/InternalMeetingStatsApi.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/InternalMeetingStatsApi.java
@@ -1,0 +1,25 @@
+package org.sopt.makers.crew.main.internal;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "internal API - 개수(스터디, 행사 등등)")
+public interface InternalMeetingStatsApi {
+
+	@Operation(summary = "유저의 승인된 스터디 수 조회", description = "특정 유저의 승인된 스터디 수를 조회하는 API입니다.", tags = {
+		"Internal Meeting Stats"})
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "APPROVE된 스터디 수 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(example = "{\"orgId\": 1, \"approvedStudyCount\": 5}"))),
+		@ApiResponse(responseCode = "404", description = "존재하지 않는 유저입니다.", content = @Content(mediaType = "application/json"))})
+	ResponseEntity<Map<String, Object>> getApprovedStudyCountByOrgId(
+		@Parameter(description = "플레이그라운드 유저 ID(orgId)", example = "1") Integer orgId);
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/InternalMeetingStatsController.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/InternalMeetingStatsController.java
@@ -1,0 +1,26 @@
+package org.sopt.makers.crew.main.internal;
+
+import org.sopt.makers.crew.main.internal.dto.ApprovedStudyCountResponseDto;
+import org.sopt.makers.crew.main.internal.service.InternalMeetingStatsService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/internal/meeting/stats")
+@RequiredArgsConstructor
+public class InternalMeetingStatsController {
+	private final InternalMeetingStatsService internalMeetingStatsService;
+
+	@GetMapping("/approved-studies/{orgId}")
+	public ResponseEntity<ApprovedStudyCountResponseDto> getApprovedStudyCountByOrgId(
+		@PathVariable Integer orgId
+	) {
+		ApprovedStudyCountResponseDto response = internalMeetingStatsService.getApprovedStudyCountByOrgId(orgId);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/dto/ApprovedStudyCountProjection.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/dto/ApprovedStudyCountProjection.java
@@ -1,0 +1,7 @@
+package org.sopt.makers.crew.main.internal.dto;
+
+public interface ApprovedStudyCountProjection {
+	Integer getOrgId();
+
+	Long getApprovedStudyCount();
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/dto/ApprovedStudyCountProjection.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/dto/ApprovedStudyCountProjection.java
@@ -1,7 +1,0 @@
-package org.sopt.makers.crew.main.internal.dto;
-
-public interface ApprovedStudyCountProjection {
-	Integer getOrgId();
-
-	Long getApprovedStudyCount();
-}

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/dto/ApprovedStudyCountResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/dto/ApprovedStudyCountResponseDto.java
@@ -1,0 +1,13 @@
+package org.sopt.makers.crew.main.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "승인된 스터디 수를 나타내는 DTO")
+public record ApprovedStudyCountResponseDto(
+	@Schema(description = "플레이그라운드 유저 ID(orgId)", example = "1")
+	Integer orgId,
+
+	@Schema(description = "승인된 스터디 수", example = "5")
+	Long approvedStudyCount
+) {
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/dto/ApprovedStudyCountResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/dto/ApprovedStudyCountResponseDto.java
@@ -10,4 +10,14 @@ public record ApprovedStudyCountResponseDto(
 	@Schema(description = "승인된 스터디 수", example = "5")
 	Long approvedStudyCount
 ) {
+	public static ApprovedStudyCountResponseDto fromProjection(ApprovedStudyCountProjection projection) {
+		return new ApprovedStudyCountResponseDto(
+			projection.getOrgId(),
+			projection.getApprovedStudyCount()
+		);
+	}
+
+	public static ApprovedStudyCountResponseDto empty(Integer orgId) {
+		return new ApprovedStudyCountResponseDto(orgId, 0L);
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/dto/ApprovedStudyCountResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/dto/ApprovedStudyCountResponseDto.java
@@ -10,14 +10,7 @@ public record ApprovedStudyCountResponseDto(
 	@Schema(description = "승인된 스터디 수", example = "5")
 	Long approvedStudyCount
 ) {
-	public static ApprovedStudyCountResponseDto fromProjection(ApprovedStudyCountProjection projection) {
-		return new ApprovedStudyCountResponseDto(
-			projection.getOrgId(),
-			projection.getApprovedStudyCount()
-		);
-	}
-
-	public static ApprovedStudyCountResponseDto empty(Integer orgId) {
-		return new ApprovedStudyCountResponseDto(orgId, 0L);
+	public static ApprovedStudyCountResponseDto of(Integer orgId, Long approvedStudyCount) {
+		return new ApprovedStudyCountResponseDto(orgId, approvedStudyCount);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingStatsService.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingStatsService.java
@@ -28,6 +28,6 @@ public class InternalMeetingStatsService {
 		Long approvedStudyCount = applyRepository.findApprovedStudyCountByOrgId(MeetingCategory.STUDY,
 			EnApplyStatus.APPROVE, user.getOrgId());
 
-		return ApprovedStudyCountResponseDto.of(orgId, approvedStudyCount);
+		return ApprovedStudyCountResponseDto.of(user.getOrgId(), approvedStudyCount);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingStatsService.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingStatsService.java
@@ -1,0 +1,49 @@
+package org.sopt.makers.crew.main.internal.service;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.UserRepository;
+import org.sopt.makers.crew.main.global.exception.ErrorStatus;
+import org.sopt.makers.crew.main.global.exception.NotFoundException;
+import org.sopt.makers.crew.main.internal.dto.ApprovedStudyCountProjection;
+import org.sopt.makers.crew.main.internal.dto.ApprovedStudyCountResponseDto;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class InternalMeetingStatsService {
+	private final ApplyRepository applyRepository;
+	private final UserRepository userRepository;
+
+	public ApprovedStudyCountResponseDto getApprovedStudyCountByOrgId(Integer orgId) {
+		User user = userRepository.findByOrgId(orgId)
+			.orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_USER.getErrorCode()));
+
+		return fetchApprovedStudyCount(user);
+	}
+
+	private ApprovedStudyCountResponseDto fetchApprovedStudyCount(User user) {
+		List<ApprovedStudyCountProjection> results = applyRepository.findApprovedStudyCountByOrgId(
+			MeetingCategory.STUDY, EnApplyStatus.APPROVE, user.getOrgId()
+		);
+
+		return results.stream()
+			.findFirst()
+			.map(this::toResponse)
+			.orElseGet(() -> toEmptyResponse(user.getOrgId()));
+	}
+
+	private ApprovedStudyCountResponseDto toResponse(ApprovedStudyCountProjection projection) {
+		return new ApprovedStudyCountResponseDto(projection.getOrgId(), projection.getApprovedStudyCount());
+	}
+
+	private ApprovedStudyCountResponseDto toEmptyResponse(Integer orgId) {
+		return new ApprovedStudyCountResponseDto(orgId, 0L);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingStatsService.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingStatsService.java
@@ -1,7 +1,5 @@
 package org.sopt.makers.crew.main.internal.service;
 
-import java.util.List;
-
 import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
@@ -9,7 +7,6 @@ import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.entity.user.UserRepository;
 import org.sopt.makers.crew.main.global.exception.ErrorStatus;
 import org.sopt.makers.crew.main.global.exception.NotFoundException;
-import org.sopt.makers.crew.main.internal.dto.ApprovedStudyCountProjection;
 import org.sopt.makers.crew.main.internal.dto.ApprovedStudyCountResponseDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,17 +24,9 @@ public class InternalMeetingStatsService {
 		User user = userRepository.findByOrgId(orgId)
 			.orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_USER.getErrorCode()));
 
-		return fetchApprovedStudyCount(user);
-	}
+		Long approvedStudyCount = applyRepository.findApprovedStudyCountByOrgId(
+			MeetingCategory.STUDY, EnApplyStatus.APPROVE, user.getOrgId());
 
-	private ApprovedStudyCountResponseDto fetchApprovedStudyCount(User user) {
-		List<ApprovedStudyCountProjection> results = applyRepository.findApprovedStudyCountByOrgId(
-			MeetingCategory.STUDY, EnApplyStatus.APPROVE, user.getOrgId()
-		);
-
-		return results.stream()
-			.findFirst()
-			.map(ApprovedStudyCountResponseDto::fromProjection)
-			.orElse(ApprovedStudyCountResponseDto.empty(user.getOrgId()));
+		return ApprovedStudyCountResponseDto.of(user.getOrgId(), approvedStudyCount);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingStatsService.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingStatsService.java
@@ -5,8 +5,6 @@ import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.entity.user.UserRepository;
-import org.sopt.makers.crew.main.global.exception.ErrorStatus;
-import org.sopt.makers.crew.main.global.exception.NotFoundException;
 import org.sopt.makers.crew.main.internal.dto.ApprovedStudyCountResponseDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,12 +19,15 @@ public class InternalMeetingStatsService {
 	private final UserRepository userRepository;
 
 	public ApprovedStudyCountResponseDto getApprovedStudyCountByOrgId(Integer orgId) {
-		User user = userRepository.findByOrgId(orgId)
-			.orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_USER.getErrorCode()));
+		User user = userRepository.findByOrgId(orgId).orElse(null);
 
-		Long approvedStudyCount = applyRepository.findApprovedStudyCountByOrgId(
-			MeetingCategory.STUDY, EnApplyStatus.APPROVE, user.getOrgId());
+		if (user == null) {
+			return ApprovedStudyCountResponseDto.of(orgId, 0L);
+		}
 
-		return ApprovedStudyCountResponseDto.of(user.getOrgId(), approvedStudyCount);
+		Long approvedStudyCount = applyRepository.findApprovedStudyCountByOrgId(MeetingCategory.STUDY,
+			EnApplyStatus.APPROVE, user.getOrgId());
+
+		return ApprovedStudyCountResponseDto.of(orgId, approvedStudyCount);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingStatsService.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingStatsService.java
@@ -12,11 +12,13 @@ import org.sopt.makers.crew.main.global.exception.NotFoundException;
 import org.sopt.makers.crew.main.internal.dto.ApprovedStudyCountProjection;
 import org.sopt.makers.crew.main.internal.dto.ApprovedStudyCountResponseDto;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class InternalMeetingStatsService {
 	private final ApplyRepository applyRepository;
 	private final UserRepository userRepository;

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingStatsService.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingStatsService.java
@@ -35,15 +35,7 @@ public class InternalMeetingStatsService {
 
 		return results.stream()
 			.findFirst()
-			.map(this::toResponse)
-			.orElseGet(() -> toEmptyResponse(user.getOrgId()));
-	}
-
-	private ApprovedStudyCountResponseDto toResponse(ApprovedStudyCountProjection projection) {
-		return new ApprovedStudyCountResponseDto(projection.getOrgId(), projection.getApprovedStudyCount());
-	}
-
-	private ApprovedStudyCountResponseDto toEmptyResponse(Integer orgId) {
-		return new ApprovedStudyCountResponseDto(orgId, 0L);
+			.map(ApprovedStudyCountResponseDto::fromProjection)
+			.orElse(ApprovedStudyCountResponseDto.empty(user.getOrgId()));
 	}
 }


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- app be를 위해 스터디 수 조회 API를 구현했습니다.
- 솝커톤 조회 API의 경우 아직 앱쪽에서 기획 확정이 되지 않아서 보류하고 작업했습니다.


## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

### [2024.11.19, 23:11]
- 앱 측에서 스터디 수 조회 API만 필요하다는 의견이 다시 나와, 스터디 수 조회 API만 구현하기로 결정하였습니다.

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #488 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?