### PR TITLE
feat: 번쩍 상세 조회 GET API 구현 완료

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/Lightning.java
@@ -9,6 +9,7 @@ import org.sopt.makers.crew.main.entity.lightning.converter.LightningPlaceTypeCo
 import org.sopt.makers.crew.main.entity.lightning.converter.LightningTimingTypeConverter;
 import org.sopt.makers.crew.main.entity.lightning.enums.LightningPlaceType;
 import org.sopt.makers.crew.main.entity.lightning.enums.LightningTimingType;
+import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
@@ -119,4 +120,23 @@ public class Lightning extends BaseTimeEntity {
 		this.createdGeneration = createdGeneration;
 		this.imageURL = imageURL;
 	}
+
+	public boolean checkLightningMeetingLeader(Integer userId) {
+		return this.leaderUserId.equals(userId);
+	}
+
+	public int getLightningMeetingStatusValue(LocalDateTime now) {
+		return getLightningMeetingStatus(now).getValue();
+	}
+
+	public EnMeetingStatus getLightningMeetingStatus(LocalDateTime now) {
+		if (now.isBefore(startDate)) {
+			return EnMeetingStatus.BEFORE_START;
+		}
+		if (now.isBefore(endDate)) {
+			return EnMeetingStatus.APPLY_ABLE;
+		}
+		return EnMeetingStatus.RECRUITMENT_COMPLETE;
+	}
+
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/LightningRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/lightning/LightningRepository.java
@@ -1,6 +1,9 @@
 package org.sopt.makers.crew.main.entity.lightning;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LightningRepository extends JpaRepository<Lightning, Integer> {
+	Optional<Lightning> findByMeetingId(Integer meetingId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/tag/TagRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/tag/TagRepository.java
@@ -1,7 +1,13 @@
 package org.sopt.makers.crew.main.entity.tag;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TagRepository extends JpaRepository<Tag, Integer> {
+	@Query("SELECT t.welcomeMessageTypes FROM Tag t WHERE t.lightningId = :lightningId")
+	Optional<String> findWelcomeMessageTypesByLightningId(@Param("lightningId") Integer lightningId);
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
@@ -72,6 +72,7 @@ public enum ErrorStatus {
 	 * 405 METHOD_NOT_ALLOWED
 	 */
 	METHOD_NOT_SUPPORTED("지원되지 않는 HTTP 메서드입니다."),
+	TAG_NOT_FOUND_EXCEPTION("해당 태그를 찾을 수 없습니다."),
 
 	/**
 	 * 500 SERVER_ERROR

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Api.java
@@ -34,6 +34,6 @@ public interface LightningV2Api {
 		@ApiResponse(responseCode = "400", description = "번쩍 모임이 없습니다.", content = @Content),
 	})
 	ResponseEntity<LightningV2GetLightningByMeetingIdResponseDto> getLightningByMeetingId(
-		@PathVariable Integer lightningId,
+		@PathVariable Integer meetingId,
 		Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Api.java
@@ -4,7 +4,9 @@ import java.security.Principal;
 
 import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyDto;
 import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2CreateLightningResponseDto;
+import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2GetLightningByMeetingIdResponseDto;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,12 +28,12 @@ public interface LightningV2Api {
 		@Valid @RequestBody LightningV2CreateLightningBodyDto requestBody,
 		Principal principal);
 
-	// @Operation(summary = "번쩍 모임 상세 조회")
-	// @ApiResponses(value = {
-	// 	@ApiResponse(responseCode = "200", description = "번쩍 모임 상세 조회 성공"),
-	// 	@ApiResponse(responseCode = "400", description = "번쩍 모임이 없습니다.", content = @Content),
-	// })
-	// ResponseEntity<LightningV2GetLightningByIdResponseDto> getLightningById(
-	// 	@PathVariable Integer lightningId,
-	// 	Principal principal);
+	@Operation(summary = "번쩍 모임 상세 조회")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "번쩍 모임 상세 조회 성공"),
+		@ApiResponse(responseCode = "400", description = "번쩍 모임이 없습니다.", content = @Content),
+	})
+	ResponseEntity<LightningV2GetLightningByMeetingIdResponseDto> getLightningByMeetingId(
+		@PathVariable Integer lightningId,
+		Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/LightningV2Controller.java
@@ -5,9 +5,12 @@ import java.security.Principal;
 import org.sopt.makers.crew.main.global.util.UserUtil;
 import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyDto;
 import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2CreateLightningResponseDto;
+import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2GetLightningByMeetingIdResponseDto;
 import org.sopt.makers.crew.main.lightning.v2.service.LightningV2Service;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,14 +35,14 @@ public class LightningV2Controller implements LightningV2Api {
 		return ResponseEntity.status(HttpStatus.CREATED).body(lightningV2Service.createLightning(requestBody, userId));
 	}
 
-	// @Override
-	// @GetMapping("{lightningId}")
-	// public ResponseEntity<LightningV2GetLightningByIdResponseDto> getLightningById(
-	// 	@PathVariable Integer lightningId,
-	// 	Principal principal
-	// ) {
-	// 	Integer userId = UserUtil.getUserId(principal);
-	//
-	// 	return ResponseEntity.ok(lightningV2Service.getLightningById(lightningId, userId));
-	// }
+	@Override
+	@GetMapping("{meetingId}")
+	public ResponseEntity<LightningV2GetLightningByMeetingIdResponseDto> getLightningByMeetingId(
+		@PathVariable Integer meetingId,
+		Principal principal
+	) {
+		Integer userId = UserUtil.getUserId(principal);
+
+		return ResponseEntity.ok(lightningV2Service.getLightningByMeetingId(meetingId, userId));
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/response/LightningV2CreateLightningResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/response/LightningV2CreateLightningResponseDto.java
@@ -5,11 +5,11 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(name = "LightningV2CreateLightningResponseDto", description = "번쩍 모임 생성 응답 Dto")
 public record LightningV2CreateLightningResponseDto(
-	@Schema(description = "번쩍 모임 id", example = "1")
+	@Schema(description = "모임 id - 번쩍 카테고리", example = "1")
 	@NotNull
-	Integer lightningId
+	Integer meetingId
 ) {
-	public static LightningV2CreateLightningResponseDto from(Integer lightningId) {
-		return new LightningV2CreateLightningResponseDto(lightningId);
+	public static LightningV2CreateLightningResponseDto from(Integer meetingId) {
+		return new LightningV2CreateLightningResponseDto(meetingId);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/response/LightningV2GetLightningByMeetingIdResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/dto/response/LightningV2GetLightningByMeetingIdResponseDto.java
@@ -1,0 +1,163 @@
+package org.sopt.makers.crew.main.lightning.v2.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.sopt.makers.crew.main.entity.lightning.Lightning;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
+import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+import org.sopt.makers.crew.main.entity.tag.enums.WelcomeMessageType;
+import org.sopt.makers.crew.main.global.dto.MeetingCreatorDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyWholeInfoDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "번쩍 상세 조회 dto")
+public record LightningV2GetLightningByMeetingIdResponseDto(
+
+	@Schema(description = "모임 id", example = "2")
+	@NotNull
+	Integer id,
+
+	@Schema(description = "번쩍장 id", example = "184")
+	@NotNull
+	Integer leaderUserId,
+
+	@Schema(description = "번쩍 제목", example = "번쩍 제목입니다.")
+	@NotNull
+	@Size(min = 1, max = 30)
+	String title,
+
+	@Schema(description = "모임 카테고리(번쩍)", example = "번쩍")
+	@NotNull
+	String category,
+
+	@Schema(description = "번쩍 이미지", example = "[url 형식]")
+	@NotNull
+	List<ImageUrlVO> imageURL,
+
+	@Schema(description = "번쩍 신청 종료 시간", example = "2025-07-30T23:59:59")
+	@NotNull
+	LocalDateTime endDate,
+
+	@Schema(example = "1", description = "최소 모집 인원")
+	@Min(1)
+	@NotNull
+	Integer minimumCapacity,
+
+	@Schema(example = "5", description = "최대 모집 인원")
+	@Min(1)
+	@Max(999)
+	@NotNull
+	Integer maximumCapacity,
+
+	@Schema(description = "환영 메시지 타입 목록")
+	@NotNull
+	List<String> welcomeMessageTypes,
+
+	@Schema(description = "번쩍 소개", example = "번쩍 소개 입니다.")
+	@NotNull
+	String desc,
+
+	@Schema(description = "번쩍 활동 시작 시간", example = "2024-08-13T15:30:00", name = "activityStartDate")
+	@NotNull
+	LocalDateTime activityStartDate,
+
+	@Schema(description = "번쩍 활동 종료 시간", example = "2024-10-13T23:59:59", name = "activityEndDate")
+	@NotNull
+	LocalDateTime activityEndDate,
+
+	@Schema(description = "번쩍 일시 타입", example = "예정 기간(협의 후 결정)")
+	@NotNull
+	String timingType,
+
+	@Schema(description = "번쩍 장소 타입", example = "온라인")
+	@NotNull
+	String placeType,
+
+	@Schema(description = "번쩍 장소", example = "Zoom 링크")
+	@NotNull
+	String place,
+
+	@Schema(description = "개설 기수", example = "36")
+	@NotNull
+	Integer createdGeneration,
+
+	@Schema(description = "번쩍 상태, 0: 모집전, 1: 모집중, 2: 모집종료", example = "1", type = "integer", allowableValues = {"0",
+		"1", "2"})
+	@NotNull
+	int status,
+
+	@Schema(description = "승인된 신청 수", example = "7")
+	@NotNull
+	long approvedApplyCount,
+
+	@Schema(description = "번쩍 개설자 여부", example = "true")
+	@NotNull
+	boolean host,
+
+	@Schema(description = "번쩍 신청 여부", example = "false")
+	@NotNull
+	boolean apply,
+
+	@Schema(description = "번쩍 승인 여부", example = "false")
+	@NotNull
+	boolean approved,
+
+	@Schema(description = "번쩍장 객체", example = "")
+	@NotNull
+	MeetingCreatorDto user,
+
+	@Schema(description = "신청 목록", example = "")
+	@NotNull
+	List<ApplyWholeInfoDto> appliedInfo
+
+) {
+	public static LightningV2GetLightningByMeetingIdResponseDto of(
+		Integer meetingId,
+		Lightning lightning,
+		List<WelcomeMessageType> welcomeMessageTypes,
+		long approvedCount,
+		boolean isHost,
+		boolean isApply,
+		boolean isApproved,
+		MeetingCreatorDto meetingCreatorDto,
+		List<ApplyWholeInfoDto> appliedInfo,
+		LocalDateTime now
+	) {
+
+		int lightningMeetingStatus = lightning.getLightningMeetingStatusValue(now);
+		List<String> welcomeMessageTypeValues = welcomeMessageTypes.stream()
+			.map(WelcomeMessageType::getValue)
+			.toList();
+
+		return new LightningV2GetLightningByMeetingIdResponseDto(
+			meetingId,
+			lightning.getLeaderUserId(),
+			lightning.getTitle(),
+			MeetingCategory.LIGHTNING.getValue(),
+			lightning.getImageURL(),
+			lightning.getEndDate(),
+			lightning.getMinimumCapacity(),
+			lightning.getMaximumCapacity(),
+			welcomeMessageTypeValues,
+			lightning.getDesc(),
+			lightning.getActivityStartDate(),
+			lightning.getActivityEndDate(),
+			lightning.getLightningTimingType().getValue(),
+			lightning.getLightningPlaceType().getValue(),
+			lightning.getLightningPlace(),
+			lightning.getCreatedGeneration(),
+			lightningMeetingStatus,
+			approvedCount,
+			isHost,
+			isApply,
+			isApproved,
+			meetingCreatorDto,
+			appliedInfo);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/service/LightningV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/lightning/v2/service/LightningV2Service.java
@@ -2,8 +2,11 @@ package org.sopt.makers.crew.main.lightning.v2.service;
 
 import org.sopt.makers.crew.main.lightning.v2.dto.request.LightningV2CreateLightningBodyDto;
 import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2CreateLightningResponseDto;
+import org.sopt.makers.crew.main.lightning.v2.dto.response.LightningV2GetLightningByMeetingIdResponseDto;
 
 public interface LightningV2Service {
 	LightningV2CreateLightningResponseDto createLightning(
 		LightningV2CreateLightningBodyDto requestBody, Integer userId);
+
+	LightningV2GetLightningByMeetingIdResponseDto getLightningByMeetingId(Integer meetingId, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2Service.java
@@ -2,8 +2,11 @@ package org.sopt.makers.crew.main.tag.v2.service;
 
 import java.util.List;
 
+import org.sopt.makers.crew.main.entity.tag.enums.WelcomeMessageType;
 import org.sopt.makers.crew.main.tag.v2.dto.response.TagV2CreateTagResponseDto;
 
 public interface TagV2Service {
 	TagV2CreateTagResponseDto createLightningTag(List<String> welcomeMessageTypes, Integer lightningId);
+
+	List<WelcomeMessageType> getWelcomeMessageTypesByLightningId(Integer lightningId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2ServiceImpl.java
@@ -85,7 +85,7 @@ public class TagV2ServiceImpl implements TagV2Service {
 		try {
 			return WelcomeMessageType.valueOf(value);
 		} catch (IllegalArgumentException e) {
-			return null;  // Invalid value 처리 (null 반환 또는 기본 값 처리)
+			return null;
 		}
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2ServiceImpl.java
@@ -23,6 +23,8 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class TagV2ServiceImpl implements TagV2Service {
 
+	private static final String JSON_VALUE_SEPARATOR = ",";
+
 	private final TagRepository tagRepository;
 
 	// 여기에 createGeneralMeetingTag 메서드도 추가하면 될 것 같습니다 나중에! (추후 일반 모임에 태그 추가 시 작성)
@@ -76,7 +78,7 @@ public class TagV2ServiceImpl implements TagV2Service {
 	}
 
 	private List<String> splitAndTrimJsonValues(String jsonWelcomeMessageTypes) {
-		return Arrays.stream(jsonWelcomeMessageTypes.split(","))
+		return Arrays.stream(jsonWelcomeMessageTypes.split(JSON_VALUE_SEPARATOR))
 			.map(String::trim)
 			.toList();
 	}


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->

- 번쩍 상세 조회 GET API를 구현했습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

### 모임 id? 번쩍 id?
- 처음에 번쩍 상세 조회를 설계했었을 때, 번쩍 id로 조회할 수 있도록 하려고 했습니다.
- 그런데 프론트 분들에게 물어본 결과 전체 모임 리스트 조회 시에도 모임 id를 사용하고 있다고 했었고, 번쩍 id를 프론트에서 새롭게 관리해야 한다는 부담감이 있을 것이라고 판단했습니다.
- 따라서 프론트 분들은 meetingId만 알고 있고, 이를 조회 시 보내면 번쩍 엔티티에도 meetingId를 저장하기 때문에 이를 이용해서 번쩍 정보들을 조회하는 방식으로 구현하였습니다.
- 따라서 저번에 번쩍 개설 시 주던 lightningId도 meetingId를 주도록 변경하였습니다.

### userReader 객체를 통해 모임장 정보 조회 문의
```java
MeetingCreatorDto meetingLeader = userReader.getMeetingLeader(lightning.getLeaderUserId());
```
- 현재 LightningV2ServiceImpl에서도 모임장 정보를 조회하기 위해 해당 메서드를 사용하고 있습니다.
- 이번 번쩍 상세 조회에서도 레디스의 캐시를 사용하게 되었는데, 혹시 getMeetingLeader를 2개의 서비스 레이어에서 접근하는 것에는 문제가 없는지 여쭙고 싶습니다. (문제는 없을 것 같은데 혹시 몰라서 여쭈어봤습니다!)

### 응답 response
<img width="1131" alt="image" src="https://github.com/user-attachments/assets/9fe2586f-bc49-41e1-8073-11e6fe20d860" />
<img width="1128" alt="image" src="https://github.com/user-attachments/assets/5f4dea36-8a31-49b3-93b4-e3e75d9cf8c4" />

- 스웨거로 테스트한 response 입니다.

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #539 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?