### PR TITLE
feat: 모임 정보에 신청 순서 추가

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/flash/v2/service/FlashV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/flash/v2/service/FlashV2ServiceImpl.java
@@ -4,9 +4,12 @@ import static org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus.*;
 import static org.sopt.makers.crew.main.global.constant.CrewConst.*;
 import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.sopt.makers.crew.main.entity.apply.Applies;
+import org.sopt.makers.crew.main.entity.apply.Apply;
 import org.sopt.makers.crew.main.entity.apply.ApplyRepository;
 import org.sopt.makers.crew.main.entity.flash.Flash;
 import org.sopt.makers.crew.main.entity.flash.FlashRepository;
@@ -154,9 +157,12 @@ public class FlashV2ServiceImpl implements FlashV2Service {
 		if (!applies.hasApplies(meetingId)) {
 			return List.of();
 		}
+		AtomicInteger applyNumber = new AtomicInteger(1);
 
 		return applies.getAppliesMap().get(meetingId).stream()
-			.map(apply -> ApplyWholeInfoDto.of(apply, apply.getUser(), userId))
+			.sorted(Comparator.comparing(Apply::getAppliedDate))
+			.map(apply -> ApplyWholeInfoDto.ofIncludeApplyNumber(apply, apply.getUser(), userId,
+				applyNumber.getAndIncrement()))
 			.toList();
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/flash/v2/service/FlashV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/flash/v2/service/FlashV2ServiceImpl.java
@@ -161,7 +161,7 @@ public class FlashV2ServiceImpl implements FlashV2Service {
 
 		return applies.getAppliesMap().get(meetingId).stream()
 			.sorted(Comparator.comparing(Apply::getAppliedDate))
-			.map(apply -> ApplyWholeInfoDto.ofIncludeApplyNumber(apply, apply.getUser(), userId,
+			.map(apply -> ApplyWholeInfoDto.of(apply, apply.getUser(), userId,
 				applyNumber.getAndIncrement()))
 			.toList();
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/flash/v2/service/FlashV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/flash/v2/service/FlashV2ServiceImpl.java
@@ -6,7 +6,7 @@ import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 
 import org.sopt.makers.crew.main.entity.apply.Applies;
 import org.sopt.makers.crew.main.entity.apply.Apply;
@@ -157,12 +157,16 @@ public class FlashV2ServiceImpl implements FlashV2Service {
 		if (!applies.hasApplies(meetingId)) {
 			return List.of();
 		}
-		AtomicInteger applyNumber = new AtomicInteger(1);
-
-		return applies.getAppliesMap().get(meetingId).stream()
+		List<Apply> sortedApplies = applies.getAppliesMap().get(meetingId).stream()
 			.sorted(Comparator.comparing(Apply::getAppliedDate))
-			.map(apply -> ApplyWholeInfoDto.of(apply, apply.getUser(), userId,
-				applyNumber.getAndIncrement()))
+			.toList();
+
+		return IntStream.rangeClosed(1, sortedApplies.size())
+			.mapToObj(i -> ApplyWholeInfoDto.of(
+				sortedApplies.get(i - 1),
+				sortedApplies.get(i - 1).getUser(),
+				userId,
+				i))
 			.toList();
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyInfoDetailDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyInfoDetailDto.java
@@ -1,0 +1,46 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import java.time.LocalDateTime;
+
+import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Schema(name = "ApplyInfoDetailDto", description = "모임 신청 객체 Dto 상세 -> 신청 번호 추가")
+@RequiredArgsConstructor
+public class ApplyInfoDetailDto {
+
+	@Schema(description = "신청 id", example = "1")
+	@NotNull
+	private final Integer id;
+
+	@Schema(description = "신청 번호", example = "1")
+	@NotNull
+	private final Integer applyNumber;
+
+	@Schema(description = "전하는 말", example = "저 뽑아주세요.")
+	private final String content;
+
+	@Schema(description = "신청 시간", example = "2024-07-30T15:30:00")
+	@NotNull
+	private final LocalDateTime appliedDate;
+
+	@Schema(description = "신청 상태", example = "1")
+	@NotNull
+	private final EnApplyStatus status;
+
+	@Schema(description = "신청자 정보", example = "")
+	@NotNull
+	private final ApplicantDto user;
+
+	public static ApplyInfoDetailDto toApplyInfoDetailDto(ApplyInfoDto applyInfoDto, Integer applyNumber) {
+		return new ApplyInfoDetailDto(applyInfoDto.getId(), applyNumber, applyInfoDto.getContent(),
+			applyInfoDto.getAppliedDate(),
+			applyInfoDto.getStatus(), applyInfoDto.getUser());
+	}
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyWholeInfoDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyWholeInfoDto.java
@@ -19,6 +19,9 @@ public class ApplyWholeInfoDto {
 	@NotNull
 	private final Integer id;
 
+	@Schema(description = "신청 번호", example = "1")
+	private final Integer applyNumber;
+
 	@Schema(description = "신청 타입", example = "0")
 	@NotNull
 	private final Integer type;
@@ -47,11 +50,23 @@ public class ApplyWholeInfoDto {
 	@NotNull
 	private final ApplicantByMeetingDto user;
 
+	public static ApplyWholeInfoDto ofIncludeApplyNumber(Apply apply, User user, Integer requestUserId,
+		Integer applyNumber) {
+
+		ApplicantByMeetingDto applicantByMeetingDto = ApplicantByMeetingDto.of(user);
+
+		return new ApplyWholeInfoDto(apply.getId(), applyNumber, apply.getType().getValue(), apply.getMeetingId(),
+			apply.getUserId(),
+			apply.getContent(requestUserId), apply.getAppliedDate(), apply.getStatus().getValue(),
+			applicantByMeetingDto);
+	}
+
 	public static ApplyWholeInfoDto of(Apply apply, User user, Integer requestUserId) {
 
 		ApplicantByMeetingDto applicantByMeetingDto = ApplicantByMeetingDto.of(user);
 
-		return new ApplyWholeInfoDto(apply.getId(), apply.getType().getValue(), apply.getMeetingId(), apply.getUserId(),
+		return new ApplyWholeInfoDto(apply.getId(), null, apply.getType().getValue(), apply.getMeetingId(),
+			apply.getUserId(),
 			apply.getContent(requestUserId), apply.getAppliedDate(), apply.getStatus().getValue(),
 			applicantByMeetingDto);
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyWholeInfoDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyWholeInfoDto.java
@@ -20,6 +20,7 @@ public class ApplyWholeInfoDto {
 	private final Integer id;
 
 	@Schema(description = "신청 번호", example = "1")
+	@NotNull
 	private final Integer applyNumber;
 
 	@Schema(description = "신청 타입", example = "0")
@@ -50,7 +51,7 @@ public class ApplyWholeInfoDto {
 	@NotNull
 	private final ApplicantByMeetingDto user;
 
-	public static ApplyWholeInfoDto ofIncludeApplyNumber(Apply apply, User user, Integer requestUserId,
+	public static ApplyWholeInfoDto of(Apply apply, User user, Integer requestUserId,
 		Integer applyNumber) {
 
 		ApplicantByMeetingDto applicantByMeetingDto = ApplicantByMeetingDto.of(user);
@@ -61,13 +62,4 @@ public class ApplyWholeInfoDto {
 			applicantByMeetingDto);
 	}
 
-	public static ApplyWholeInfoDto of(Apply apply, User user, Integer requestUserId) {
-
-		ApplicantByMeetingDto applicantByMeetingDto = ApplicantByMeetingDto.of(user);
-
-		return new ApplyWholeInfoDto(apply.getId(), null, apply.getType().getValue(), apply.getMeetingId(),
-			apply.getUserId(),
-			apply.getContent(requestUserId), apply.getAppliedDate(), apply.getStatus().getValue(),
-			applicantByMeetingDto);
-	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingGetApplyListResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingGetApplyListResponseDto.java
@@ -2,12 +2,12 @@ package org.sopt.makers.crew.main.meeting.v2.dto.response;
 
 import java.util.List;
 
+import org.sopt.makers.crew.main.global.pagination.dto.PageMetaDto;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
-import org.sopt.makers.crew.main.global.pagination.dto.PageMetaDto;
 
 @Getter
 @AllArgsConstructor(staticName = "of")
@@ -16,7 +16,7 @@ public class MeetingGetApplyListResponseDto {
 
 	@Schema(description = "신청 목록", example = "")
 	@NotNull
-	private final List<ApplyInfoDto> apply;
+	private final List<ApplyInfoDetailDto> apply;
 
 	@NotNull
 	private final PageMetaDto meta;

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -487,6 +487,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		if (applies.hasApplies(meetingId)) {
 			AtomicInteger applyNumber = new AtomicInteger(1);
 			applyWholeInfoDtos = applies.getAppliesMap().get(meetingId).stream()
+				.sorted(Comparator.comparing(Apply::getAppliedDate))
 				.map(apply -> ApplyWholeInfoDto.ofIncludeApplyNumber(apply, apply.getUser(), userId,
 					applyNumber.getAndIncrement()))
 				.toList();

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -332,7 +332,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		return applyInfoDtos.map(
 			a -> ApplyInfoDetailDto.toApplyInfoDetailDto(a, applyNumbers.getAndIncrement()));
 	}
-	
+
 	private PageMetaDto madePageMetaDto(MeetingGetAppliesQueryDto queryCommand,
 		Page<ApplyInfoDetailDto> applyInfoDetailDtos) {
 		PageOptionsDto pageOptionsDto = new PageOptionsDto(queryCommand.getPage(), queryCommand.getTake());
@@ -507,7 +507,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 			AtomicInteger applyNumber = new AtomicInteger(1);
 			applyWholeInfoDtos = applies.getAppliesMap().get(meetingId).stream()
 				.sorted(Comparator.comparing(Apply::getAppliedDate))
-				.map(apply -> ApplyWholeInfoDto.ofIncludeApplyNumber(apply, apply.getUser(), userId,
+				.map(apply -> ApplyWholeInfoDto.of(apply, apply.getUser(), userId,
 					applyNumber.getAndIncrement()))
 				.toList();
 		}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -312,18 +312,31 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		Integer meetingId,
 		Integer userId) {
 		Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
+
+		Page<ApplyInfoDetailDto> applyInfoDetails = madeApplyInfoDetails(
+			queryCommand, meetingId, userId, meeting);
+
+		PageMetaDto pageMetaDto = madePageMetaDto(queryCommand,
+			applyInfoDetails);
+
+		return MeetingGetApplyListResponseDto.of(applyInfoDetails.getContent(), pageMetaDto);
+	}
+
+	private Page<ApplyInfoDetailDto> madeApplyInfoDetails(MeetingGetAppliesQueryDto queryCommand, Integer meetingId,
+		Integer userId, Meeting meeting) {
 		Page<ApplyInfoDto> applyInfoDtos = applyRepository.findApplyList(queryCommand,
 			PageRequest.of(queryCommand.getPage() - 1, queryCommand.getTake()),
 			meetingId, meeting.getUserId(), userId);
 
 		AtomicInteger applyNumbers = new AtomicInteger(1);
-		Page<ApplyInfoDetailDto> applyInfoDetailDtos = applyInfoDtos.map(
+		return applyInfoDtos.map(
 			a -> ApplyInfoDetailDto.toApplyInfoDetailDto(a, applyNumbers.getAndIncrement()));
-
+	}
+	
+	private PageMetaDto madePageMetaDto(MeetingGetAppliesQueryDto queryCommand,
+		Page<ApplyInfoDetailDto> applyInfoDetailDtos) {
 		PageOptionsDto pageOptionsDto = new PageOptionsDto(queryCommand.getPage(), queryCommand.getTake());
-		PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, (int)applyInfoDetailDtos.getTotalElements());
-
-		return MeetingGetApplyListResponseDto.of(applyInfoDetailDtos.getContent(), pageMetaDto);
+		return new PageMetaDto(pageOptionsDto, (int)applyInfoDetailDtos.getTotalElements());
 	}
 
 	@Override

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -77,6 +77,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.request.ApplyV2UpdateStatusBodyD
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.AppliesCsvFileUrlResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDetailDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyWholeInfoDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
@@ -314,10 +315,15 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		Page<ApplyInfoDto> applyInfoDtos = applyRepository.findApplyList(queryCommand,
 			PageRequest.of(queryCommand.getPage() - 1, queryCommand.getTake()),
 			meetingId, meeting.getUserId(), userId);
-		PageOptionsDto pageOptionsDto = new PageOptionsDto(queryCommand.getPage(), queryCommand.getTake());
-		PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, (int)applyInfoDtos.getTotalElements());
 
-		return MeetingGetApplyListResponseDto.of(applyInfoDtos.getContent(), pageMetaDto);
+		AtomicInteger applyNumbers = new AtomicInteger(1);
+		Page<ApplyInfoDetailDto> applyInfoDetailDtos = applyInfoDtos.map(
+			a -> ApplyInfoDetailDto.toApplyInfoDetailDto(a, applyNumbers.getAndIncrement()));
+
+		PageOptionsDto pageOptionsDto = new PageOptionsDto(queryCommand.getPage(), queryCommand.getTake());
+		PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, (int)applyInfoDetailDtos.getTotalElements());
+
+		return MeetingGetApplyListResponseDto.of(applyInfoDetailDtos.getContent(), pageMetaDto);
 	}
 
 	@Override

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -484,8 +485,10 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
 		List<ApplyWholeInfoDto> applyWholeInfoDtos = new ArrayList<>();
 		if (applies.hasApplies(meetingId)) {
+			AtomicInteger applyNumber = new AtomicInteger(1);
 			applyWholeInfoDtos = applies.getAppliesMap().get(meetingId).stream()
-				.map(apply -> ApplyWholeInfoDto.of(apply, apply.getUser(), userId))
+				.map(apply -> ApplyWholeInfoDto.ofIncludeApplyNumber(apply, apply.getUser(), userId,
+					applyNumber.getAndIncrement()))
 				.toList();
 		}
 

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -6,6 +6,7 @@ import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -1084,7 +1085,7 @@ public class MeetingV2ServiceTest extends redisContainerBaseTest {
 		}
 
 		@Test
-		@DisplayName("모임 신청자 인원 조회시, 신청 번호 조회시 연속적인 번호가 나와야한다.")
+		@DisplayName("모임 신청자 인원 조회시, 정렬된 정보여야 하고 신청 번호 조회시 연속적인 번호가 나와야한다.")
 		void getMeeting_extract_field() {
 			//given
 			Integer meetingId = 1;
@@ -1101,6 +1102,8 @@ public class MeetingV2ServiceTest extends redisContainerBaseTest {
 			List<Integer> expectedNumbers = IntStream.rangeClosed(1, size)
 				.boxed().toList();
 
+			Assertions.assertThat(responseDto.getAppliedInfo())
+				.isSortedAccordingTo(Comparator.comparing(ApplyWholeInfoDto::getAppliedDate));
 			Assertions.assertThat(applyNumbers).isEqualTo(expectedNumbers);
 		}
 

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -7,6 +7,7 @@ import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -45,6 +46,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.request.ApplyV2UpdateStatusBodyD
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyWholeInfoDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
@@ -79,6 +81,35 @@ public class MeetingV2ServiceTest extends redisContainerBaseTest {
 
 	@Autowired
 	private ActiveGenerationProvider activeGenerationProvide;
+
+	private Meeting createMeetingFixture(Integer index, User user) {
+
+		List<ImageUrlVO> imageUrlVOList = Arrays.asList(
+			new ImageUrlVO(1, "https://example.com/image1.png"),
+			new ImageUrlVO(2, "https://example.com/image2.png")
+		);
+
+		return Meeting.builder()
+			.userId(user.getId())
+			.user(user)
+			.title("Weekly Coding Meetup" + index)
+			.category(MeetingCategory.STUDY)
+			.imageURL(imageUrlVOList)
+			.startDate(LocalDateTime.of(2024, 5, 29, 0, 0))
+			.endDate(LocalDateTime.of(2024, 5, 31, 0, 0))
+			.capacity(50)
+			.desc("Let's gather and improve our coding skills.")
+			.processDesc("Online meeting via Zoom.")
+			.mStartDate(LocalDateTime.of(2024, 5, 29, 0, 0))  // 모임 시작일: 4일 후
+			.mEndDate(LocalDateTime.of(2024, 5, 31, 0, 0))    // 모임 종료일: 5일 후
+			.leaderDesc("John Doe is an experienced software engineer.")
+			.note("Bring your best coding questions!")
+			.isMentorNeeded(true)
+			.canJoinOnlyActiveGeneration(false)
+			.createdGeneration(34)
+			.joinableParts(new MeetingJoinablePart[] {WEB, SERVER})
+			.build();
+	}
 
 	@Nested
 	class 모임_생성 {
@@ -1052,6 +1083,27 @@ public class MeetingV2ServiceTest extends redisContainerBaseTest {
 			Assertions.assertThat(responseDto.getApprovedApplyCount()).isEqualTo(2);
 		}
 
+		@Test
+		@DisplayName("모임 신청자 인원 조회시, 신청 번호 조회시 연속적인 번호가 나와야한다.")
+		void getMeeting_extract_field() {
+			//given
+			Integer meetingId = 1;
+			Integer userId = 4;
+
+			//when
+			MeetingV2GetMeetingByIdResponseDto responseDto = meetingV2Service.getMeetingById(meetingId, userId);
+
+			//then
+			int size = responseDto.getAppliedInfo().size(); // 사이즈 값 까지의 값이 하나씩 있어야 한다.
+			List<Integer> applyNumbers = responseDto.getAppliedInfo().stream()
+				.map(ApplyWholeInfoDto::getApplyNumber)
+				.toList();
+			List<Integer> expectedNumbers = IntStream.rangeClosed(1, size)
+				.boxed().toList();
+
+			Assertions.assertThat(applyNumbers).isEqualTo(expectedNumbers);
+		}
+
 	}
 
 	@Nested
@@ -1983,34 +2035,5 @@ public class MeetingV2ServiceTest extends redisContainerBaseTest {
 				.isInstanceOf(ForbiddenException.class)
 				.hasMessage(FORBIDDEN_EXCEPTION.getErrorCode());
 		}
-	}
-
-	private Meeting createMeetingFixture(Integer index, User user) {
-
-		List<ImageUrlVO> imageUrlVOList = Arrays.asList(
-			new ImageUrlVO(1, "https://example.com/image1.png"),
-			new ImageUrlVO(2, "https://example.com/image2.png")
-		);
-
-		return Meeting.builder()
-			.userId(user.getId())
-			.user(user)
-			.title("Weekly Coding Meetup" + index)
-			.category(MeetingCategory.STUDY)
-			.imageURL(imageUrlVOList)
-			.startDate(LocalDateTime.of(2024, 5, 29, 0, 0))
-			.endDate(LocalDateTime.of(2024, 5, 31, 0, 0))
-			.capacity(50)
-			.desc("Let's gather and improve our coding skills.")
-			.processDesc("Online meeting via Zoom.")
-			.mStartDate(LocalDateTime.of(2024, 5, 29, 0, 0))  // 모임 시작일: 4일 후
-			.mEndDate(LocalDateTime.of(2024, 5, 31, 0, 0))    // 모임 종료일: 5일 후
-			.leaderDesc("John Doe is an experienced software engineer.")
-			.note("Bring your best coding questions!")
-			.isMentorNeeded(true)
-			.canJoinOnlyActiveGeneration(false)
-			.createdGeneration(34)
-			.joinableParts(new MeetingJoinablePart[] {WEB, SERVER})
-			.build();
 	}
 }


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->


- playground 에서 모임 신청하였을 때 순번이라는 개념을 추가하기 위한 정보를 제공하기 위해 api 응답을 수정하였습니다.
- 추가로 모임을 신청한 사람 순번대로 정보를 제공하기 위하여 정렬하여 응답하는 작업 진행하였습니다.
   - 모집 현황 리스트
   - 신청자 관리
   - 참여자 리스트



### 결과용 api 응답! AS-IS

<img width="395" alt="image" src="https://github.com/user-attachments/assets/05a0d871-66aa-4a87-ba1c-2ebf2e115d25" />

<img width="381" alt="image" src="https://github.com/user-attachments/assets/fc4d56b5-8a80-4f91-80fe-095f5b76b8c0" />




### 결과용 api 응답! TO-BE(applyNumber 생성)


<img width="311" alt="image" src="https://github.com/user-attachments/assets/f1d226f1-0d93-41fe-8bd4-72bab1c52f0d" />

<img width="302" alt="image" src="https://github.com/user-attachments/assets/bf8d5c30-22fd-4957-a4b8-dd3559eda46d" />





## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 현재 진행하면서 사실 이름 정하기가 제일 어려웠던 거 같습니다.
- 모임 참여자에 뜰 이 순번 관련하여서 applyNumber로 잡았는데 다른 변수명 추천받슴다...
- 추가로 list 를 조회하는 api 내부에서 사용하는 dto 의 경우 확인해봤을때 queryDsl과 강하게 결합되어있는 요소가 있어 변경에 있어 다른 객체로 분리를 하는 방향으로 진행하였는데요! 이런 친구들에 대해서 제가 생각한 방식대로 변경해보긴 했지만 동훈님이시라면 이런 상황에서 어떻게 대처하실 지 궁금하네요!


## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #593 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?