### PR TITLE
refactor: 모집중, 모집전, 모집마감 순으로 모임조회 정렬 정책 변경

### DIFF
--- a/main/.gitignore
+++ b/main/.gitignore
@@ -40,3 +40,6 @@ out/
 application-secret.properties
 
 .DS_Store
+
+### Qclass
+src/main/generated/

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -322,7 +322,9 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		Pageable pageable = pageableStrategy.createPageable(queryCommand);
 
 		Page<Meeting> meetings = meetingRepository.findAllByQuery(queryCommand, pageable, time);
-		List<Integer> meetingIds = meetings.stream().map(Meeting::getId).toList();
+		List<Integer> meetingIds = meetings.stream()
+			.map(Meeting::getId)
+			.toList();
 
 		Applies allApplies = new Applies(applyRepository.findAllByMeetingIdIn(meetingIds));
 

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -528,6 +528,18 @@ public class MeetingV2ServiceTest extends redisContainerBaseTest {
 					"capacity", "isMentorNeeded", "targetActiveGeneration",
 					"joinableParts", "status", "approvedCount"
 				).containsExactly(
+					tuple("스터디 구합니다1", "행사", true,
+						LocalDateTime.of(2024, 5, 29, 0, 0),
+						LocalDateTime.of(2024, 5, 31, 23, 59, 59),
+						10, true, 35,
+						new MeetingJoinablePart[] {PM, SERVER}, 1, 2
+					),
+					tuple("스터디 구합니다 - 신청전", "스터디", false,
+						LocalDateTime.of(2024, 5, 29, 0, 0),
+						LocalDateTime.of(2024, 5, 31, 23, 59, 59),
+						10, false, null,
+						new MeetingJoinablePart[] {PM, SERVER}, 0, 0
+					),
 					tuple("세미나 구합니다 - 신청후", "세미나", false,
 						LocalDateTime.of(2024, 5, 29, 0, 0),
 						LocalDateTime.of(2024, 5, 31, 23, 59, 59),
@@ -539,38 +551,24 @@ public class MeetingV2ServiceTest extends redisContainerBaseTest {
 						LocalDateTime.of(2024, 5, 31, 23, 59, 59),
 						10, false, null,
 						new MeetingJoinablePart[] {PM, SERVER}, 2, 0
-					),
-					tuple("스터디 구합니다 - 신청전", "스터디", false,
-						LocalDateTime.of(2024, 5, 29, 0, 0),
-						LocalDateTime.of(2024, 5, 31, 23, 59, 59),
-						10, false, null,
-						new MeetingJoinablePart[] {PM, SERVER}, 0, 0
-					),
-					tuple("스터디 구합니다1", "행사", true,
-						LocalDateTime.of(2024, 5, 29, 0, 0),
-						LocalDateTime.of(2024, 5, 31, 23, 59, 59),
-						10, true, 35,
-						new MeetingJoinablePart[] {PM, SERVER}, 1, 2
 					)
-
 				);
 
 			Assertions.assertThat(meetingCreatorDtos)
 				.extracting("name", "orgId", "profileImage", "activities", "phone")
 				.containsExactly(
-					tuple("모임개설자2", 1005, "profile5.jpg",
-						List.of(new UserActivityVO("iOS", 35), new UserActivityVO("안드로이드", 34)),
-						"010-6666-6666"),
-					tuple("모임개설자2", 1005, "profile5.jpg",
-						List.of(new UserActivityVO("iOS", 35), new UserActivityVO("안드로이드", 34)),
-						"010-6666-6666"),
-					tuple("모임개설자2", 1005, "profile5.jpg",
-						List.of(new UserActivityVO("iOS", 35), new UserActivityVO("안드로이드", 34)),
-						"010-6666-6666"),
 					tuple("모임개설자", 1001, "profile1.jpg",
 						List.of(new UserActivityVO("서버", 33), new UserActivityVO("iOS", 32)),
-						"010-1234-5678")
-
+						"010-1234-5678"),
+					tuple("모임개설자2", 1005, "profile5.jpg",
+						List.of(new UserActivityVO("iOS", 35), new UserActivityVO("안드로이드", 34)),
+						"010-6666-6666"),
+					tuple("모임개설자2", 1005, "profile5.jpg",
+						List.of(new UserActivityVO("iOS", 35), new UserActivityVO("안드로이드", 34)),
+						"010-6666-6666"),
+					tuple("모임개설자2", 1005, "profile5.jpg",
+						List.of(new UserActivityVO("iOS", 35), new UserActivityVO("안드로이드", 34)),
+						"010-6666-6666")
 				);
 		}
 

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -22,22 +22,22 @@ import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyType;
 import org.sopt.makers.crew.main.entity.meeting.CoLeader;
 import org.sopt.makers.crew.main.entity.meeting.CoLeaderRepository;
-import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
-import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
-import org.sopt.makers.crew.main.external.redisContainerBaseTest;
-import org.sopt.makers.crew.main.global.annotation.IntegratedTest;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
+import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.entity.user.UserRepository;
 import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
