### PR TITLE
refactor: ExceptionHandler 예외 메시지 구체화 및 번쩍 관련 로직 수정

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/global/advice/ControllerExceptionAdvice.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/advice/ControllerExceptionAdvice.java
@@ -38,17 +38,17 @@ public class ControllerExceptionAdvice {
 
 	@ExceptionHandler(MissingServletRequestParameterException.class)
 	public ResponseEntity<ExceptionResponse> handleMissingParameter(MissingServletRequestParameterException e) {
-		log.warn("누락된 파라미터: {}", e.getMessage());
+		log.warn("누락된 요청 파라미터: {}", e.getMessage());
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(ExceptionResponse.fail(
 				ErrorStatus.MISSING_REQUEST_PARAMETER.getErrorCode(),
-				String.format("누락된 파라미터: %s", e.getParameterName())));
+				String.format("누락된 요청 파라미터: %s", e.getParameterName())));
 	}
 
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<ExceptionResponse> handleIllegalArgument(IllegalArgumentException e) {
-		log.warn("잘못된 인자: {}", e.getMessage());
-		String errorDetails = String.format("예외 발생 위치: %s.%s - 인자: %s",
+		log.warn("잘못된 입력 값: {}", e.getMessage());
+		String errorDetails = String.format("예외 발생 위치: %s.%s - 입력 값: %s",
 			e.getStackTrace()[0].getClassName(),
 			e.getStackTrace()[0].getMethodName(),
 			e.getMessage());
@@ -60,7 +60,7 @@ public class ControllerExceptionAdvice {
 
 	@ExceptionHandler(ConstraintViolationException.class)
 	public ResponseEntity<ExceptionResponse> handleConstraintViolationException(ConstraintViolationException e) {
-		log.warn("제약 조건 위반: {}", e.getMessage());
+		log.warn("제약 조건 위반 발생: {}", e.getMessage());
 
 		StringBuilder violationMessages = new StringBuilder();
 		for (ConstraintViolation<?> violation : e.getConstraintViolations()) {
@@ -85,7 +85,7 @@ public class ControllerExceptionAdvice {
 
 	@ExceptionHandler(HttpMessageNotReadableException.class)
 	public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
-		log.warn("읽을 수 없는 메시지: {}", e.getMessage());
+		log.warn("읽을 수 없는 요청 메시지: {}", e.getMessage());
 		String errorDetails = String.format("잘못된 JSON 요청: %s", e.getMessage());
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(ExceptionResponse.fail(
@@ -95,7 +95,7 @@ public class ControllerExceptionAdvice {
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-		log.warn("메서드 인자 유효성 검사 실패: {}", e.getMessage());
+		log.warn("메서드 인자 검증 실패: {}", e.getMessage());
 		StringBuilder errorDetails = new StringBuilder("유효성 검증 실패: ");
 		e.getBindingResult().getFieldErrors().forEach(fieldError ->
 			errorDetails.append(
@@ -129,12 +129,12 @@ public class ControllerExceptionAdvice {
 
 	@ExceptionHandler(IOException.class)
 	public ResponseEntity<ExceptionResponse> handleIOException(IOException e) {
-		log.warn("입출력 예외: {}", e.getMessage());
+		log.warn("입출력 오류: {}", e.getMessage());
 		String errorMessage = (e.getCause() != null) ? e.getCause().getMessage() : e.getMessage();
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(ExceptionResponse.fail(
 				ErrorStatus.IO_EXCEPTION.getErrorCode(),
-				String.format("입출력 예외 발생: %s", errorMessage)));
+				String.format("입출력 오류 발생: %s", errorMessage)));
 	}
 
 	/**

--- a/main/src/main/java/org/sopt/makers/crew/main/global/advice/ControllerExceptionAdvice.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/advice/ControllerExceptionAdvice.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 
@@ -24,105 +25,142 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ControllerExceptionAdvice {
 
+	/**
+	 * 400 Bad Request
+	 * 클라이언트에서 잘못된 요청을 보냈을 때 처리하는 예외들
+	 */
 	@ExceptionHandler(BaseException.class)
-	public ResponseEntity<ExceptionResponse> handleGlobalException(BaseException e) {
-		log.warn("{}", e.getMessage());
+	public ResponseEntity<ExceptionResponse> handleBaseException(BaseException e) {
+		log.warn("기본 예외 발생: {}", e.getMessage());
 		return ResponseEntity.status(e.getStatusCode())
 			.body(ExceptionResponse.fail(e.getErrorCode()));
 	}
 
 	@ExceptionHandler(MissingServletRequestParameterException.class)
-	public ResponseEntity<ExceptionResponse> handleMissingParameter(
-		MissingServletRequestParameterException e) {
-		log.warn("{}", e.getMessage());
+	public ResponseEntity<ExceptionResponse> handleMissingParameter(MissingServletRequestParameterException e) {
+		log.warn("누락된 파라미터: {}", e.getMessage());
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(ExceptionResponse.fail(
-				ErrorStatus.VALIDATION_REQUEST_MISSING_EXCEPTION.getErrorCode()));
+				ErrorStatus.MISSING_REQUEST_PARAMETER.getErrorCode(),
+				String.format("누락된 파라미터: %s", e.getParameterName())));
 	}
 
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<ExceptionResponse> handleIllegalArgument(IllegalArgumentException e) {
-		log.warn("{}", e.getMessage());
+		log.warn("잘못된 인자: {}", e.getMessage());
+		String errorDetails = String.format("예외 발생 위치: %s.%s - 인자: %s",
+			e.getStackTrace()[0].getClassName(),
+			e.getStackTrace()[0].getMethodName(),
+			e.getMessage());
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(ExceptionResponse.fail(
-				ErrorStatus.INVALID_INPUT_VALUE.getErrorCode()));
+				ErrorStatus.INVALID_ARGUMENT.getErrorCode(),
+				errorDetails));
 	}
 
-	@ExceptionHandler(ConstraintViolationException.class)  // @Notnull 오류
+	@ExceptionHandler(ConstraintViolationException.class)
 	public ResponseEntity<ExceptionResponse> handleConstraintViolationException(ConstraintViolationException e) {
-		log.warn("{}", e.getMessage());
+		log.warn("제약 조건 위반: {}", e.getMessage());
+
+		StringBuilder violationMessages = new StringBuilder();
+		for (ConstraintViolation<?> violation : e.getConstraintViolations()) {
+			violationMessages.append(String.format("필드: %s, 메시지: %s; ",
+				violation.getPropertyPath(), violation.getMessage()));
+		}
+
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(ExceptionResponse.fail(
-				ErrorStatus.INVALID_INPUT_VALUE.getErrorCode()));
+				ErrorStatus.CONSTRAINT_VIOLATION.getErrorCode(),
+				violationMessages.toString()));
 	}
 
-	@ExceptionHandler(DataIntegrityViolationException.class)  // null value 오류
+	@ExceptionHandler(DataIntegrityViolationException.class)
 	public ResponseEntity<ExceptionResponse> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
-		log.warn("{}", e.getMessage());
+		log.warn("데이터 무결성 위반: {}", e.getMessage());
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(ExceptionResponse.fail(
-				ErrorStatus.INVALID_INPUT_VALUE.getErrorCode()));
+				ErrorStatus.DATA_INTEGRITY_VIOLATION.getErrorCode(),
+				e.getMostSpecificCause().getMessage()));
 	}
 
-	@ExceptionHandler(HttpMessageNotReadableException.class)  // null value 오류
+	@ExceptionHandler(HttpMessageNotReadableException.class)
 	public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
-		log.warn("{}", e.getMessage());
+		log.warn("읽을 수 없는 메시지: {}", e.getMessage());
+		String errorDetails = String.format("잘못된 JSON 요청: %s", e.getMessage());
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(ExceptionResponse.fail(
-				ErrorStatus.INVALID_INPUT_VALUE.getErrorCode()));
+				ErrorStatus.MESSAGE_NOT_READABLE.getErrorCode(),
+				errorDetails));
 	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-		log.warn("{}", e.getMessage());
+		log.warn("메서드 인자 유효성 검사 실패: {}", e.getMessage());
+		StringBuilder errorDetails = new StringBuilder("유효성 검증 실패: ");
+		e.getBindingResult().getFieldErrors().forEach(fieldError ->
+			errorDetails.append(
+				String.format("필드: '%s', 오류: '%s' ", fieldError.getField(), fieldError.getDefaultMessage())
+			)
+		);
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(ExceptionResponse.fail(
-				ErrorStatus.INVALID_INPUT_VALUE.getErrorCode()));
+				ErrorStatus.METHOD_ARGUMENT_NOT_VALID.getErrorCode(),
+				errorDetails.toString()));
 	}
 
