### PR TITLE
feat: 번쩍 엔티티에 startDate, endDate 필드 추가 및 기획 변경 싱크 맞추기

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
@@ -52,6 +52,14 @@ public class Lightning extends BaseTimeEntity {
 	@Convert(converter = LightningTimingTypeConverter.class)
 	private LightningTimingType lightningTimingType;
 
+	@Column(name = "startDate")
+	@NotNull
+	private LocalDateTime startDate;
+
+	@Column(name = "endDate")
+	@NotNull
+	private LocalDateTime endDate;
+
 	@Column(name = "activityStartDate")
 	@NotNull
 	private LocalDateTime activityStartDate;
@@ -87,6 +95,7 @@ public class Lightning extends BaseTimeEntity {
 
 	@Builder
 	public Lightning(Integer leaderUserId, String title, String desc, LightningTimingType lightningTimingType,
+		LocalDateTime startDate, LocalDateTime endDate,
 		LocalDateTime activityStartDate, LocalDateTime activityEndDate, LightningPlaceType lightningPlaceType,
 		String lightningPlace, int minimumCapacity, int maximumCapacity, Integer createdGeneration,
 		List<ImageUrlVO> imageURL) {
@@ -94,6 +103,8 @@ public class Lightning extends BaseTimeEntity {
 		this.title = title;
 		this.desc = desc;
 		this.lightningTimingType = lightningTimingType;
+		this.startDate = startDate;
+		this.endDate = endDate;
 		this.activityStartDate = activityStartDate;
 		this.activityEndDate = activityEndDate;
 		this.lightningPlaceType = lightningPlaceType;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
@@ -74,7 +74,6 @@ public class Lightning extends BaseTimeEntity {
 	private LightningPlaceType lightningPlaceType;
 
 	@Column(name = "lightningPlace")
-	@NotNull
 	private String lightningPlace;
 
 	@Column(name = "minimumCapacity")

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/enums/LightningTimingType.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/enums/LightningTimingType.java
@@ -5,8 +5,7 @@ import lombok.Getter;
 @Getter
 public enum LightningTimingType {
 	IMMEDIATE("당일"),
-	DURATION("기간"),
-	AFTER_DISCUSSION("협의 후 결정");
+	AFTER_DISCUSSION("예정 기간(협의 후 결정)");
 
 	private final String value;
 

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Api.java
@@ -4,7 +4,9 @@ import java.security.Principal;
 
 import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyDto;
 import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2CreateLightningResponseDto;
+import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2GetLightningByIdResponseDto;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,12 +18,22 @@ import jakarta.validation.Valid;
 
 @Tag(name = "번쩍 모임")
 public interface LightningV2Api {
+
 	@Operation(summary = "번쩍 모임 생성")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "201", description = "성공"),
-		@ApiResponse(responseCode = "400", description = "\"이미지 파일이 없습니다.\" or \"한 개 이상의 파트를 입력해주세요\" or \"프로필을 입력해주세요\"", content = @Content),
+		@ApiResponse(responseCode = "201", description = "lightningId: 10"),
+		@ApiResponse(responseCode = "400", description = "VALIDATION_EXCEPTION", content = @Content),
 	})
 	ResponseEntity<LightningV2CreateLightningResponseDto> createLightning(
 		@Valid @RequestBody LightningV2CreateLightningBodyDto requestBody,
+		Principal principal);
+
+	@Operation(summary = "번쩍 모임 상세 조회")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "번쩍 모임 상세 조회 성공"),
+		@ApiResponse(responseCode = "400", description = "번쩍 모임이 없습니다.", content = @Content),
+	})
+	ResponseEntity<LightningV2GetLightningByIdResponseDto> getLightningById(
+		@PathVariable Integer lightningId,
 		Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Api.java
@@ -4,9 +4,7 @@ import java.security.Principal;
 
 import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyDto;
 import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2CreateLightningResponseDto;
-import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2GetLightningByIdResponseDto;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,12 +26,12 @@ public interface LightningV2Api {
 		@Valid @RequestBody LightningV2CreateLightningBodyDto requestBody,
 		Principal principal);
 
-	@Operation(summary = "번쩍 모임 상세 조회")
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "번쩍 모임 상세 조회 성공"),
-		@ApiResponse(responseCode = "400", description = "번쩍 모임이 없습니다.", content = @Content),
-	})
-	ResponseEntity<LightningV2GetLightningByIdResponseDto> getLightningById(
-		@PathVariable Integer lightningId,
-		Principal principal);
+	// @Operation(summary = "번쩍 모임 상세 조회")
+	// @ApiResponses(value = {
+	// 	@ApiResponse(responseCode = "200", description = "번쩍 모임 상세 조회 성공"),
+	// 	@ApiResponse(responseCode = "400", description = "번쩍 모임이 없습니다.", content = @Content),
+	// })
+	// ResponseEntity<LightningV2GetLightningByIdResponseDto> getLightningById(
+	// 	@PathVariable Integer lightningId,
+	// 	Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Controller.java
@@ -5,12 +5,9 @@ import java.security.Principal;
 import org.sopt.makers.crew.main.global.util.UserUtil;
 import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyDto;
 import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2CreateLightningResponseDto;
