### PR TITLE
feat: 번쩍 개설 기능 구현

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
@@ -1,6 +1,5 @@
 package org.sopt.makers.crew.main.entity.lightning;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -22,6 +21,7 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -53,7 +53,7 @@ public class Lightning extends BaseTimeEntity {
 
 	@Column(name = "activityStartDate")
 	@NotNull
-	private LocalDate activityStartDate;
+	private LocalDateTime activityStartDate;
 
 	@Column(name = "activityEndDate")
 	@NotNull
@@ -81,4 +81,23 @@ public class Lightning extends BaseTimeEntity {
 	@Column(name = "imageURL", columnDefinition = "jsonb")
 	@Type(JsonBinaryType.class)
 	private List<ImageUrlVO> imageURL;
+
+	@Builder
+	public Lightning(Integer leaderUserId, String title, String desc, LightningTimingType lightningTimingType,
+		LocalDateTime activityStartDate, LocalDateTime activityEndDate, LightningPlaceType lightningPlaceType,
+		String lightningPlace, int minimumCapacity, int maximumCapacity, Integer createdGeneration,
+		List<ImageUrlVO> imageURL) {
+		this.leaderUserId = leaderUserId;
+		this.title = title;
+		this.desc = desc;
+		this.lightningTimingType = lightningTimingType;
+		this.activityStartDate = activityStartDate;
+		this.activityEndDate = activityEndDate;
+		this.lightningPlaceType = lightningPlaceType;
+		this.lightningPlace = lightningPlace;
+		this.minimumCapacity = minimumCapacity;
+		this.maximumCapacity = maximumCapacity;
+		this.createdGeneration = createdGeneration;
+		this.imageURL = imageURL;
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
@@ -5,15 +5,16 @@ import java.util.List;
 
 import org.hibernate.annotations.Type;
 import org.sopt.makers.crew.main.entity.common.BaseTimeEntity;
+import org.sopt.makers.crew.main.entity.lightning.converter.LightningPlaceTypeConverter;
+import org.sopt.makers.crew.main.entity.lightning.converter.LightningTimingTypeConverter;
 import org.sopt.makers.crew.main.entity.lightning.enums.LightningPlaceType;
 import org.sopt.makers.crew.main.entity.lightning.enums.LightningTimingType;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -48,7 +49,7 @@ public class Lightning extends BaseTimeEntity {
 
 	@Column(name = "lightningTimingType")
 	@NotNull
-	@Enumerated(EnumType.STRING)
+	@Convert(converter = LightningTimingTypeConverter.class)
 	private LightningTimingType lightningTimingType;
 
 	@Column(name = "activityStartDate")
@@ -61,7 +62,7 @@ public class Lightning extends BaseTimeEntity {
 
 	@Column(name = "lightningPlaceType")
 	@NotNull
-	@Enumerated(EnumType.STRING)
+	@Convert(converter = LightningPlaceTypeConverter.class)
 	private LightningPlaceType lightningPlaceType;
 
 	@Column(name = "lightningPlace")
@@ -69,9 +70,11 @@ public class Lightning extends BaseTimeEntity {
 	private String lightningPlace;
 
 	@Column(name = "minimumCapacity")
+	@NotNull
 	private int minimumCapacity;
 
 	@Column(name = "maximumCapacity")
+	@NotNull
 	private int maximumCapacity;
 
 	@Column(name = "createdGeneration")

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
@@ -46,7 +46,7 @@ public class Lightning extends BaseTimeEntity {
 	@Column(name = "desc", columnDefinition = "TEXT")
 	private String desc;
 
-	@Column(name = "lightningTiming")
+	@Column(name = "lightningTimingType")
 	@NotNull
 	@Enumerated(EnumType.STRING)
 	private LightningTimingType lightningTimingType;
@@ -58,9 +58,6 @@ public class Lightning extends BaseTimeEntity {
 	@Column(name = "activityEndDate")
 	@NotNull
 	private LocalDateTime activityEndDate;
-
-	@Column(name = "lightningTime")
-	private LocalDateTime lightningTime;
 
 	@Column(name = "lightningPlaceType")
 	@NotNull

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
@@ -77,6 +77,10 @@ public class Lightning extends BaseTimeEntity {
 	@Column(name = "maximumCapacity")
 	private int maximumCapacity;
 
+	@Column(name = "createdGeneration")
+	@NotNull
+	private Integer createdGeneration;
+
 	@Column(name = "imageURL", columnDefinition = "jsonb")
 	@Type(JsonBinaryType.class)
 	private List<ImageUrlVO> imageURL;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
@@ -79,7 +79,7 @@ public class Lightning extends BaseTimeEntity {
 
 	@Column(name = "createdGeneration")
 	@NotNull
-	private Integer createdGeneration;
+	private int createdGeneration;
 
 	@Column(name = "imageURL", columnDefinition = "jsonb")
 	@Type(JsonBinaryType.class)

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import org.hibernate.annotations.Type;
 import org.sopt.makers.crew.main.entity.common.BaseTimeEntity;
+import org.sopt.makers.crew.main.entity.lightning.enums.LightningPlaceType;
+import org.sopt.makers.crew.main.entity.lightning.enums.LightningTimingType;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
@@ -44,6 +46,11 @@ public class Lightning extends BaseTimeEntity {
 	@Column(name = "desc", columnDefinition = "TEXT")
 	private String desc;
 
+	@Column(name = "lightningTiming")
+	@NotNull
+	@Enumerated(EnumType.STRING)
+	private LightningTimingType lightningTimingType;
+
 	@Column(name = "activityStartDate")
 	@NotNull
 	private LocalDate activityStartDate;
@@ -73,5 +80,4 @@ public class Lightning extends BaseTimeEntity {
 	@Column(name = "imageURL", columnDefinition = "jsonb")
 	@Type(JsonBinaryType.class)
 	private List<ImageUrlVO> imageURL;
-
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/LightningRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/LightningRepository.java
@@ -1,0 +1,6 @@
+package org.sopt.makers.crew.main.entity.lightning;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LightningRepository extends JpaRepository<Lightning, Integer> {
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/converter/LightningPlaceTypeConverter.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/converter/LightningPlaceTypeConverter.java
@@ -1,0 +1,20 @@
+package org.sopt.makers.crew.main.entity.lightning.converter;
+
+import org.sopt.makers.crew.main.entity.lightning.enums.LightningPlaceType;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class LightningPlaceTypeConverter implements AttributeConverter<LightningPlaceType, String> {
+
+	@Override
+	public String convertToDatabaseColumn(LightningPlaceType lightningPlaceType) {
+		return lightningPlaceType.getValue(); // LightningPlaceType의 값을 반환
+	}
+
+	@Override
+	public LightningPlaceType convertToEntityAttribute(String dbData) {
+		return LightningPlaceType.ofValue(dbData); // dbData에 해당하는 LightningPlaceType 객체를 반환
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/converter/LightningTimingTypeConverter.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/converter/LightningTimingTypeConverter.java
@@ -1,0 +1,20 @@
+package org.sopt.makers.crew.main.entity.lightning.converter;
+
+import org.sopt.makers.crew.main.entity.lightning.enums.LightningTimingType;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class LightningTimingTypeConverter implements AttributeConverter<LightningTimingType, String> {
+
+	@Override
+	public String convertToDatabaseColumn(LightningTimingType lightningTimingType) {
+		return lightningTimingType.getValue(); // LightningTimingType의 값을 반환
+	}
+
+	@Override
+	public LightningTimingType convertToEntityAttribute(String dbData) {
+		return LightningTimingType.ofValue(dbData); // dbData에 해당하는 LightningTimingType 객체를 반환
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/enums/LightningPlaceType.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/enums/LightningPlaceType.java
@@ -1,7 +1,25 @@
 package org.sopt.makers.crew.main.entity.lightning.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum LightningPlaceType {
-	OFFLINE,
-	ONLINE,
-	NOT_DECIDED
+	OFFLINE("오프라인"),
+	ONLINE("온라인"),
+	AFTER_DISCUSSION("협의 후 결정");
+
+	private final String value;
+
+	LightningPlaceType(String value) {
+		this.value = value;
+	}
+
+	public static LightningPlaceType ofValue(String dbData) {
+		for (LightningPlaceType place : LightningPlaceType.values()) {
+			if (place.getValue().equals(dbData)) {
+				return place;
+			}
+		}
+		throw new IllegalArgumentException("Invalid LightningPlaceType value: " + dbData);
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/enums/LightningPlaceType.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/enums/LightningPlaceType.java
@@ -1,4 +1,4 @@
-package org.sopt.makers.crew.main.entity.lightning;
+package org.sopt.makers.crew.main.entity.lightning.enums;
 
 public enum LightningPlaceType {
 	OFFLINE,

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/enums/LightningTimingType.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/enums/LightningTimingType.java
@@ -1,7 +1,25 @@
 package org.sopt.makers.crew.main.entity.lightning.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum LightningTimingType {
-	IMMEDIATE, // 당일
-	DURATION,  // 기간
-	AFTER_DISCUSSION // 협의 후 결정
+	IMMEDIATE("당일"),
+	DURATION("기간"),
+	AFTER_DISCUSSION("협의 후 결정");
+
+	private final String value;
+
+	LightningTimingType(String value) {
+		this.value = value;
+	}
+
+	public static LightningTimingType ofValue(String dbData) {
+		for (LightningTimingType timing : LightningTimingType.values()) {
+			if (timing.getValue().equals(dbData)) {
+				return timing;
+			}
+		}
+		throw new IllegalArgumentException("Invalid LightningTimingType value: " + dbData);
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/enums/LightningTimingType.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/enums/LightningTimingType.java
@@ -1,0 +1,7 @@
+package org.sopt.makers.crew.main.entity.lightning.enums;
+
+public enum LightningTimingType {
+	IMMEDIATE, // 당일
+	DURATION,  // 기간
+	AFTER_DISCUSSION // 협의 후 결정
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -2,13 +2,27 @@ package org.sopt.makers.crew.main.entity.meeting;
 
 import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.hibernate.annotations.Parameter;
+import org.hibernate.annotations.Type;
+import org.sopt.makers.crew.main.entity.common.BaseTimeEntity;
+import org.sopt.makers.crew.main.entity.meeting.converter.MeetingCategoryConverter;
+import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.global.exception.BadRequestException;
+import org.sopt.makers.crew.main.global.exception.ForbiddenException;
+
 import io.hypersistence.utils.hibernate.type.array.EnumArrayType;
 import io.hypersistence.utils.hibernate.type.array.internal.AbstractArrayType;
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -16,27 +30,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import org.hibernate.annotations.Parameter;
-import org.hibernate.annotations.Type;
-import org.sopt.makers.crew.main.entity.common.BaseTimeEntity;
-import org.sopt.makers.crew.main.global.exception.BadRequestException;
-import org.sopt.makers.crew.main.global.exception.ForbiddenException;
-import org.sopt.makers.crew.main.entity.meeting.converter.MeetingCategoryConverter;
-import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
-import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
-import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
-import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
-import org.sopt.makers.crew.main.entity.user.User;
 
 @Entity
 @Getter
@@ -152,7 +150,7 @@ public class Meeting extends BaseTimeEntity {
 	 * 모임 기수
 	 */
 	@Column(name = "createdGeneration", nullable = false)
-	private Integer createdGeneration;
+	private int createdGeneration;
 
 	/**
 	 * 대상 활동 기수
@@ -265,6 +263,5 @@ public class Meeting extends BaseTimeEntity {
 	public LocalDateTime getmEndDate() {
 		return mEndDate;
 	}
-
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/tag/Tag.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/tag/Tag.java
@@ -2,11 +2,15 @@ package org.sopt.makers.crew.main.entity.tag;
 
 import java.util.List;
 
+import org.hibernate.annotations.Type;
 import org.sopt.makers.crew.main.entity.common.BaseTimeEntity;
 import org.sopt.makers.crew.main.entity.tag.enums.TagType;
 import org.sopt.makers.crew.main.entity.tag.enums.WelcomeMessageType;
+import org.sopt.makers.crew.main.entity.tag.enums.WelcomeTypeConverter;
 
+import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -16,6 +20,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -45,8 +50,37 @@ public class Tag extends BaseTimeEntity {
 	@Column(name = "lightningId")
 	private Integer lightningId;
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "welcomeMessageTypes")
+	@Column(name = "welcomeMessageTypes", columnDefinition = "jsonb")
 	@NotNull
+	@Convert(converter = WelcomeTypeConverter.class)
+	@Type(JsonBinaryType.class)
 	private List<WelcomeMessageType> welcomeMessageTypes;
+
+	@Builder
+	private Tag(TagType tagType, Integer meetingId, Integer lightningId, List<WelcomeMessageType> welcomeMessageTypes) {
+		this.tagType = tagType;
+		this.meetingId = meetingId;
+		this.lightningId = lightningId;
+		this.welcomeMessageTypes = welcomeMessageTypes;
+	}
+
+	public static Tag createGeneralMeetingTag(TagType tagType, Integer meetingId,
+		List<WelcomeMessageType> welcomeMessageTypes) {
+		return Tag.builder()
+			.tagType(tagType)
+			.meetingId(meetingId)
+			.lightningId(null)
+			.welcomeMessageTypes(welcomeMessageTypes)
+			.build();
+	}
+
+	public static Tag createLightningMeetingTag(TagType tagType, Integer lightningId,
+		List<WelcomeMessageType> welcomeMessageTypes) {
+		return Tag.builder()
+			.tagType(tagType)
+			.meetingId(null)
+			.lightningId(lightningId)
+			.welcomeMessageTypes(welcomeMessageTypes)
+			.build();
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/tag/Tag.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/tag/Tag.java
@@ -1,6 +1,10 @@
 package org.sopt.makers.crew.main.entity.tag;
 
+import java.util.List;
+
 import org.sopt.makers.crew.main.entity.common.BaseTimeEntity;
+import org.sopt.makers.crew.main.entity.tag.enums.TagType;
+import org.sopt.makers.crew.main.entity.tag.enums.WelcomeMessageType;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -41,7 +45,8 @@ public class Tag extends BaseTimeEntity {
 	@Column(name = "lightningId")
 	private Integer lightningId;
 
+	@Enumerated(EnumType.STRING)
+	@Column(name = "welcomeMessageTypes")
 	@NotNull
-	private String content;
-
+	private List<WelcomeMessageType> welcomeMessageTypes;
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/tag/Tag.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/tag/Tag.java
@@ -51,7 +51,6 @@ public class Tag extends BaseTimeEntity {
 	private Integer lightningId;
 
 	@Column(name = "welcomeMessageTypes", columnDefinition = "jsonb")
-	@NotNull
 	@Convert(converter = WelcomeTypeConverter.class)
 	@Type(JsonBinaryType.class)
 	private List<WelcomeMessageType> welcomeMessageTypes;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/tag/TagRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/tag/TagRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.makers.crew.main.entity.tag;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Integer> {
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/tag/TagType.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/tag/TagType.java
@@ -1,6 +1,0 @@
-package org.sopt.makers.crew.main.entity.tag;
-
-public enum TagType {
-	MEETING,
-	LIGHTING
-}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/tag/enums/TagType.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/tag/enums/TagType.java
@@ -1,0 +1,6 @@
+package org.sopt.makers.crew.main.entity.tag.enums;
+
+public enum TagType {
+	MEETING,
+	LIGHTING
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/tag/enums/TagType.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/tag/enums/TagType.java
@@ -2,5 +2,5 @@ package org.sopt.makers.crew.main.entity.tag.enums;
 
 public enum TagType {
 	MEETING,
-	LIGHTING
+	LIGHTNING
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/tag/enums/WelcomeMessageType.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/tag/enums/WelcomeMessageType.java
@@ -1,0 +1,9 @@
+package org.sopt.makers.crew.main.entity.tag.enums;
+
+public enum WelcomeMessageType {
+	YB_WELCOME, // YB 환영 메시지
+	OB_WELCOME, // OB 환영 메시지
+	FIRST_MEETING_WELCOME, // 초면 환영 메시지
+	BEGINNER_WELCOME, // 입문자 환영 메시지
+	EXPERIENCED_WELCOME; // 숙련자 환영 메시지
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/tag/enums/WelcomeMessageType.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/tag/enums/WelcomeMessageType.java
@@ -1,9 +1,27 @@
 package org.sopt.makers.crew.main.entity.tag.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum WelcomeMessageType {
-	YB_WELCOME, // YB 환영 메시지
-	OB_WELCOME, // OB 환영 메시지
-	FIRST_MEETING_WELCOME, // 초면 환영 메시지
-	BEGINNER_WELCOME, // 입문자 환영 메시지
-	EXPERIENCED_WELCOME; // 숙련자 환영 메시지
+	YB_WELCOME("YB 환영"),
+	OB_WELCOME("OB 환영"),
+	FIRST_MEETING_WELCOME("초면 환영"),
+	BEGINNER_WELCOME("입문자 환영"),
+	EXPERIENCED_WELCOME("숙련자 환영");
+
+	private final String value;
+
+	WelcomeMessageType(String value) {
+		this.value = value;
+	}
+
+	public static WelcomeMessageType ofValue(String dbData) {
+		for (WelcomeMessageType type : WelcomeMessageType.values()) {
+			if (type.getValue().equals(dbData)) {
+				return type;
+			}
+		}
+		throw new IllegalArgumentException("Invalid WelcomeMessageType value: " + dbData);
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/tag/enums/WelcomeTypeConverter.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/tag/enums/WelcomeTypeConverter.java
@@ -15,7 +15,11 @@ public class WelcomeTypeConverter implements AttributeConverter<List<WelcomeMess
 	@Override
 	public String convertToDatabaseColumn(List<WelcomeMessageType> attribute) {
 		try {
-			return objectMapper.writeValueAsString(attribute);
+			// Enum -> 한글 값 리스트 -> JSON
+			List<String> values = attribute.stream()
+				.map(WelcomeMessageType::getValue)
+				.toList();
+			return objectMapper.writeValueAsString(values);
 		} catch (Exception e) {
 			throw new IllegalArgumentException("Error converting list to JSON: " + attribute, e);
 		}
@@ -24,8 +28,12 @@ public class WelcomeTypeConverter implements AttributeConverter<List<WelcomeMess
 	@Override
 	public List<WelcomeMessageType> convertToEntityAttribute(String dbData) {
 		try {
-			return objectMapper.readValue(dbData, new TypeReference<>() {
+			// JSON -> 한글 값 리스트 -> Enum
+			List<String> values = objectMapper.readValue(dbData, new TypeReference<>() {
 			});
+			return values.stream()
+				.map(WelcomeMessageType::ofValue)
+				.toList();
 		} catch (Exception e) {
 			throw new IllegalArgumentException("Error converting JSON to list: " + dbData, e);
 		}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/tag/enums/WelcomeTypeConverter.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/tag/enums/WelcomeTypeConverter.java
@@ -1,0 +1,33 @@
+package org.sopt.makers.crew.main.entity.tag.enums;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class WelcomeTypeConverter implements AttributeConverter<List<WelcomeMessageType>, String> {
+	private static final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Override
+	public String convertToDatabaseColumn(List<WelcomeMessageType> attribute) {
+		try {
+			return objectMapper.writeValueAsString(attribute);
+		} catch (Exception e) {
+			throw new IllegalArgumentException("Error converting list to JSON: " + attribute, e);
+		}
+	}
+
+	@Override
+	public List<WelcomeMessageType> convertToEntityAttribute(String dbData) {
+		try {
+			return objectMapper.readValue(dbData, new TypeReference<>() {
+			});
+		} catch (Exception e) {
+			throw new IllegalArgumentException("Error converting JSON to list: " + dbData, e);
+		}
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Api.java
@@ -1,0 +1,27 @@
+package org.sopt.makers.crew.main.lightning.v2;
+
+import java.security.Principal;
+
+import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyDto;
+import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2CreateLightningResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "번쩍 모임")
+public interface LightningV2Api {
+	@Operation(summary = "번쩍 모임 생성")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "201", description = "성공"),
+		@ApiResponse(responseCode = "400", description = "\"이미지 파일이 없습니다.\" or \"한 개 이상의 파트를 입력해주세요\" or \"프로필을 입력해주세요\"", content = @Content),
+	})
+	ResponseEntity<LightningV2CreateLightningResponseDto> createLightning(
+		@Valid @RequestBody LightningV2CreateLightningBodyDto requestBody,
+		Principal principal);
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Controller.java
@@ -1,0 +1,35 @@
+package org.sopt.makers.crew.main.lightning.v2;
+
+import java.security.Principal;
+
+import org.sopt.makers.crew.main.global.util.UserUtil;
+import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyDto;
+import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2CreateLightningResponseDto;
+import org.sopt.makers.crew.main.lightning.v2.service.LightningV2Service;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/lightning/v2")
+@RequiredArgsConstructor
+public class LightningV2Controller implements LightningV2Api {
+	private final LightningV2Service lightningV2Service;
+
+	@Override
+	@PostMapping
+	public ResponseEntity<LightningV2CreateLightningResponseDto> createLightning(
+		@Valid @RequestBody LightningV2CreateLightningBodyDto requestBody,
+		Principal principal
+	) {
+		Integer userId = UserUtil.getUserId(principal);
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(lightningV2Service.createLightning(requestBody, userId));
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/mapper/LightningMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/mapper/LightningMapper.java
@@ -49,11 +49,11 @@ public interface LightningMapper {
 
 	@Named("getLightningPlaceType")
 	static LightningPlaceType getLightningPlaceType(String placeType) {
-		return LightningPlaceType.valueOf(placeType);
+		return LightningPlaceType.ofValue(placeType);
 	}
 
 	@Named("getLightningTimingType")
 	static LightningTimingType getLightningTimingType(String timingType) {
-		return LightningTimingType.valueOf(timingType);
+		return LightningTimingType.ofValue(timingType);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/mapper/LightningMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/mapper/LightningMapper.java
@@ -1,0 +1,59 @@
+package org.sopt.makers.crew.main.lightning.v2.dto.mapper;
+
+import static org.sopt.makers.crew.main.global.constant.CrewConst.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.sopt.makers.crew.main.entity.lightning.Lightning;
+import org.sopt.makers.crew.main.entity.lightning.enums.LightningPlaceType;
+import org.sopt.makers.crew.main.entity.lightning.enums.LightningTimingType;
+import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyWithoutWelcomeMessageDto;
+
+@Mapper(componentModel = "spring")
+public interface LightningMapper {
+
+	@Mapping(source = "lightningBody.files", target = "imageURL", qualifiedByName = "getImageURL")
+	@Mapping(source = "lightningBody.activityStartDate", target = "activityStartDate", qualifiedByName = "getStartDate")
+	@Mapping(source = "lightningBody.activityEndDate", target = "activityEndDate", qualifiedByName = "getEndDate")
+	@Mapping(source = "lightningBody.lightningPlaceType", target = "lightningPlaceType", qualifiedByName = "getLightningPlaceType")
+	@Mapping(source = "lightningBody.lightningTimingType", target = "lightningTimingType", qualifiedByName = "getLightningTimingType")
+	Lightning toLightningEntity(LightningV2CreateLightningBodyWithoutWelcomeMessageDto lightningBody,
+		Integer createdGeneration, Integer leaderUserId);
+
+	@Named("getImageURL")
+	static List<ImageUrlVO> getImageURL(List<String> files) {
+		AtomicInteger index = new AtomicInteger(0);
+
+		return files.stream()
+			.map(fileUrl -> new ImageUrlVO(index.getAndIncrement(), fileUrl))
+			.toList();
+	}
+
+	@Named("getStartDate")
+	static LocalDateTime getStartDate(String date) {
+		return LocalDateTime.parse(date + DAY_START_TIME, DateTimeFormatter.ofPattern(DAY_TIME_FORMAT));
+	}
+
+	@Named("getEndDate")
+	static LocalDateTime getEndDate(String date) {
+		return LocalDateTime.parse(date + DAY_END_TIME, DateTimeFormatter.ofPattern(DAY_TIME_FORMAT));
+
+	}
+
+	@Named("getLightningPlaceType")
+	static LightningPlaceType getLightningPlaceType(String placeType) {
+		return LightningPlaceType.valueOf(placeType);
+	}
+
+	@Named("getLightningTimingType")
+	static LightningTimingType getLightningTimingType(String timingType) {
+		return LightningTimingType.valueOf(timingType);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyDto.java
@@ -3,15 +3,15 @@ package org.sopt.makers.crew.main.lightning.v2.dto.request;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 @Schema(name = "LightningV2CreateLightningBodyDto", description = "번쩍 모임 생성 및 수정 request body dto")
 public record LightningV2CreateLightningBodyDto(
 	@Schema(description = "번쩍 모임 생성 및 수정 request body")
-	@NotNull LightningV2CreateLightningBodyWithoutWelcomeMessageDto lightningBody,
+	@NotNull
+	LightningV2CreateLightningBodyWithoutWelcomeMessageDto lightningBody,
 
 	@Schema(example = "[\"YB 환영\", \"OB 환영\"]", description = "환영 메시지 타입 리스트")
-	@NotEmpty List<String> welcomeMessageTypes
+	List<String> welcomeMessageTypes
 ) {
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyDto.java
@@ -1,0 +1,19 @@
+package org.sopt.makers.crew.main.lightning.v2.dto.request;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.entity.tag.enums.WelcomeMessageType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(name = "LightningV2CreateLightningBodyDto", description = "번쩍 모임 생성 및 수정 request body dto")
+public record LightningV2CreateLightningBodyDto(
+	@Schema(description = "번쩍 모임 생성 및 수정 request body")
+	@NotNull LightningV2CreateLightningBodyWithoutWelcomeMessageDto lightningBody,
+
+	@Schema(example = "[\"YB_WELCOME\", \"FIRST_MEETING_WELCOME\"]", description = "환영 메시지 타입 리스트")
+	@NotEmpty List<WelcomeMessageType> welcomeMessageTypes
+) {
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyDto.java
@@ -2,8 +2,6 @@ package org.sopt.makers.crew.main.lightning.v2.dto.request;
 
 import java.util.List;
 
-import org.sopt.makers.crew.main.entity.tag.enums.WelcomeMessageType;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -13,7 +11,7 @@ public record LightningV2CreateLightningBodyDto(
 	@Schema(description = "번쩍 모임 생성 및 수정 request body")
 	@NotNull LightningV2CreateLightningBodyWithoutWelcomeMessageDto lightningBody,
 
-	@Schema(example = "[\"YB_WELCOME\", \"FIRST_MEETING_WELCOME\"]", description = "환영 메시지 타입 리스트")
-	@NotEmpty List<WelcomeMessageType> welcomeMessageTypes
+	@Schema(example = "[\"YB 환영\", \"OB 환영\"]", description = "환영 메시지 타입 리스트")
+	@NotEmpty List<String> welcomeMessageTypes
 ) {
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyWithoutWelcomeMessageDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyWithoutWelcomeMessageDto.java
@@ -1,0 +1,58 @@
+package org.sopt.makers.crew.main.lightning.v2.dto.request;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(name = "LightningV2CreateLightningBodyWithoutWelcomeMessageDto", description = "번쩍 모임 생성 및 수정 request body dto (환영 메시지 타입 제외)")
+public record LightningV2CreateLightningBodyWithoutWelcomeMessageDto(
+	@Schema(example = "알고보면 쓸데있는 개발 프로세스", description = "번쩍 모임 제목")
+	@Size(min = 1, max = 30)
+	@NotNull String title,
+
+	@Schema(example = "api 가 터졌다고? 깃이 터졌다고?", description = "번쩍 소개")
+	@Size(min = 1, max = 500)
+	@NotNull
+	String desc,
+
+	@Schema(example = "협의 후 결정", description = "번쩍 일정 결정 방식")
+	@NotNull
+	String lightningTimingType,
+
+	@Schema(example = "2025.10.29", description = "번쩍 활동 시작 날짜", name = "activityStartDate")
+	@NotNull
+	String activityStartDate,
+
+	@Schema(example = "2025.10.30", description = "번쩍 활동 종료 날짜", name = "activityEndDate")
+	@NotNull
+	String activityEndDate,
+
+	@Schema(example = "오프라인", description = "모임 장소 Tag")
+	@NotNull
+	String lightningPlaceType,
+
+	@Schema(example = "잠실역 5번 출구", description = "모임 장소")
+	@NotNull
+	String lightningPlace,
+
+	@Schema(example = "1", description = "최소 모집 인원")
+	@Size(min = 1)
+	@NotNull
+	Integer minimumCapacity,
+
+	@Schema(example = "5", description = "최대 모집 인원")
+	@Size(max = 999)
+	@NotNull
+	Integer maximumCapacity,
+
+	@Schema(example = "[\n"
+		+ "    \"https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2023/04/12/7bd87736-b557-4b26-a0d5-9b09f1f1d7df\"\n"
+		+ "  ]", description = "모임 이미지 리스트, 최대 1개")
+	@NotEmpty
+	@Size(max = 1)
+	List<String> files
+) {
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/response/LightningV2CreateLightningResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/response/LightningV2CreateLightningResponseDto.java
@@ -1,0 +1,15 @@
+package org.sopt.makers.crew.main.lightning.v2.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(name = "LightningV2CreateLightningResponseDto", description = "번쩍 모임 생성 응답 Dto")
+public record LightningV2CreateLightningResponseDto(
+	@Schema(description = "번쩍 모임 id", example = "1")
+	@NotNull
+	Integer lightningId
+) {
+	public static LightningV2CreateLightningResponseDto from(Integer lightningId) {
+		return new LightningV2CreateLightningResponseDto(lightningId);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/service/LightningV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/service/LightningV2Service.java
@@ -1,0 +1,9 @@
+package org.sopt.makers.crew.main.lightning.v2.service;
+
+import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyDto;
+import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2CreateLightningResponseDto;
+
+public interface LightningV2Service {
+	LightningV2CreateLightningResponseDto createLightning(
+		LightningV2CreateLightningBodyDto requestBody, Integer userId);
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/service/LightningV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/service/LightningV2ServiceImpl.java
@@ -1,0 +1,55 @@
+package org.sopt.makers.crew.main.lightning.v2.service;
+
+import static org.sopt.makers.crew.main.global.constant.CrewConst.*;
+import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
+
+import org.sopt.makers.crew.main.entity.lightning.Lightning;
+import org.sopt.makers.crew.main.entity.lightning.LightningRepository;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.global.exception.BadRequestException;
+import org.sopt.makers.crew.main.lightning.v2.dto.mapper.LightningMapper;
+import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyDto;
+import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2CreateLightningResponseDto;
+import org.sopt.makers.crew.main.tag.v2.service.TagV2Service;
+import org.sopt.makers.crew.main.user.v2.service.UserV2Service;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LightningV2ServiceImpl implements LightningV2Service {
+
+	private static final int INTRO_IMAGE_LIST_SIZE = 1;
+
+	private final UserV2Service userV2Service;
+	private final TagV2Service tagV2Service;
+
+	private final LightningRepository lightningRepository;
+	private final LightningMapper lightningMapper;
+
+	@Override
+	@Transactional
+	public LightningV2CreateLightningResponseDto createLightning(
+		LightningV2CreateLightningBodyDto requestBody, Integer userId) {
+		User user = userV2Service.getUserByUserId(userId);
+
+		if (user.getActivities() == null) {
+			throw new BadRequestException(VALIDATION_EXCEPTION.getErrorCode());
+		}
+
+		if (requestBody.lightningBody().files().size() > INTRO_IMAGE_LIST_SIZE) {
+			throw new BadRequestException(VALIDATION_EXCEPTION.getErrorCode());
+		}
+
+		Lightning lightning = lightningMapper.toLightningEntity(requestBody.lightningBody(), ACTIVE_GENERATION,
+			user.getId());
+
+		lightningRepository.save(lightning);
+		tagV2Service.createLightningTag(requestBody.welcomeMessageTypes(), lightning.getId());
+
+		return LightningV2CreateLightningResponseDto.from(lightning.getId());
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/tag/v2/dto/response/TagV2CreateTagResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/tag/v2/dto/response/TagV2CreateTagResponseDto.java
@@ -1,0 +1,15 @@
+package org.sopt.makers.crew.main.tag.v2.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(name = "TagV2CreateLightningTagResponseDto", description = "번쩍 모임 태그 생성 응답 Dto")
+public record TagV2CreateTagResponseDto(
+	@Schema(description = "모임 태그 id", example = "1")
+	@NotNull
+	Integer tagId
+) {
+	public static TagV2CreateTagResponseDto from(Integer tagId) {
+		return new TagV2CreateTagResponseDto(tagId);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2Service.java
@@ -1,0 +1,10 @@
+package org.sopt.makers.crew.main.tag.v2.service;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.entity.tag.enums.WelcomeMessageType;
+import org.sopt.makers.crew.main.tag.v2.dto.response.TagV2CreateTagResponseDto;
+
+public interface TagV2Service {
+	TagV2CreateTagResponseDto createLightningTag(List<WelcomeMessageType> welcomeMessageTypes, Integer lightningId);
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2Service.java
@@ -2,9 +2,8 @@ package org.sopt.makers.crew.main.tag.v2.service;
 
 import java.util.List;
 
-import org.sopt.makers.crew.main.entity.tag.enums.WelcomeMessageType;
 import org.sopt.makers.crew.main.tag.v2.dto.response.TagV2CreateTagResponseDto;
 
 public interface TagV2Service {
-	TagV2CreateTagResponseDto createLightningTag(List<WelcomeMessageType> welcomeMessageTypes, Integer lightningId);
+	TagV2CreateTagResponseDto createLightningTag(List<String> welcomeMessageTypes, Integer lightningId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2ServiceImpl.java
@@ -31,9 +31,13 @@ public class TagV2ServiceImpl implements TagV2Service {
 			throw new BadRequestException(VALIDATION_EXCEPTION.getErrorCode());
 		}
 
-		List<WelcomeMessageType> welcomeMessageTypeEnums = welcomeMessageTypes.stream()
-			.map(WelcomeMessageType::ofValue)
-			.toList();
+		List<WelcomeMessageType> welcomeMessageTypeEnums = null;
+
+		if (welcomeMessageTypes != null) {
+			welcomeMessageTypeEnums = welcomeMessageTypes.stream()
+				.map(WelcomeMessageType::ofValue)
+				.toList();
+		}
 
 		Tag tag = Tag.createLightningMeetingTag(TagType.LIGHTNING, lightningId, welcomeMessageTypeEnums);
 		tagRepository.save(tag);

--- a/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2ServiceImpl.java
@@ -1,0 +1,41 @@
+package org.sopt.makers.crew.main.tag.v2.service;
+
+import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.entity.tag.Tag;
+import org.sopt.makers.crew.main.entity.tag.TagRepository;
+import org.sopt.makers.crew.main.entity.tag.enums.TagType;
+import org.sopt.makers.crew.main.entity.tag.enums.WelcomeMessageType;
+import org.sopt.makers.crew.main.global.exception.BadRequestException;
+import org.sopt.makers.crew.main.tag.v2.dto.response.TagV2CreateTagResponseDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TagV2ServiceImpl implements TagV2Service {
+
+	private final TagRepository tagRepository;
+
+	@Override
+	@Transactional
+	public TagV2CreateTagResponseDto createLightningTag(List<WelcomeMessageType> welcomeMessageTypes,
+		Integer lightningId) {
+
+		if (lightningId == null) {
+			throw new BadRequestException(VALIDATION_EXCEPTION.getErrorCode());
+		}
+
+		Tag tag = Tag.createLightningMeetingTag(TagType.LIGHTNING, lightningId, welcomeMessageTypes);
+		tagRepository.save(tag);
+
+		return TagV2CreateTagResponseDto.from(tag.getId());
+	}
+
+	// 여기에 createGeneralMeetingTag 메서드도 추가하면 될 것 같습니다 나중에!
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2ServiceImpl.java
@@ -24,14 +24,18 @@ public class TagV2ServiceImpl implements TagV2Service {
 
 	@Override
 	@Transactional
-	public TagV2CreateTagResponseDto createLightningTag(List<WelcomeMessageType> welcomeMessageTypes,
+	public TagV2CreateTagResponseDto createLightningTag(List<String> welcomeMessageTypes,
 		Integer lightningId) {
 
 		if (lightningId == null) {
 			throw new BadRequestException(VALIDATION_EXCEPTION.getErrorCode());
 		}
 
-		Tag tag = Tag.createLightningMeetingTag(TagType.LIGHTNING, lightningId, welcomeMessageTypes);
+		List<WelcomeMessageType> welcomeMessageTypeEnums = welcomeMessageTypes.stream()
+			.map(WelcomeMessageType::ofValue)
+			.toList();
+
+		Tag tag = Tag.createLightningMeetingTag(TagType.LIGHTNING, lightningId, welcomeMessageTypeEnums);
 		tagRepository.save(tag);
 
 		return TagV2CreateTagResponseDto.from(tag.getId());

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
@@ -3,8 +3,6 @@ package org.sopt.makers.crew.main.user.v2;
 import java.security.Principal;
 import java.util.List;
 
-import lombok.RequiredArgsConstructor;
-
 import org.sopt.makers.crew.main.global.util.UserUtil;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMeetingByUserMeetingDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMentionUserDto;
@@ -19,6 +17,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/user/v2")
@@ -75,5 +75,4 @@ public class UserV2Controller implements UserV2Api {
 		Integer userId = UserUtil.getUserId(principal);
 		return ResponseEntity.ok().body(userV2Service.getCreatedMeetingByUser(userId));
 	}
-
 }

--- a/main/src/main/resources/application-dev.yml
+++ b/main/src/main/resources/application-dev.yml
@@ -29,7 +29,7 @@ spring:
       storage_engine: innodb
   data:
     redis:
-      host: localhost
+      host: redis
       port: 6379
 
 jwt:

--- a/main/src/main/resources/application-dev.yml
+++ b/main/src/main/resources/application-dev.yml
@@ -29,7 +29,7 @@ spring:
       storage_engine: innodb
   data:
     redis:
-      host: redis
+      host: localhost
       port: 6379
 
 jwt:


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->

https://www.notion.so/sopt-makers/cb7a4bf4670940f399d7fa45c6667e92?pvs=4

<img width="1068" alt="image" src="https://github.com/user-attachments/assets/9c856cbd-78ee-48d2-9eb6-fbf03ea509d8" />


- 번쩍 개설 기능을 구현하였습니다.
- 명세서는 위에 적어두었습니다.


## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## DTO의 Trade off 

<img width="740" alt="image" src="https://github.com/user-attachments/assets/d78ed7e1-589b-4bb2-9af6-443a7b6a1f87" />

- 번쩍 개설 시, 환영태그를 받게 되는데, 이를 Tag 엔티티에서 관리하게 됨으로서 DTO 관련해서 고민이 좀 있었습니다.
- 일단은 코드 상 1번 로직이 가져다주는 장점이 많기때문에 1번으로 진행했으나, 클라이언트측의 의견을 들어보고 바꿔야 될 수도 있을 것 같습니다!
- **LightningV2CreateLightningBodyDto와 같이 봐주시면 될것 같습니다.**


### 1. 환영태그 필드 + 번쩍 개설 요청 객체 필드를 감싼 DTO를 만들자
- 해당 DTO를 만들게 되면, 중복 코드도 사라지고, 번쩍 개설 요청 객체 필드만 꺼내서 toLightningEntity로 보낼 수 있기 때문에 코드가 깔끔하다는 장점이 있습니다.
- 단, 클라이언트 측에서 요청 구조를 바꿔야 하기 때문에 공수가 더 들 수도 있을 것 같다는 생각이 듭니다.

### 2. 환영태그 필드와 번쩍 개설 요청 필드를 모두 포함한 DTO를 하나 더 만들자
- 해당 DTO를 만들게 되면 중복 코드도 늘어나는 단점이 있습니다(번쩍 개설 요청 필드, 환영태그 필드를 모두 명시한 DTO를 다시 생성해야함) 
- 또한, 번쩍 개설 요청 객체 필드만 꺼내서 toLightningEntity로 보낼 수 없고, 번쩍 개설 요청 필드만 포함된 DTO 객체를 서비스 로직 중간에 만들어서 toLightningEntity로 보내야한다는 단점이 있습니다.

## Meeting 테이블 에서 사용되지 않는 필드 발견

<img width="685" alt="image" src="https://github.com/user-attachments/assets/0c6f6976-80d1-4ca2-92ae-38da7446fae7" />

- targetDesc이 사용되지 않는 필드로 잡히고 있고, DB에 계속 Null로 정보가 들어가고 있는 상황인 것 같습니다.

<img width="873" alt="image" src="https://github.com/user-attachments/assets/d61ff6e2-0d96-43cc-aa11-561964cebffe" />

- 또한, MeetingRedisDto에서도 null로 targetDesc을 집어넣고 있는데 이유가 있는지 궁금합니다!


## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #530 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?