-	/**
-	 * path variable errors
-	 */
 	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
 	public ResponseEntity<ExceptionResponse> handleMethodArgumentTypeMismatchException(
 		MethodArgumentTypeMismatchException e) {
-		log.warn("{}", e.getMessage());
+		log.warn("인자 타입 불일치: {}", e.getMessage());
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(ExceptionResponse.fail(
-				ErrorStatus.INVALID_INPUT_VALUE.getErrorCode()));
+				ErrorStatus.ARGUMENT_TYPE_MISMATCH.getErrorCode(),
+				String.format("인자 타입 불일치: '%s', 잘못된 값: '%s'", e.getName(), e.getValue())));
 	}
 
 	@ExceptionHandler(MissingPathVariableException.class)
-	public ResponseEntity<ExceptionResponse> handleMissingPathVariableException(
-		MissingPathVariableException e) {
-		log.warn("{}", e.getMessage());
+	public ResponseEntity<ExceptionResponse> handleMissingPathVariableException(MissingPathVariableException e) {
+		log.warn("누락된 경로 변수: {}", e.getVariableName());
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(ExceptionResponse.fail(
-				ErrorStatus.INVALID_INPUT_VALUE.getErrorCode()));
-	}
-
-	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-	public ResponseEntity<ExceptionResponse> handleHttpRequestMethodNotSupportedException(
-		HttpRequestMethodNotSupportedException e) {
-		log.warn("{}", e.getMessage());
-		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-			.body(ExceptionResponse.fail(
-				ErrorStatus.INVALID_INPUT_VALUE.getErrorCode()));
+				ErrorStatus.MISSING_PATH_VARIABLE.getErrorCode(),
+				String.format("누락된 경로 변수: %s", e.getVariableName())));
 	}
 
 	@ExceptionHandler(IOException.class)
 	public ResponseEntity<ExceptionResponse> handleIOException(IOException e) {
-		log.warn("{}", e.getMessage());
+		log.warn("입출력 예외: {}", e.getMessage());
+		String errorMessage = (e.getCause() != null) ? e.getCause().getMessage() : e.getMessage();
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(ExceptionResponse.fail(
-				ErrorStatus.IO_EXCEPTION.getErrorCode()));
+				ErrorStatus.IO_EXCEPTION.getErrorCode(),
+				String.format("입출력 예외 발생: %s", errorMessage)));
 	}
 