-import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2GetLightningByIdResponseDto;
 import org.sopt.makers.crew.main.lightning.v2.service.LightningV2Service;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,14 +32,14 @@ public class LightningV2Controller implements LightningV2Api {
 		return ResponseEntity.status(HttpStatus.CREATED).body(lightningV2Service.createLightning(requestBody, userId));
 	}
 
-	@Override
-	@GetMapping("{lightningId}")
-	public ResponseEntity<LightningV2GetLightningByIdResponseDto> getLightningById(
-		@PathVariable Integer lightningId,
-		Principal principal
-	) {
-		Integer userId = UserUtil.getUserId(principal);
-
-		return ResponseEntity.ok(lightningV2Service.getLightningById(lightningId, userId));
-	}
+	// @Override
+	// @GetMapping("{lightningId}")
+	// public ResponseEntity<LightningV2GetLightningByIdResponseDto> getLightningById(
+	// 	@PathVariable Integer lightningId,
+	// 	Principal principal
+	// ) {
+	// 	Integer userId = UserUtil.getUserId(principal);
+	//
+	// 	return ResponseEntity.ok(lightningV2Service.getLightningById(lightningId, userId));
+	// }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Controller.java
@@ -5,9 +5,12 @@ import java.security.Principal;
 import org.sopt.makers.crew.main.global.util.UserUtil;
 import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyDto;
 import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2CreateLightningResponseDto;
