### PR TITLE
refactor: 최신 기수(36th) 변경에 따른 Crew Const 변경

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -109,6 +109,9 @@ dependencies {
     // @ConfigurationProperties auto bean register
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
+    // JSR305 (The compiler helps interpret null-safety-related annotations)
+    implementation 'com.google.code.findbugs:jsr305:3.0.2'
+
 }
 
 tasks.named('test') {

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepository.java
@@ -8,7 +8,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface MeetingSearchRepository {
-	Page<Meeting> findAllByQuery(MeetingV2GetAllMeetingQueryDto queryCommand, Pageable pageable, Time time);
+	Page<Meeting> findAllByQuery(MeetingV2GetAllMeetingQueryDto queryCommand, Pageable pageable, Time time,
+		Integer activeGeneration);
 
 	List<Meeting> findRecommendMeetings(List<Integer> meetingIds, Time time);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/flash/v2/service/FlashV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/flash/v2/service/FlashV2ServiceImpl.java
@@ -22,6 +22,7 @@ import org.sopt.makers.crew.main.global.dto.MeetingCreatorDto;
 import org.sopt.makers.crew.main.global.dto.OrgIdListDto;
 import org.sopt.makers.crew.main.global.exception.BadRequestException;
 import org.sopt.makers.crew.main.global.exception.NotFoundException;
+import org.sopt.makers.crew.main.global.util.ActiveGenerationProvider;
 import org.sopt.makers.crew.main.global.util.Time;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyWholeInfoDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateAndUpdateMeetingForFlashResponseDto;
@@ -54,6 +55,7 @@ public class FlashV2ServiceImpl implements FlashV2Service {
 	private final FlashMapper flashMapper;
 
 	private final ApplicationEventPublisher eventPublisher;
+	private final ActiveGenerationProvider activeGenerationProvider;
 	private final Time realTime;
 
 	@Override
@@ -74,7 +76,7 @@ public class FlashV2ServiceImpl implements FlashV2Service {
 			userId, requestBody.flashBody());
 
 		Flash flash = flashMapper.toFlashEntity(meetingV2CreateAndUpdateMeetingForFlashResponseDto,
-			ACTIVE_GENERATION, user.getId(), realTime);
+			activeGenerationProvider.getActiveGeneration(), user.getId(), realTime);
 
 		flashRepository.save(flash);
 		tagV2Service.createFlashTag(requestBody.welcomeMessageTypes(), flash.getId());
@@ -139,7 +141,7 @@ public class FlashV2ServiceImpl implements FlashV2Service {
 			meetingId, userId, requestBody.flashBody());
 
 		Flash updatedFlash = flashMapper.toFlashEntity(meetingV2CreateAndUpdateMeetingForFlashResponseDto,
-			ACTIVE_GENERATION, user.getId(), realTime);
+			activeGenerationProvider.getActiveGeneration(), user.getId(), realTime);
 
 		flash.updateFlash(updatedFlash);
 

--- a/main/src/main/java/org/sopt/makers/crew/main/global/constant/CrewConst.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/constant/CrewConst.java
@@ -9,7 +9,7 @@ public final class CrewConst {
 	/**
 	 * 매 기수 시작하기 전에 수정 필요
 	 * */
-	public static final Integer ACTIVE_GENERATION = 35;
+	public static final Integer ACTIVE_GENERATION = 36;
 
 	public static final String DAY_START_TIME = " 00:00:00";
 	public static final String DAY_END_TIME = " 23:59:59";

--- a/main/src/main/java/org/sopt/makers/crew/main/global/dto/MeetingResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/dto/MeetingResponseDto.java
@@ -1,11 +1,9 @@
 package org.sopt.makers.crew.main.global.dto;
 
 import java.time.LocalDateTime;
-
 import java.util.List;
 import java.util.Objects;
 
-import org.sopt.makers.crew.main.global.constant.CrewConst;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
@@ -83,11 +81,12 @@ public class MeetingResponseDto {
 		return mEndDate;
 	}
 
-	public static MeetingResponseDto of(Meeting meeting, User meetingCreator, int approvedCount, LocalDateTime now) {
+	public static MeetingResponseDto of(Meeting meeting, User meetingCreator, int approvedCount, LocalDateTime now,
+		Integer activeGeneration) {
 		MeetingCreatorDto creatorDto = MeetingCreatorDto.of(meetingCreator);
 		boolean canJoinOnlyActiveGeneration =
-			Objects.equals(meeting.getTargetActiveGeneration(), CrewConst.ACTIVE_GENERATION)
-			&& meeting.getCanJoinOnlyActiveGeneration();
+			Objects.equals(meeting.getTargetActiveGeneration(), activeGeneration)
+				&& meeting.getCanJoinOnlyActiveGeneration();
 
 		return new MeetingResponseDto(meeting.getId(), meeting.getTitle(),
 			meeting.getTargetActiveGeneration(), meeting.getJoinableParts(), meeting.getCategory().getValue(),

--- a/main/src/main/java/org/sopt/makers/crew/main/global/util/ActiveGenerationProvider.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/util/ActiveGenerationProvider.java
@@ -1,0 +1,5 @@
+package org.sopt.makers.crew.main.global.util;
+
+public interface ActiveGenerationProvider {
+	Integer getActiveGeneration();
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/global/util/DefaultActiveGenerationProvider.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/util/DefaultActiveGenerationProvider.java
@@ -1,0 +1,14 @@
+package org.sopt.makers.crew.main.global.util;
+
+import org.sopt.makers.crew.main.global.constant.CrewConst;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("!test")
+public class DefaultActiveGenerationProvider implements ActiveGenerationProvider {
+	@Override
+	public Integer getActiveGeneration() {
+		return CrewConst.ACTIVE_GENERATION;
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingService.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingService.java
@@ -2,18 +2,17 @@ package org.sopt.makers.crew.main.internal.service;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
 import org.sopt.makers.crew.main.external.playground.service.MemberBlockService;
 import org.sopt.makers.crew.main.global.pagination.dto.PageMetaDto;
 import org.sopt.makers.crew.main.global.pagination.dto.PageOptionsDto;
+import org.sopt.makers.crew.main.global.util.ActiveGenerationProvider;
 import org.sopt.makers.crew.main.global.util.CustomPageable;
 import org.sopt.makers.crew.main.global.util.Time;
 import org.sopt.makers.crew.main.internal.dto.InternalMeetingGetAllMeetingDto;
 import org.sopt.makers.crew.main.internal.dto.InternalMeetingResponseDto;
-import org.sopt.makers.crew.main.internal.dto.UserOrgIdRequestDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
@@ -29,6 +28,7 @@ public class InternalMeetingService {
 	private final MeetingRepository meetingRepository;
 	private final MemberBlockService memberBlockService;
 
+	private final ActiveGenerationProvider activeGenerationProvider;
 	private final Time time;
 
 	/**
@@ -44,7 +44,8 @@ public class InternalMeetingService {
 		Sort sort = Sort.by(Sort.Direction.ASC, "id");
 
 		Page<Meeting> meetings = meetingRepository.findAllByQuery(queryCommand,
-			new CustomPageable(queryCommand.getPage() - 1, queryCommand.getTake(), sort), time);
+			new CustomPageable(queryCommand.getPage() - 1, queryCommand.getTake(), sort), time,
+			activeGenerationProvider.getActiveGeneration());
 
 		List<Long> userOrgIds = meetings.getContent()
 			.stream()

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/FlashMeetingMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/FlashMeetingMapper.java
@@ -28,7 +28,7 @@ public interface FlashMeetingMapper {
 	@Mapping(source = "flashBody.activityStartDate", target = "mStartDate", qualifiedByName = "getStartDate")
 	@Mapping(source = "flashBody.activityEndDate", target = "mEndDate", qualifiedByName = "getEndDate")
 	@Mapping(target = "category", expression = "java(org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory.FLASH)")
-	@Mapping(target = "createdGeneration", expression = "java(org.sopt.makers.crew.main.global.constant.CrewConst.ACTIVE_GENERATION)")
+	@Mapping(source = "activeGeneration", target = "createdGeneration")
 	@Mapping(target = "processDesc", constant = "") // null 대신 빈 문자열로 NPE 방지
 	@Mapping(target = "leaderDesc", constant = "") // null 대신 빈 문자열로 NPE 방지
 	@Mapping(target = "note", constant = "") // null 대신 빈 문자열로 NPE 방지
@@ -37,8 +37,13 @@ public interface FlashMeetingMapper {
 	@Mapping(target = "targetActiveGeneration", expression = "java(null)") // 번쩍 정책에 맞게 null
 	@Mapping(target = "joinableParts", expression = "java(org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart.values())")
 		// 번쩍 정책에 맞게 모든 파트 허용
-	Meeting toMeetingEntityForFlash(FlashV2CreateAndUpdateFlashBodyWithoutWelcomeMessageDto flashBody,
-		User user, Integer userId, LocalDateTime now);
+	Meeting toMeetingEntityForFlash(
+		FlashV2CreateAndUpdateFlashBodyWithoutWelcomeMessageDto flashBody,
+		User user,
+		Integer userId,
+		LocalDateTime now,
+		Integer activeGeneration
+	);
 
 	@Named("getImageURL")
 	static List<ImageUrlVO> getImageURL(List<String> files) {

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
@@ -2,12 +2,12 @@ package org.sopt.makers.crew.main.user.v2.dto.response;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
-import org.sopt.makers.crew.main.global.constant.CrewConst;
-import org.sopt.makers.crew.main.global.dto.MeetingCreatorDto;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+import org.sopt.makers.crew.main.global.dto.MeetingCreatorDto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -75,9 +75,9 @@ public record MeetingV2GetCreatedMeetingByUserResponseDto(
 	int approvedCount
 ) {
 	public static MeetingV2GetCreatedMeetingByUserResponseDto of(Meeting meeting, boolean isCoLeader, int approvedCount,
-		LocalDateTime now) {
+		LocalDateTime now, Integer activeGeneration) {
 		MeetingCreatorDto creatorDto = MeetingCreatorDto.of(meeting.getUser());
-		boolean canJoinOnlyActiveGeneration = meeting.getTargetActiveGeneration() == CrewConst.ACTIVE_GENERATION
+		boolean canJoinOnlyActiveGeneration = Objects.equals(meeting.getTargetActiveGeneration(), activeGeneration)
 			&& meeting.getCanJoinOnlyActiveGeneration();
 
 		return new MeetingV2GetCreatedMeetingByUserResponseDto(meeting.getId(), meeting.getTitle(),

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
@@ -5,19 +5,20 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.sopt.makers.crew.main.entity.meeting.CoLeader;
-import org.sopt.makers.crew.main.entity.meeting.CoLeaderRepository;
-import org.sopt.makers.crew.main.entity.meeting.CoLeaders;
-import org.sopt.makers.crew.main.global.exception.BaseException;
-import org.sopt.makers.crew.main.global.util.Time;
 import org.sopt.makers.crew.main.entity.apply.Applies;
 import org.sopt.makers.crew.main.entity.apply.Apply;
 import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
 import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
+import org.sopt.makers.crew.main.entity.meeting.CoLeader;
+import org.sopt.makers.crew.main.entity.meeting.CoLeaderRepository;
+import org.sopt.makers.crew.main.entity.meeting.CoLeaders;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.entity.user.UserRepository;
+import org.sopt.makers.crew.main.global.exception.BaseException;
+import org.sopt.makers.crew.main.global.util.ActiveGenerationProvider;
+import org.sopt.makers.crew.main.global.util.Time;
 import org.sopt.makers.crew.main.user.v2.dto.response.ApplyV2GetAppliedMeetingByUserResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.MeetingV2GetCreatedMeetingByUserResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMeetingByUserMeetingDto;
@@ -42,6 +43,7 @@ public class UserV2ServiceImpl implements UserV2Service {
 	private final MeetingRepository meetingRepository;
 	private final CoLeaderRepository coLeaderRepository;
 
+	private final ActiveGenerationProvider activeGenerationProvider;
 	private final Time time;
 
 	@Override
@@ -111,7 +113,8 @@ public class UserV2ServiceImpl implements UserV2Service {
 
 		List<MeetingV2GetCreatedMeetingByUserResponseDto> meetingByUserDtos = myMeetings.stream()
 			.map(meeting -> MeetingV2GetCreatedMeetingByUserResponseDto.of(meeting,
-				coLeaders.isCoLeader(meeting.getId(), userId), applies.getApprovedCount(meeting.getId()), time.now()))
+				coLeaders.isCoLeader(meeting.getId(), userId), applies.getApprovedCount(meeting.getId()), time.now(),
+				activeGenerationProvider.getActiveGeneration()))
 			.toList();
 
 		return UserV2GetCreatedMeetingByUserResponseDto.of(meetingByUserDtos);
@@ -132,7 +135,8 @@ public class UserV2ServiceImpl implements UserV2Service {
 		List<ApplyV2GetAppliedMeetingByUserResponseDto> appliedMeetingByUserDtos = myApplies.stream()
 			.map(apply -> ApplyV2GetAppliedMeetingByUserResponseDto.of(apply.getId(), apply.getStatus().getValue(),
 				MeetingV2GetCreatedMeetingByUserResponseDto.of(apply.getMeeting(), false,
-					allApplies.getApprovedCount(apply.getMeetingId()), time.now())))
+					allApplies.getApprovedCount(apply.getMeetingId()), time.now(),
+					activeGenerationProvider.getActiveGeneration())))
 			.toList();
 
 		return UserV2GetAppliedMeetingByUserResponseDto.of(appliedMeetingByUserDtos);

--- a/main/src/test/java/org/sopt/makers/crew/main/global/util/TestActiveGenerationProvider.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/global/util/TestActiveGenerationProvider.java
@@ -1,0 +1,15 @@
+package org.sopt.makers.crew.main.global.util;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("test")
+public class TestActiveGenerationProvider implements ActiveGenerationProvider {
+	private static final Integer FIX_ACTIVE_GENERATION = 35;
+
+	@Override
+	public Integer getActiveGeneration() {
+		return FIX_ACTIVE_GENERATION;
+	}
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -2,7 +2,6 @@ package org.sopt.makers.crew.main.meeting.v2.service;
 
 import static org.assertj.core.groups.Tuple.*;
 import static org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart.*;
-import static org.sopt.makers.crew.main.global.constant.CrewConst.*;
 import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
 
 import java.time.LocalDateTime;
@@ -38,6 +37,7 @@ import org.sopt.makers.crew.main.global.dto.MeetingResponseDto;
 import org.sopt.makers.crew.main.global.exception.BadRequestException;
 import org.sopt.makers.crew.main.global.exception.ForbiddenException;
 import org.sopt.makers.crew.main.global.exception.NotFoundException;
+import org.sopt.makers.crew.main.global.util.ActiveGenerationProvider;
 import org.sopt.makers.crew.main.meeting.v2.dto.ApplyMapper;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
@@ -76,6 +76,9 @@ public class MeetingV2ServiceTest extends redisContainerBaseTest {
 
 	@Autowired
 	private ApplyMapper applyMapper;
+
+	@Autowired
+	private ActiveGenerationProvider activeGenerationProvide;
 
 	@Nested
 	class 모임_생성 {
@@ -155,8 +158,9 @@ public class MeetingV2ServiceTest extends redisContainerBaseTest {
 					"준비물은 노트북과 열정입니다.",  // note 필드
 					false,  // isMentorNeeded 필드
 					canJoinOnlyActiveGeneration,  // canJoinOnlyActiveGeneration 필드
-					ACTIVE_GENERATION,  // createdGeneration 필드
-					canJoinOnlyActiveGeneration ? ACTIVE_GENERATION : null,  // targetActiveGeneration 필드
+					activeGenerationProvide.getActiveGeneration(),  // createdGeneration 필드
+					canJoinOnlyActiveGeneration ? activeGenerationProvide.getActiveGeneration() : null,
+					// targetActiveGeneration 필드
 					new MeetingJoinablePart[] {MeetingJoinablePart.SERVER, MeetingJoinablePart.IOS}  // joinableParts 필드
 				);
 


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 최신 기수(36th) 변경에 따른 Crew Const의 ACTIVE_GENERATION을 변경했습니다.

## 🌎 Share Situation


- 지금 36기로 상수를 바꾸면서 `canJoinOnlyActiveGeneration` boolean 필드가 false로 나와 테스트 결과가 달라지는 상황입니다!
- `getMeetings`를 호출할 때, 비즈니스 로직 내에서 ACTIVE_GENERATION=36 과 비교를 하기 때문에 false가 나오고 있습니다.
- 테스트 코드에서 ACTIVE_GENERATION을 전역적으로 고정해서, 다음 기수가 진행되어도 영향이 없도록 설계를 해야할 것 같은데 좋은 방법 있으시면 의견주시면 감사하겠습니다!

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

### 환경에 따라 다른 상수값을 주입할 수 있는 구현체 생성

```java
public interface ActiveGenerationProvider {
	Integer getActiveGeneration();
}
```

```java
@Component
@Profile("!test")
public class DefaultActiveGenerationProvider implements ActiveGenerationProvider {
	@Override
	public Integer getActiveGeneration() {
		return CrewConst.ACTIVE_GENERATION;
	}
}
```

```java
@Component
@Profile("test")
public class TestActiveGenerationProvider implements ActiveGenerationProvider {
	private static final Integer FIX_ACTIVE_GENERATION = 35;

	@Override
	public Integer getActiveGeneration() {
		return FIX_ACTIVE_GENERATION;
	}
}

```

- 이번 기회에, 테스트 환경에서 특정 값을 고정하여 예측 가능한 테스트를 수행할 수 있도록 설정하였습니다.
- 이를 통해 테스트 실행 시 최신 기수가 변경되는 영향을 받지 않고 일관된 결과를 얻을 수 있습니다.
- 또한, @Profile("test")을 활용하여 테스트 환경에서만 특정 구현체가 적용되도록 구성하였으며, @Profile("!test")을 사용하여 운영 및 개발 환경에서는 최신 기수를 동적으로 반영할 수 있도록 구현하였습니다.
- 또한, 테스트 환경에서는 시간이 지남에 따라 변경될 수 있는 데이터(예: 최신 기수, 현재 시간 등)를 고정해야 예측 가능한 테스트가 가능하다는 점을 깨달았습니다.
- 이를 반영하여, 테스트 환경에서는 특정 기수를 고정하고, 운영 및 개발 환경에서는 동적으로 반영될 수 있도록 구현함으로써, 테스트 안정성을 더욱 강화할 수 있었습니다.

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #587 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?