+	/**
+	 * 405 Method Not Allowed
+	 * 지원되지 않는 HTTP 메서드 처리
+	 */
+	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+	public ResponseEntity<ExceptionResponse> handleHttpRequestMethodNotSupportedException(
+		HttpRequestMethodNotSupportedException e) {
+		log.warn("지원되지 않는 요청 메서드: {}", e.getMessage());
+		return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
+			.body(ExceptionResponse.fail(
+				ErrorStatus.METHOD_NOT_SUPPORTED.getErrorCode(),
+				String.format("지원되지 않는 메서드: %s", e.getMethod())));
+	}
+
+	/**
+	 * 500 Internal Server Error
+	 * 예상치 못한 예외 처리
+	 */
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ExceptionResponse> handleException(Exception e) {
-		log.error("", e);
+		log.error("예기치 않은 예외 발생: ", e);
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(ExceptionResponse.fail(
-				ErrorStatus.INTERNAL_SERVER_ERROR.getErrorCode()));
+				ErrorStatus.INTERNAL_SERVER_ERROR.getErrorCode(),
+				"예기치 않은 오류가 발생했습니다."));
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/global/exception/BaseException.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/exception/BaseException.java
@@ -1,29 +1,30 @@
 package org.sopt.makers.crew.main.global.exception;
 