+import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2GetLightningByIdResponseDto;
 import org.sopt.makers.crew.main.lightning.v2.service.LightningV2Service;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,7 +32,17 @@ public class LightningV2Controller implements LightningV2Api {
 		Principal principal
 	) {
 		Integer userId = UserUtil.getUserId(principal);
-		return ResponseEntity.status(HttpStatus.CREATED)
-			.body(lightningV2Service.createLightning(requestBody, userId));
+		return ResponseEntity.status(HttpStatus.CREATED).body(lightningV2Service.createLightning(requestBody, userId));
+	}
+
+	@Override
+	@GetMapping("{lightningId}")
+	public ResponseEntity<LightningV2GetLightningByIdResponseDto> getLightningById(
+		@PathVariable Integer lightningId,
+		Principal principal
+	) {
+		Integer userId = UserUtil.getUserId(principal);
+
+		return ResponseEntity.ok(lightningV2Service.getLightningById(lightningId, userId));
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/mapper/LightningMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/mapper/LightningMapper.java
@@ -14,18 +14,21 @@ import org.sopt.makers.crew.main.entity.lightning.Lightning;
 import org.sopt.makers.crew.main.entity.lightning.enums.LightningPlaceType;
 import org.sopt.makers.crew.main.entity.lightning.enums.LightningTimingType;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+import org.sopt.makers.crew.main.global.util.Time;
 import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyWithoutWelcomeMessageDto;
 
 @Mapper(componentModel = "spring")
 public interface LightningMapper {
 
 	@Mapping(source = "lightningBody.files", target = "imageURL", qualifiedByName = "getImageURL")
-	@Mapping(source = "lightningBody.activityStartDate", target = "activityStartDate", qualifiedByName = "getStartDate")
-	@Mapping(source = "lightningBody.activityEndDate", target = "activityEndDate", qualifiedByName = "getEndDate")
+	@Mapping(source = "lightningBody.activityStartDate", target = "activityStartDate", qualifiedByName = "getActivityStartDate")
+	@Mapping(source = "lightningBody.activityEndDate", target = "activityEndDate", qualifiedByName = "getActivityEndDate")
 	@Mapping(source = "lightningBody.lightningPlaceType", target = "lightningPlaceType", qualifiedByName = "getLightningPlaceType")
 	@Mapping(source = "lightningBody.lightningTimingType", target = "lightningTimingType", qualifiedByName = "getLightningTimingType")
+	@Mapping(target = "startDate", expression = "java(time.now())")
+	@Mapping(source = "lightningBody.activityStartDate", target = "endDate", qualifiedByName = "getActivityStartDate")
 	Lightning toLightningEntity(LightningV2CreateLightningBodyWithoutWelcomeMessageDto lightningBody,
-		Integer createdGeneration, Integer leaderUserId);
+		Integer createdGeneration, Integer leaderUserId, Time time);
 
 	@Named("getImageURL")
 	static List<ImageUrlVO> getImageURL(List<String> files) {
@@ -36,13 +39,13 @@ public interface LightningMapper {
 			.toList();
 	}
 
-	@Named("getStartDate")
-	static LocalDateTime getStartDate(String date) {
+	@Named("getActivityStartDate")
+	static LocalDateTime getActivityStartDate(String date) {
 		return LocalDateTime.parse(date + DAY_START_TIME, DateTimeFormatter.ofPattern(DAY_TIME_FORMAT));
 	}
 
-	@Named("getEndDate")
-	static LocalDateTime getEndDate(String date) {
+	@Named("getActivityEndDate")
+	static LocalDateTime getActivityEndDate(String date) {
 		return LocalDateTime.parse(date + DAY_END_TIME, DateTimeFormatter.ofPattern(DAY_TIME_FORMAT));
 
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyWithoutWelcomeMessageDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyWithoutWelcomeMessageDto.java
@@ -34,7 +34,6 @@ public record LightningV2CreateLightningBodyWithoutWelcomeMessageDto(
 	String lightningPlaceType,
 
 	@Schema(example = "잠실역 5번 출구", description = "모임 장소")
-	@NotNull
 	String lightningPlace,
 
 	@Schema(example = "1", description = "최소 모집 인원")

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyWithoutWelcomeMessageDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyWithoutWelcomeMessageDto.java
@@ -17,7 +17,7 @@ public record LightningV2CreateLightningBodyWithoutWelcomeMessageDto(
 	@NotNull
 	String desc,
 
-	@Schema(example = "협의 후 결정", description = "번쩍 일정 결정 방식")
+	@Schema(example = "예정 기간(협의 후 결정)", description = "번쩍 일정 결정 방식")
 	@NotNull
 	String lightningTimingType,
 

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyWithoutWelcomeMessageDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyWithoutWelcomeMessageDto.java
@@ -3,7 +3,6 @@ package org.sopt.makers.crew.main.lightning.v2.dto.request;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -51,7 +50,7 @@ public record LightningV2CreateLightningBodyWithoutWelcomeMessageDto(
 	@Schema(example = "[\n"
 		+ "    \"https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2023/04/12/7bd87736-b557-4b26-a0d5-9b09f1f1d7df\"\n"
 		+ "  ]", description = "모임 이미지 리스트, 최대 1개")
-	@NotEmpty
+	@NotNull
 	@Size(max = 1)
 	List<String> files
 ) {

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/service/LightningV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/service/LightningV2ServiceImpl.java
@@ -7,6 +7,7 @@ import org.sopt.makers.crew.main.entity.lightning.Lightning;
 import org.sopt.makers.crew.main.entity.lightning.LightningRepository;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.global.exception.BadRequestException;
+import org.sopt.makers.crew.main.global.util.Time;
 import org.sopt.makers.crew.main.lightning.v2.dto.mapper.LightningMapper;
 import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyDto;
 import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2CreateLightningResponseDto;
@@ -30,6 +31,8 @@ public class LightningV2ServiceImpl implements LightningV2Service {
 	private final LightningRepository lightningRepository;
 	private final LightningMapper lightningMapper;
 
+	private final Time realTime;
+
 	@Override
 	@Transactional
 	public LightningV2CreateLightningResponseDto createLightning(
@@ -45,7 +48,7 @@ public class LightningV2ServiceImpl implements LightningV2Service {
 		}
 
 		Lightning lightning = lightningMapper.toLightningEntity(requestBody.lightningBody(), ACTIVE_GENERATION,
-			user.getId());
+			user.getId(), realTime);
 
 		lightningRepository.save(lightning);
 		tagV2Service.createLightningTag(requestBody.welcomeMessageTypes(), lightning.getId());


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 번쩍 엔티티에 startDate, endDate 필드를 추가하였습니다.
- 기획 변경에 대해서 싱크 맞추는 작업을 하였습니다. (LightningTimingType에서 기간 삭제)

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 본래 번쩍 상세 조회 GET API를 작업하다가, 기획이 변경이 되어 FE 분들을 위해 중간 PR을 날리게 되었습니다.
- 따라서 번쩍 상세 조회는 새롭게 이슈를 파서 작업하겠습니다!

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #533 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?