### PR TITLE
refactor: 번쩍 모임 생성 시 모임 정보를 먼저 저장하도록 변경 완료

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
@@ -40,6 +40,10 @@ public class Lightning extends BaseTimeEntity {
 	private Integer leaderUserId;
 
 	@NotNull
+	@Column(name = "meetingId")
+	private Integer meetingId;
+
+	@NotNull
 	@Size(min = 1, max = 30)
 	@Column(name = "title")
 	private String title;
@@ -93,12 +97,14 @@ public class Lightning extends BaseTimeEntity {
 	private List<ImageUrlVO> imageURL;
 
 	@Builder
-	public Lightning(Integer leaderUserId, String title, String desc, LightningTimingType lightningTimingType,
+	public Lightning(Integer leaderUserId, Integer meetingId, String title, String desc,
+		LightningTimingType lightningTimingType,
 		LocalDateTime startDate, LocalDateTime endDate,
 		LocalDateTime activityStartDate, LocalDateTime activityEndDate, LightningPlaceType lightningPlaceType,
 		String lightningPlace, int minimumCapacity, int maximumCapacity, Integer createdGeneration,
 		List<ImageUrlVO> imageURL) {
 		this.leaderUserId = leaderUserId;
+		this.meetingId = meetingId;
 		this.title = title;
 		this.desc = desc;
 		this.lightningTimingType = lightningTimingType;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -195,6 +195,35 @@ public class Meeting extends BaseTimeEntity {
 		this.joinableParts = joinableParts;
 	}
 
+	public static Meeting createLightningMeeting(User user, Integer userId, String title,
+		List<ImageUrlVO> imageURL, LocalDateTime startDate,
+		LocalDateTime endDate, Integer capacity, String desc,
+		LocalDateTime mStartDate, LocalDateTime mEndDate,
+		int createdGeneration, String processDesc, String leaderDesc, String note) {
+
+		return Meeting.builder()
+			.user(user)
+			.userId(userId)
+			.title(title)
+			.category(MeetingCategory.LIGHTNING)
+			.imageURL(imageURL)
+			.startDate(startDate)
+			.endDate(endDate)
+			.capacity(capacity)
+			.desc(desc)
+			.mStartDate(mStartDate)
+			.mEndDate(mEndDate)
+			.createdGeneration(createdGeneration)
+			.processDesc(processDesc)
+			.leaderDesc(leaderDesc)
+			.note(note)
+			.isMentorNeeded(false)
+			.canJoinOnlyActiveGeneration(false)
+			.targetActiveGeneration(null)
+			.joinableParts(MeetingJoinablePart.values())
+			.build();
+	}
+
 	/**
 	 * 모임 모집상태 확인
 	 *

--- a/main/src/main/java/org/sopt/makers/crew/main/global/config/ImageSetting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/config/ImageSetting.java
@@ -1,0 +1,5 @@
+package org.sopt.makers.crew.main.global.config;
+
+public interface ImageSetting {
+	String getDefaultLightningImage();
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/global/config/ImageSettingConfig.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/config/ImageSettingConfig.java
@@ -1,0 +1,15 @@
+package org.sopt.makers.crew.main.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ImageSettingConfig implements ImageSetting {
+	@Value("${img.lightning}")
+	private String defaultLightningImage;
+
+	@Override
+	public String getDefaultLightningImage() {
+		return defaultLightningImage;
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
@@ -64,6 +64,10 @@ public enum ErrorStatus {
 	FORBIDDEN_EXCEPTION("권한이 없습니다."),
 
 	/**
+	 * 404 NOT_FOUND
+	 */
+	NOT_FOUND_LIGHTNING("번쩍 모임이 없습니다."),
+	/**
 	 * 405 METHOD_NOT_ALLOWED
 	 */
 	METHOD_NOT_SUPPORTED("지원되지 않는 HTTP 메서드입니다."),

--- a/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
@@ -18,10 +18,6 @@ public enum ErrorStatus {
 	VALIDATION_EXCEPTION("CF-001"),
 	VALIDATION_REQUEST_MISSING_EXCEPTION("요청값이 입력되지 않았습니다."),
 	INVALID_INPUT_VALUE_FILTER("요청값 또는 토큰이 올바르지 않습니다."),
-	NOT_FOUND_MEETING("모임이 없습니다."),
-	NOT_FOUND_POST("존재하지 않는 게시글입니다."),
-	NOT_FOUND_USER("존재하지 않는 유저입니다."),
-	NOT_FOUND_COMMENT("존재하지 않는 댓글입니다."),
 	FULL_MEETING_CAPACITY("정원이 꽉 찼습니다."),
 	ALREADY_APPLIED_MEETING("이미 지원한 모임입니다."),
 	ALREADY_REPORTED_COMMENT("이미 신고한 댓글입니다."),
@@ -66,7 +62,12 @@ public enum ErrorStatus {
 	/**
 	 * 404 NOT_FOUND
 	 */
-	NOT_FOUND_LIGHTNING("번쩍 모임이 없습니다."),
+	NOT_FOUND_MEETING("모임이 없습니다."), // 예외 처리 NotFound로 수정 필요
+	NOT_FOUND_POST("존재하지 않는 게시글입니다."), // 예외 처리 NotFound로 수정 필요
+	NOT_FOUND_USER("존재하지 않는 유저입니다."), // 예외 처리 NotFound로 수정 필요
+	NOT_FOUND_COMMENT("존재하지 않는 댓글입니다."), // 예외 처리 NotFound로 수정 필요
+	NOT_FOUND_LIGHTNING("번쩍 모임이 없습니다."), // 예외 처리 NotFound로 수정 필요
+
 	/**
 	 * 405 METHOD_NOT_ALLOWED
 	 */

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/mapper/LightningMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/mapper/LightningMapper.java
@@ -15,19 +15,19 @@ import org.sopt.makers.crew.main.entity.lightning.enums.LightningPlaceType;
 import org.sopt.makers.crew.main.entity.lightning.enums.LightningTimingType;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 import org.sopt.makers.crew.main.global.util.Time;
-import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyWithoutWelcomeMessageDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingForLightningResponseDto;
 
 @Mapper(componentModel = "spring")
 public interface LightningMapper {
-
-	@Mapping(source = "lightningBody.files", target = "imageURL", qualifiedByName = "getImageURL")
-	@Mapping(source = "lightningBody.activityStartDate", target = "activityStartDate", qualifiedByName = "getActivityStartDate")
-	@Mapping(source = "lightningBody.activityEndDate", target = "activityEndDate", qualifiedByName = "getActivityEndDate")
-	@Mapping(source = "lightningBody.lightningPlaceType", target = "lightningPlaceType", qualifiedByName = "getLightningPlaceType")
-	@Mapping(source = "lightningBody.lightningTimingType", target = "lightningTimingType", qualifiedByName = "getLightningTimingType")
+	@Mapping(source = "meetingV2CreateMeetingForLightningResponseDto.files", target = "imageURL", qualifiedByName = "getImageURL")
 	@Mapping(target = "startDate", expression = "java(time.now())")
-	@Mapping(source = "lightningBody.activityStartDate", target = "endDate", qualifiedByName = "getActivityStartDate")
-	Lightning toLightningEntity(LightningV2CreateLightningBodyWithoutWelcomeMessageDto lightningBody,
+	@Mapping(source = "meetingV2CreateMeetingForLightningResponseDto.activityStartDate", target = "endDate", qualifiedByName = "getActivityStartDate")
+	@Mapping(source = "meetingV2CreateMeetingForLightningResponseDto.activityStartDate", target = "activityStartDate", qualifiedByName = "getActivityStartDate")
+	@Mapping(source = "meetingV2CreateMeetingForLightningResponseDto.activityEndDate", target = "activityEndDate", qualifiedByName = "getActivityEndDate")
+	@Mapping(source = "meetingV2CreateMeetingForLightningResponseDto.lightningPlaceType", target = "lightningPlaceType", qualifiedByName = "getLightningPlaceType")
+	@Mapping(source = "meetingV2CreateMeetingForLightningResponseDto.lightningTimingType", target = "lightningTimingType", qualifiedByName = "getLightningTimingType")
+	Lightning toLightningEntity(
+		MeetingV2CreateMeetingForLightningResponseDto meetingV2CreateMeetingForLightningResponseDto,
 		Integer createdGeneration, Integer leaderUserId, Time time);
 
 	@Named("getImageURL")
@@ -47,7 +47,6 @@ public interface LightningMapper {
 	@Named("getActivityEndDate")
 	static LocalDateTime getActivityEndDate(String date) {
 		return LocalDateTime.parse(date + DAY_END_TIME, DateTimeFormatter.ofPattern(DAY_TIME_FORMAT));
-
 	}
 
 	@Named("getLightningPlaceType")

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/mapper/LightningMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/mapper/LightningMapper.java
@@ -5,7 +5,7 @@ import static org.sopt.makers.crew.main.global.constant.CrewConst.*;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -32,10 +32,8 @@ public interface LightningMapper {
 
 	@Named("getImageURL")
 	static List<ImageUrlVO> getImageURL(List<String> files) {
-		AtomicInteger index = new AtomicInteger(0);
-
-		return files.stream()
-			.map(fileUrl -> new ImageUrlVO(index.getAndIncrement(), fileUrl))
+		return IntStream.range(0, files.size())
+			.mapToObj(index -> new ImageUrlVO(index, files.get(index)))
 			.toList();
 	}
 

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/service/LightningV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/service/LightningV2ServiceImpl.java
@@ -11,6 +11,8 @@ import org.sopt.makers.crew.main.global.util.Time;
 import org.sopt.makers.crew.main.lightning.v2.dto.mapper.LightningMapper;
 import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyDto;
 import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2CreateLightningResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingForLightningResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.service.MeetingV2Service;
 import org.sopt.makers.crew.main.tag.v2.service.TagV2Service;
 import org.sopt.makers.crew.main.user.v2.service.UserV2Service;
 import org.springframework.stereotype.Service;
@@ -27,6 +29,7 @@ public class LightningV2ServiceImpl implements LightningV2Service {
 
 	private final UserV2Service userV2Service;
 	private final TagV2Service tagV2Service;
+	private final MeetingV2Service meetingV2Service;
 
 	private final LightningRepository lightningRepository;
 	private final LightningMapper lightningMapper;
@@ -47,12 +50,50 @@ public class LightningV2ServiceImpl implements LightningV2Service {
 			throw new BadRequestException(VALIDATION_EXCEPTION.getErrorCode());
 		}
 
-		Lightning lightning = lightningMapper.toLightningEntity(requestBody.lightningBody(), ACTIVE_GENERATION,
-			user.getId(), realTime);
+		MeetingV2CreateMeetingForLightningResponseDto meetingV2CreateMeetingForLightningResponseDto = meetingV2Service.createMeetingForLightning(
+			userId, requestBody.lightningBody());
+
+		Lightning lightning = lightningMapper.toLightningEntity(meetingV2CreateMeetingForLightningResponseDto,
+			ACTIVE_GENERATION, user.getId(), realTime);
 
 		lightningRepository.save(lightning);
 		tagV2Service.createLightningTag(requestBody.welcomeMessageTypes(), lightning.getId());
 
 		return LightningV2CreateLightningResponseDto.from(lightning.getId());
 	}
+
+	// @Override
+	// public LightningV2GetLightningByIdResponseDto getLightningById(Integer lightningId, Integer userId) {
+	// 	User user = userV2Service.getUserByUserId(userId);
+	//
+	// 	Lightning lightning = lightningRepository.findById(lightningId)
+	// 		.orElseThrow(() -> new NotFoundException(NOT_FOUND_LIGHTNING.getErrorCode()));
+	//
+	// 	lightning.
+	//
+	// 		Meeting meeting = meetingReader.getMeetingById(meetingId).toEntity();
+	// 	MeetingCreatorDto meetingLeader = userReader.getMeetingLeader(meeting.getUserId());
+	// 	CoLeaders coLeaders = coLeaderReader.getCoLeaders(meetingId).toEntity();
+	//
+	// 	Applies applies = new Applies(
+	// 		applyRepository.findAllByMeetingIdWithUser(meetingId, List.of(WAITING, APPROVE, REJECT), ORDER_ASC));
+	//
+	// 	Boolean isHost = meeting.checkMeetingLeader(user.getId());
+	// 	Boolean isApply = applies.isApply(meetingId, user.getId());
+	// 	Boolean isApproved = applies.isApproved(meetingId, user.getId());
+	// 	boolean isCoLeader = coLeaders.isCoLeader(meetingId, userId);
+	// 	long approvedCount = applies.getApprovedCount(meetingId);
+	//
+	// 	List<ApplyWholeInfoDto> applyWholeInfoDtos = new ArrayList<>();
+	// 	if (applies.hasApplies(meetingId)) {
+	// 		applyWholeInfoDtos = applies.getAppliesMap().get(meetingId).stream()
+	// 			.map(apply -> ApplyWholeInfoDto.of(apply, apply.getUser(), userId))
+	// 			.toList();
+	// 	}
+	//
+	// 	return LightningV2GetLightningByIdResponseDto.of(meetingId, meeting, coLeaders.getCoLeaders(meetingId),
+	// 		isCoLeader,
+	// 		approvedCount, isHost, isApply, isApproved,
+	// 		meetingLeader, applyWholeInfoDtos, realTime.now());
+	// }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2CreateMeetingForLightningResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2CreateMeetingForLightningResponseDto.java
@@ -1,0 +1,81 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyWithoutWelcomeMessageDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(name = "MeetingV2CreateMeetingForLightningResponseDto", description = "번쩍 모임 생성 및 수정 request body dto")
+public record MeetingV2CreateMeetingForLightningResponseDto(
+	@Schema(description = "모임 id", example = "1")
+	@NotNull
+	Integer meetingId,
+
+	@Schema(example = "알고보면 쓸데있는 개발 프로세스", description = "번쩍 모임 제목")
+	@Size(min = 1, max = 30)
+	@NotNull String title,
+
+	@Schema(example = "api 가 터졌다고? 깃이 터졌다고?", description = "번쩍 소개")
+	@Size(min = 1, max = 500)
+	@NotNull
+	String desc,
+
+	@Schema(example = "예정 기간(협의 후 결정)", description = "번쩍 일정 결정 방식")
+	@NotNull
+	String lightningTimingType,
+
+	@Schema(example = "2025.10.29", description = "번쩍 활동 시작 날짜", name = "activityStartDate")
+	@NotNull
+	String activityStartDate,
+
+	@Schema(example = "2025.10.30", description = "번쩍 활동 종료 날짜", name = "activityEndDate")
+	@NotNull
+	String activityEndDate,
+
+	@Schema(example = "오프라인", description = "모임 장소 Tag")
+	@NotNull
+	String lightningPlaceType,
+
+	@Schema(example = "잠실역 5번 출구", description = "모임 장소")
+	String lightningPlace,
+
+	@Schema(example = "1", description = "최소 모집 인원")
+	@Min(1)
+	@NotNull
+	Integer minimumCapacity,
+
+	@Schema(example = "5", description = "최대 모집 인원")
+	@Min(1)
+	@Max(999)
+	@NotNull
+	Integer maximumCapacity,
+
+	@Schema(example = "[\n"
+		+ "    \"https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2023/04/12/7bd87736-b557-4b26-a0d5-9b09f1f1d7df\"\n"
+		+ "  ]", description = "모임 이미지 리스트, 최대 1개")
+	@NotNull
+	@Size(max = 1)
+	List<String> files
+) {
+	public static MeetingV2CreateMeetingForLightningResponseDto of(
+		Integer meetingId, LightningV2CreateLightningBodyWithoutWelcomeMessageDto lightningBody) {
+		return new MeetingV2CreateMeetingForLightningResponseDto(
+			meetingId,
+			lightningBody.title(),
+			lightningBody.desc(),
+			lightningBody.lightningTimingType(),
+			lightningBody.activityStartDate(),
+			lightningBody.activityEndDate(),
+			lightningBody.lightningPlaceType(),
+			lightningBody.lightningPlace(),
+			lightningBody.minimumCapacity(),
+			lightningBody.maximumCapacity(),
+			lightningBody.files()
+		);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -2,6 +2,7 @@ package org.sopt.makers.crew.main.meeting.v2.service;
 
 import java.util.List;
 
+import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyWithoutWelcomeMessageDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOrgUserQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
@@ -11,6 +12,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBo
 import org.sopt.makers.crew.main.meeting.v2.dto.response.AppliesCsvFileUrlResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingForLightningResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingByOrgUserDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingDto;
@@ -50,4 +52,7 @@ public interface MeetingV2Service {
 	MeetingV2GetMeetingByIdResponseDto getMeetingById(Integer meetingId, Integer userId);
 
 	MeetingV2GetRecommendDto getRecommendMeetingsByIds(List<Integer> meetingIds, Integer userId);
+
+	MeetingV2CreateMeetingForLightningResponseDto createMeetingForLightning(Integer userId,
+		LightningV2CreateLightningBodyWithoutWelcomeMessageDto lightningBody);
 }

--- a/main/src/main/resources/application-dev.yml
+++ b/main/src/main/resources/application-dev.yml
@@ -116,3 +116,6 @@ logging:
   sentry:
     repository-uri: ${SENTRY_REPOSITORY_URI}
     environment: dev
+
+img:
+  lightning: ${LIGHTNING_IMAGE}

--- a/main/src/main/resources/application-local.yml
+++ b/main/src/main/resources/application-local.yml
@@ -69,7 +69,7 @@ push-notification:
   push-server-url: ${LOCAL_PUSH_SERVER_URL}
 
 notice:
-  secret-key : ${NOTICE_SECRET_KEY}
+  secret-key: ${NOTICE_SECRET_KEY}
 
 playground:
   server:
@@ -116,3 +116,6 @@ logging:
   sentry:
     repository-uri: ${LOCAL_SENTRY_REPOSITORY_URI}
     environment: local
+
+img:
+  lightning: ${LIGHTNING_IMAGE}

--- a/main/src/main/resources/application-prod.yml
+++ b/main/src/main/resources/application-prod.yml
@@ -116,3 +116,6 @@ logging:
   sentry:
     repository-uri: ${SENTRY_REPOSITORY_URI}
     environment: prod
+
+img:
+  lightning: ${LIGHTNING_IMAGE}

--- a/main/src/main/resources/application-test.yml
+++ b/main/src/main/resources/application-test.yml
@@ -115,3 +115,6 @@ logging:
   sentry:
     repository-uri: ${SENTRY_REPOSITORY_URI}
     environment: test
+
+img:
+  lightning: ${LIGHTNING_IMAGE}


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->

### 번쩍 모임 개발에 대한 접근 방식 및 결정 사항

현재 번쩍 모임 개발을 진행하면서, 기존 API를 유지하면서 새로운 기능을 통합할 수 있는 방법을 고민했습니다. 여러 방안을 검토한 결과, 최적의 솔루션으로 Lightning 테이블에 meetingId를 두고, MeetingCategory가 번쩍일 경우 해당 정보를 Lightning 테이블에 저장하는 방식을 선택했습니다.

### 고려 사항 및 검토한 전략
1. Apply 테이블과 기존의 구조:
- Apply 테이블에서 meetingId가 외래키로 사용되기 때문에, 기존 구조를 대폭 변경하거나 새로운 번개 지원 API를 개발하는 것은 많은 리소스가 소요되며, 구조적으로 복잡해질 가능성이 큽니다.
2. 상속 테이블 전략 검토:
- SINGLE_TABLE 전략: Meeting과 Lightning 데이터를 같은 테이블에 저장하는 전략이지만, 필드에 null 값이 많아질 가능성이 높아 제외했습니다.
- JOINED 전략: 공통 필드는 Meeting 테이블에, 전용 필드는 Lightning 테이블에 저장하는 방식이지만, 공통 필드를 현재 정책과 로직에 맞게 재구성하는 데에 많은 부담과 위험이 따릅니다. 또한, 공통 필드를 둬도 정책적 차이로 인해 의미가 없다고 판단하여 제외했습니다.

### 최종 결정

이러한 이유로, Lightning 테이블에 meetingId를 두고, MeetingCategory가 번쩍일 경우 Lightning 테이블에 정보를 저장하는 방식이 최선이라고 판단했습니다. 이를 통해 새로운 API를 개발할 필요성을 최소화하고, 필요한 경우 번쩍 상세 조회와 번쩍 개설 정도의 API만 추가하면 될 것으로 예상됩니다.

### 장점
- 기존 API 구조를 대부분 유지할 수 있어 새로운 API 개발 필요가 거의 없습니다.
- 시스템의 기존 로직과 구조를 크게 변경하지 않고도 번쩍 모임 기능을 통합할 수 있습니다.

### 단점
- Meeting 테이블에 null 값이 많은 데이터를 포함하게 되며 이로 인해 NPE 발생 가능성이 높아집니다. (이를 방지 하기 위해 아래 리뷰 노트의 방법 도입)

### 필요 조치

기존 모임 개설과 모임 조회 로직에 대해 if(category != MeetingCategory.Lightning) 조건을 추가하여, 번쩍 모임에 대한 분기 처리를 구현할 계획입니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

### Meeting 엔티티의 NPE 방지대책 (정적 팩토리 메서드를 확인해주시면 될 것 같습니다!)
- 최대한 NPE 방지를 하기위해 번쩍 모임 생성 시 기존 모임 데이터에 필요하지 않은 값을 null로 넣는 대신 Boolean의 경우 false, String의 경우 빈문자열로 넣는 방식으로 구현해 보았습니다.
- 그리고 최대한 null이나 의미 없는 값을 넣는 것을 방지하기 위해 의미있는 값을 채워넣었습니다.
    - joinableParts의 경우 번쩍 모임은 제한이 없기 때문에 모든 파트의 enum값을 넣음
    - canJoinOnlyActiveGeneration, isMentorNeeded도 번쩍에는 필요하지 않기 때문에 false값을 넣음

### 서버에서 기본 번쩍 이미지 URL 주입
- 번쩍 개설 시 이미지 리스트가 empty인 경우, 기본 번쩍 이미지 URL을 환경변수로 주입해서 서버 측에서 넣어줄 수 있도록 구현했습니다.
- 클라이언트 측에 번쩍 개설 시 이미지 리스트가 empty인 경우 기본 이미지 URL을 보내줄 것을 요청했었으나, 서로 회의하면서 다음과 같은 이유로 서버측에서 기본 이미지 URL을 저장하는 방식으로 결정되었습니다.
    - 불필요한 이미지 url 통신을 할 필요가 없다. (사소한 이유)
    - 이미지 url이 변경되면, 클라이언트 측에서 url을 바꿔주는 것보다 인프라에 익숙한 서버 측에서 바꿔주는 것이 대응도 쉽고 빠르다 (결정적 이유)

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #534 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [x] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?