+import org.springframework.http.HttpStatus;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class BaseException extends RuntimeException {
 
-    HttpStatus httpStatus;
-    String errorCode;
+	private HttpStatus httpStatus;
+	private String errorCode;
 
-    public BaseException(HttpStatus httpStatus) {
-        super();
-        this.httpStatus = httpStatus;
-    }
+	public BaseException(HttpStatus httpStatus) {
+		super();
+		this.httpStatus = httpStatus;
+	}
 
-    public BaseException(HttpStatus httpStatus, String errorCode) {
-        super(errorCode);
-        this.httpStatus = httpStatus;
-        this.errorCode = errorCode;
-    }
+	public BaseException(HttpStatus httpStatus, String errorCode) {
+		super(errorCode);
+		this.httpStatus = httpStatus;
+		this.errorCode = errorCode;
+	}
 
-    public int getStatusCode() {
-        return this.httpStatus.value();
-    }
+	public int getStatusCode() {
+		return this.httpStatus.value();
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
@@ -13,11 +13,10 @@ public enum ErrorStatus {
 	NO_CONTENT_EXCEPTION("참여한 모임이 없습니다."),
 
 	/**
-	 * 400 BAD_REQUEST
+	 * 400 BAD_REQUEST - 비즈니스 로직 관련 에러
 	 */
 	VALIDATION_EXCEPTION("CF-001"),
 	VALIDATION_REQUEST_MISSING_EXCEPTION("요청값이 입력되지 않았습니다."),
-	INVALID_INPUT_VALUE("요청값이 올바르지 않습니다. : "),
 	INVALID_INPUT_VALUE_FILTER("요청값 또는 토큰이 올바르지 않습니다."),
 	NOT_FOUND_MEETING("모임이 없습니다."),
 	NOT_FOUND_POST("존재하지 않는 게시글입니다."),
@@ -41,6 +40,19 @@ public enum ErrorStatus {
 	IO_EXCEPTION("파일 입출력 오류가 발생했습니다."),
 
 	/**
+	 * 400 BAD_REQUEST - 유효성 검사 관련 에러
+	 */
+	MISSING_REQUEST_PARAMETER("필수 요청 파라미터가 누락되었습니다."),
+	METHOD_ARGUMENT_NOT_VALID("메서드 인자 유효성 검사가 실패했습니다."),
+	ARGUMENT_TYPE_MISMATCH("인자 타입이 일치하지 않습니다."),
+	MISSING_PATH_VARIABLE("필수 경로 변수가 누락되었습니다."),
+	INVALID_ARGUMENT("잘못된 인자입니다."),
+	CONSTRAINT_VIOLATION("제약 조건을 위반했습니다."),
+	DATA_INTEGRITY_VIOLATION("데이터 무결성이 위반되었습니다."),
+	MESSAGE_NOT_READABLE("읽을 수 없는 메시지 형식입니다."),
+	INVALID_INPUT_VALUE("요청값이 올바르지 않습니다. : "),
+
+	/**
 	 * 401 UNAUTHORIZED
 	 */
 	UNAUTHORIZED_TOKEN("유효하지 않은 토큰입니다."),
@@ -50,6 +62,11 @@ public enum ErrorStatus {
 	 * 403 FORBIDDEN
 	 */
 	FORBIDDEN_EXCEPTION("권한이 없습니다."),
+
+	/**
+	 * 405 METHOD_NOT_ALLOWED
+	 */
+	METHOD_NOT_SUPPORTED("지원되지 않는 HTTP 메서드입니다."),
 
 	/**
 	 * 500 SERVER_ERROR

--- a/main/src/main/java/org/sopt/makers/crew/main/global/exception/ExceptionResponse.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/exception/ExceptionResponse.java
@@ -1,6 +1,7 @@
 package org.sopt.makers.crew.main.global.exception;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,11 +10,19 @@ import lombok.Getter;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ExceptionResponse {
 
-  private final String errorCode;
+	private final String errorCode;
+	private final String message;
 
-  public static ExceptionResponse fail(String errorCode) {
-    return ExceptionResponse.builder()
-        .errorCode(errorCode)
-        .build();
-  }
+	public static ExceptionResponse fail(String errorCode) {
+		return ExceptionResponse.builder()
+			.errorCode(errorCode)
+			.build();
+	}
+
+	public static ExceptionResponse fail(String errorCode, String message) {
+		return ExceptionResponse.builder()
+			.errorCode(errorCode)
+			.message(message)
+			.build();
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyDto.java
@@ -3,12 +3,14 @@ package org.sopt.makers.crew.main.lightning.v2.dto.request;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 @Schema(name = "LightningV2CreateLightningBodyDto", description = "번쩍 모임 생성 및 수정 request body dto")
 public record LightningV2CreateLightningBodyDto(
 	@Schema(description = "번쩍 모임 생성 및 수정 request body")
 	@NotNull
+	@Valid
 	LightningV2CreateLightningBodyWithoutWelcomeMessageDto lightningBody,
 
 	@Schema(example = "[\"YB 환영\", \"OB 환영\"]", description = "환영 메시지 타입 리스트")

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyWithoutWelcomeMessageDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/request/LightningV2CreateLightningBodyWithoutWelcomeMessageDto.java
@@ -3,6 +3,8 @@ package org.sopt.makers.crew.main.lightning.v2.dto.request;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -37,12 +39,13 @@ public record LightningV2CreateLightningBodyWithoutWelcomeMessageDto(
 	String lightningPlace,
 
 	@Schema(example = "1", description = "최소 모집 인원")
-	@Size(min = 1)
+	@Min(1)
 	@NotNull
 	Integer minimumCapacity,
 
 	@Schema(example = "5", description = "최대 모집 인원")
-	@Size(max = 999)
+	@Min(1)
+	@Max(999)
 	@NotNull
 	Integer maximumCapacity,
 


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- ExceptionHandler 예외 메시지를 구체화하였습니다.
- Valid 어노테이션과 관련해서 번쩍 관련 로직을 수정했습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

![image](https://github.com/user-attachments/assets/6767b131-3884-4e13-a169-430a3d7fab34)
![image](https://github.com/user-attachments/assets/3b3205f5-d762-4be2-b52d-94156e4a006c)

- 예외 메시지를 구체화 처리함으로서 클라이언트 측에서 예외 대응을 빠르게 할 수 있도록 하였습니다.

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #536 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?