+import org.sopt.makers.crew.main.external.redisContainerBaseTest;
+import org.sopt.makers.crew.main.global.annotation.IntegratedTest;
 import org.sopt.makers.crew.main.global.dto.MeetingCreatorDto;
 import org.sopt.makers.crew.main.global.dto.MeetingResponseDto;
+import org.sopt.makers.crew.main.global.exception.BadRequestException;
 import org.sopt.makers.crew.main.global.exception.ForbiddenException;
 import org.sopt.makers.crew.main.global.exception.NotFoundException;
-import org.sopt.makers.crew.main.global.exception.BadRequestException;
 import org.sopt.makers.crew.main.meeting.v2.dto.ApplyMapper;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
@@ -701,8 +701,8 @@ public class MeetingV2ServiceTest extends redisContainerBaseTest {
 				.extracting(
 					"title", "category"
 				).containsExactly(
-					tuple("스터디 구합니다 - 신청전", "스터디"),
-					tuple("스터디 구합니다1", "행사")
+					tuple("스터디 구합니다1", "행사"),
+					tuple("스터디 구합니다 - 신청전", "스터디")
 				);
 		}
 

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -642,6 +642,12 @@ public class MeetingV2ServiceTest extends redisContainerBaseTest {
 					"capacity", "isMentorNeeded", "targetActiveGeneration",
 					"joinableParts", "status", "approvedCount"
 				).containsExactly(
+					tuple("스터디 구합니다 - 신청전", "스터디", false,
+						LocalDateTime.of(2024, 5, 29, 0, 0),
+						LocalDateTime.of(2024, 5, 31, 23, 59, 59),
+						10, false, null,
+						new MeetingJoinablePart[] {PM, SERVER}, 0, 0
+					),
 					tuple("세미나 구합니다 - 신청후", "세미나", false,
 						LocalDateTime.of(2024, 5, 29, 0, 0),
 						LocalDateTime.of(2024, 5, 31, 23, 59, 59),
@@ -653,12 +659,6 @@ public class MeetingV2ServiceTest extends redisContainerBaseTest {
 						LocalDateTime.of(2024, 5, 31, 23, 59, 59),
 						10, false, null,
 						new MeetingJoinablePart[] {PM, SERVER}, 2, 0
-					),
-					tuple("스터디 구합니다 - 신청전", "스터디", false,
-						LocalDateTime.of(2024, 5, 29, 0, 0),
-						LocalDateTime.of(2024, 5, 31, 23, 59, 59),
-						10, false, null,
-						new MeetingJoinablePart[] {PM, SERVER}, 0, 0
 					)
 				);
 
@@ -744,10 +744,10 @@ public class MeetingV2ServiceTest extends redisContainerBaseTest {
 				.extracting(
 					"title", "category"
 				).containsExactly(
-					tuple("세미나 구합니다 - 신청후", "세미나"),
-					tuple("스터디 구합니다 - 신청후", "스터디"),
+					tuple("스터디 구합니다1", "행사"),
 					tuple("스터디 구합니다 - 신청전", "스터디"),
-					tuple("스터디 구합니다1", "행사")
+					tuple("세미나 구합니다 - 신청후", "세미나"),
+					tuple("스터디 구합니다 - 신청후", "스터디")
 				);
 		}
 


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 모집중, 모집전, 모집마감 순으로 모임조회 정렬 로직을 변경하였습니다.
- 같은 카테고리(모임 모집 상태)의 경우 기존처럼 id 순으로 최신순 정렬을 하도록 하였습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

![image](https://github.com/user-attachments/assets/4fd6bb02-7eef-498e-a990-cbdc71fb6a09)
![image](https://github.com/user-attachments/assets/3e2210d6-50f5-404f-b3c0-eb5a1d565608)

- 첫번째 이미지는 page1의 응답값, 두번째 이미지는 page2의 응답값입니다.
- postman으로 확인했을 때, 모집중 -> 모집전 -> 모집마감 순으로 최신순 정렬을 하는것을 확인했습니다.


### 주의점

#### 기존 쿼리
<img width="1132" alt="image" src="https://github.com/user-attachments/assets/28ee1e76-d224-4095-ac6c-0c5f8fc7164f" />

#### 바뀐 쿼리
<img width="1131" alt="image" src="https://github.com/user-attachments/assets/c5dc19b7-5152-498c-ba1f-2fcb90dab4cf" />

- 현재 AOP로 레포지토리 쿼리 응답속도를 측정해보니 거의 2배 차이가 납니다. 따라서 추후 최적화를 해야할 것 같습니다.

### 개선 사항
### time.now()를 여러 번 호출 시 발생하는 문제
- 여러번 time.now()를 호출할경우 결과가 매번 다르게 평가될 가능성이 있어, 쿼리 실행 시 불일치한 결과가 발생할 수 있습니다.
- 따라서 동일한 now 값을 사용하게 하여 예상치 못한 미묘한 시간 차이 문제를 방지하도록 하였습니다.


## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #485 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?