### PR TITLE
refactor: redis -> 로컬 캐시로 변환

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -100,6 +100,10 @@ dependencies {
     // Slack Webhook
     implementation 'com.github.maricn:logback-slack-appender:1.4.0'
 
+    //caffeine
+    implementation("com.github.ben-manes.caffeine:caffeine:3.2.0")
+
+
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingReader.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingReader.java
@@ -1,6 +1,6 @@
 package org.sopt.makers.crew.main.entity.meeting;
 
-import org.sopt.makers.crew.main.meeting.v2.dto.redis.MeetingRedisDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.redis.MeetingCacheDto;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,8 +15,8 @@ public class MeetingReader {
 	private final MeetingRepository meetingRepository;
 
 	@Cacheable(value = "meetingCache", key = "#meetingId")
-	public MeetingRedisDto getMeetingById(Integer meetingId) {
+	public MeetingCacheDto getMeetingById(Integer meetingId) {
 		Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
-		return MeetingRedisDto.of(meeting);
+		return MeetingCacheDto.of(meeting);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingReader.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingReader.java
@@ -17,6 +17,6 @@ public class MeetingReader {
 	@Cacheable(value = "meetingCache", key = "#meetingId")
 	public MeetingCacheDto getMeetingById(Integer meetingId) {
 		Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
-		return MeetingCacheDto.of(meeting);
+		return MeetingCacheDto.from(meeting);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/external/caffeine/CacheInfo.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/external/caffeine/CacheInfo.java
@@ -1,0 +1,4 @@
+package org.sopt.makers.crew.main.external.caffeine;
+
+public record CacheInfo(String name, long size, String type) {
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/external/caffeine/CacheQueryService.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/external/caffeine/CacheQueryService.java
@@ -20,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 public class CacheQueryService {
+	private static final String CACHE_TYPE_CAFFEINE = "Caffeine";
 	private final CacheManager cacheManager;
 
 	public List<CacheInfo> getCacheList() {
@@ -31,7 +32,7 @@ public class CacheQueryService {
 				cacheInfos.add(new CacheInfo(
 					cacheName,
 					nativeCache.estimatedSize(),
-					"Caffeine"
+					CACHE_TYPE_CAFFEINE
 				));
 			}
 		});

--- a/main/src/main/java/org/sopt/makers/crew/main/external/caffeine/CacheQueryService.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/external/caffeine/CacheQueryService.java
@@ -1,0 +1,84 @@
+package org.sopt.makers.crew.main.external.caffeine;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CacheQueryService {
+	private final CacheManager cacheManager;
+
+	public List<CacheInfo> getCacheList() {
+		List<CacheInfo> cacheInfos = new ArrayList<>();
+		cacheManager.getCacheNames().forEach(cacheName -> {
+			Cache cache = cacheManager.getCache(cacheName);
+			if (cache instanceof CaffeineCache caffeineCache) {
+				com.github.benmanes.caffeine.cache.Cache<Object, Object> nativeCache = caffeineCache.getNativeCache();
+				cacheInfos.add(new CacheInfo(
+					cacheName,
+					nativeCache.estimatedSize(),
+					"Caffeine"
+				));
+			}
+		});
+		return cacheInfos;
+	}
+
+	public List<String> getCacheKeys(String cacheName) {
+		CaffeineCache cache = (CaffeineCache)cacheManager.getCache(cacheName);
+		if (Objects.isNull(cache)) {
+			return Collections.emptyList();
+		}
+
+		com.github.benmanes.caffeine.cache.Cache<Object, Object> nativeCache = cache.getNativeCache();
+		return nativeCache.asMap().keySet()
+			.stream()
+			.map(Object::toString)
+			.toList();
+	}
+
+	public Map<String, Map<String, Object>> getAllCacheContents() {
+		Map<String, Map<String, Object>> result = new HashMap<>();
+
+		cacheManager.getCacheNames().forEach(cacheName -> {
+			CaffeineCache cache = (CaffeineCache)cacheManager.getCache(cacheName);
+			com.github.benmanes.caffeine.cache.Cache<Object, Object> nativeCache = Objects.requireNonNull(cache)
+				.getNativeCache();
+
+			Map<String, Object> cacheContents = new HashMap<>();
+			nativeCache.asMap().forEach((key, value) ->
+				cacheContents.put(key.toString(), value));
+
+			result.put(cacheName, cacheContents);
+		});
+
+		return result;
+	}
+
+	public Optional<Object> getCacheValue(String cacheName, Integer key) {
+		return getNativeCache(cacheName)
+			.map(nativeCache -> nativeCache.asMap().get(key));
+	}
+
+	private Optional<com.github.benmanes.caffeine.cache.Cache<Object, Object>> getNativeCache(String cacheName) {
+		Cache cache = cacheManager.getCache(cacheName);
+		if (cache instanceof CaffeineCache caffeineCache) {
+			return Optional.of(caffeineCache.getNativeCache());
+		}
+		return Optional.empty();
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/external/caffeine/CachesEndpointExtension.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/external/caffeine/CachesEndpointExtension.java
@@ -1,18 +1,25 @@
 package org.sopt.makers.crew.main.external.caffeine;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.Selector;
+import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.caffeine.CaffeineCache;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @Endpoint(id = "cachecontents")
+@Slf4j
 @RequiredArgsConstructor
 public class CachesEndpointExtension {
 
@@ -32,8 +39,57 @@ public class CachesEndpointExtension {
 
 			result.put(cacheName, cacheContents);
 		});
+		log.info("result: {}", result.get("meetingCache"));
 
 		return result;
 	}
 
+	@ReadOperation
+	public Object handleSingleSelector(@Selector String selector) {
+		if ("caches".equals(selector)) {
+			List<CacheInfo> cacheInfos = new ArrayList<>();
+			cacheManager.getCacheNames().forEach(cacheName -> {
+				Cache cache = cacheManager.getCache(cacheName);
+				if (cache instanceof CaffeineCache) {
+					CaffeineCache caffeineCache = (CaffeineCache)cache;
+					com.github.benmanes.caffeine.cache.Cache<Object, Object> nativeCache = caffeineCache.getNativeCache();
+
+					cacheInfos.add(new CacheInfo(
+						cacheName,
+						nativeCache.estimatedSize(),
+						"Caffeine"
+					));
+				}
+			});
+			return cacheInfos;
+		} else {
+			// 특정 캐시의 키 목록 조회
+			CaffeineCache cache = (CaffeineCache)cacheManager.getCache(selector); // key
+			if (Objects.isNull(cache)) {
+				return null;
+			}
+
+			com.github.benmanes.caffeine.cache.Cache<Object, Object> nativeCache = cache.getNativeCache();
+
+			log.info("cacheName: {}", cache);
+			log.info("nativeCache: {}", nativeCache.asMap().get(90).toString());
+			return nativeCache.asMap().keySet()
+				.stream()
+				.map(Object::toString)
+				.toList();
+		}
+	}
+
+	@ReadOperation
+	public Object retrieveCacheInfo(@Selector String cacheName, @Selector Integer key) {
+
+		CaffeineCache cache = (CaffeineCache)cacheManager.getCache(cacheName);// key
+
+		com.github.benmanes.caffeine.cache.Cache<Object, Object> nativeCache = cache.getNativeCache();
+
+		return nativeCache.asMap().get(key);
+	}
 }
+
+
+

--- a/main/src/main/java/org/sopt/makers/crew/main/external/caffeine/CachesEndpointExtension.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/external/caffeine/CachesEndpointExtension.java
@@ -1,0 +1,39 @@
+package org.sopt.makers.crew.main.external.caffeine;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@Endpoint(id = "cachecontents")
+@RequiredArgsConstructor
+public class CachesEndpointExtension {
+
+	private final CacheManager cacheManager;
+
+	@ReadOperation
+	public Map<String, Map<String, Object>> cachesWithValues() {
+		Map<String, Map<String, Object>> result = new HashMap<>();
+
+		cacheManager.getCacheNames().forEach(cacheName -> {
+			CaffeineCache cache = (CaffeineCache)cacheManager.getCache(cacheName);
+			com.github.benmanes.caffeine.cache.Cache<Object, Object> nativeCache = cache.getNativeCache();
+
+			Map<String, Object> cacheContents = new HashMap<>();
+			nativeCache.asMap().forEach((key, value) ->
+				cacheContents.put(key.toString(), value));
+
+			result.put(cacheName, cacheContents);
+		});
+
+		return result;
+	}
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/external/caffeine/CachesEndpointExtension.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/external/caffeine/CachesEndpointExtension.java
@@ -1,17 +1,10 @@
 package org.sopt.makers.crew.main.external.caffeine;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
-import org.springframework.cache.Cache;
-import org.springframework.cache.CacheManager;
-import org.springframework.cache.caffeine.CaffeineCache;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -23,71 +16,26 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class CachesEndpointExtension {
 
-	private final CacheManager cacheManager;
+	private final CacheQueryService cacheQueryService;
 
 	@ReadOperation
 	public Map<String, Map<String, Object>> cachesWithValues() {
-		Map<String, Map<String, Object>> result = new HashMap<>();
+		return cacheQueryService.getAllCacheContents();
 
-		cacheManager.getCacheNames().forEach(cacheName -> {
-			CaffeineCache cache = (CaffeineCache)cacheManager.getCache(cacheName);
-			com.github.benmanes.caffeine.cache.Cache<Object, Object> nativeCache = cache.getNativeCache();
-
-			Map<String, Object> cacheContents = new HashMap<>();
-			nativeCache.asMap().forEach((key, value) ->
-				cacheContents.put(key.toString(), value));
-
-			result.put(cacheName, cacheContents);
-		});
-		log.info("result: {}", result.get("meetingCache"));
-
-		return result;
 	}
 
 	@ReadOperation
 	public Object handleSingleSelector(@Selector String selector) {
 		if ("caches".equals(selector)) {
-			List<CacheInfo> cacheInfos = new ArrayList<>();
-			cacheManager.getCacheNames().forEach(cacheName -> {
-				Cache cache = cacheManager.getCache(cacheName);
-				if (cache instanceof CaffeineCache) {
-					CaffeineCache caffeineCache = (CaffeineCache)cache;
-					com.github.benmanes.caffeine.cache.Cache<Object, Object> nativeCache = caffeineCache.getNativeCache();
-
-					cacheInfos.add(new CacheInfo(
-						cacheName,
-						nativeCache.estimatedSize(),
-						"Caffeine"
-					));
-				}
-			});
-			return cacheInfos;
-		} else {
-			// 특정 캐시의 키 목록 조회
-			CaffeineCache cache = (CaffeineCache)cacheManager.getCache(selector); // key
-			if (Objects.isNull(cache)) {
-				return null;
-			}
-
-			com.github.benmanes.caffeine.cache.Cache<Object, Object> nativeCache = cache.getNativeCache();
-
-			log.info("cacheName: {}", cache);
-			log.info("nativeCache: {}", nativeCache.asMap().get(90).toString());
-			return nativeCache.asMap().keySet()
-				.stream()
-				.map(Object::toString)
-				.toList();
+			return cacheQueryService.getCacheList();
 		}
+		return cacheQueryService.getCacheKeys(selector);
 	}
 
 	@ReadOperation
 	public Object retrieveCacheInfo(@Selector String cacheName, @Selector Integer key) {
-
-		CaffeineCache cache = (CaffeineCache)cacheManager.getCache(cacheName);// key
-
-		com.github.benmanes.caffeine.cache.Cache<Object, Object> nativeCache = cache.getNativeCache();
-
-		return nativeCache.asMap().get(key);
+		return cacheQueryService.getCacheValue(cacheName, key)
+			.orElse(null);
 	}
 }
 

--- a/main/src/main/java/org/sopt/makers/crew/main/external/caffeine/CaffeineConfig.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/external/caffeine/CaffeineConfig.java
@@ -1,0 +1,10 @@
+package org.sopt.makers.crew.main.external.caffeine;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CaffeineConfig {
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/external/redis/RedisConfig.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/external/redis/RedisConfig.java
@@ -1,77 +1,60 @@
 package org.sopt.makers.crew.main.external.redis;
 
-import java.time.Duration;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.cache.RedisCacheManager;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.RedisSerializationContext;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 @Configuration
-@EnableCaching
+//@EnableCaching
 public class RedisConfig {
 
-	@Bean
-	public RedisConnectionFactory redisConnectionFactory(RedisProperties redisProperties) {
-		return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
-	}
-
-	@Bean
-	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
-		RedisTemplate<String, Object> template = new RedisTemplate<>();
-		template.setConnectionFactory(redisConnectionFactory);
-
-		ObjectMapper objectMapper = new ObjectMapper();
-		objectMapper.registerModule(new JavaTimeModule());
-		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식
-		objectMapper.activateDefaultTyping(objectMapper.getPolymorphicTypeValidator(),
-			ObjectMapper.DefaultTyping.NON_FINAL); // 타입 정보 추가
-
-		StringRedisSerializer stringSerializer = new StringRedisSerializer();
-		GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
-
-		// Key serializer 설정
-		template.setKeySerializer(stringSerializer);
-		template.setHashKeySerializer(stringSerializer);
-
-		// Value serializer 설정
-		template.setValueSerializer(jsonSerializer);
-		template.setHashValueSerializer(jsonSerializer);
-
-		template.afterPropertiesSet();
-		return template;
-	}
-
-	@Bean
-	public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
-		// 동일한 직렬화 설정 공유
-		ObjectMapper objectMapper = new ObjectMapper();
-		objectMapper.registerModule(new JavaTimeModule());
-		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식
-		objectMapper.activateDefaultTyping(objectMapper.getPolymorphicTypeValidator(),
-			ObjectMapper.DefaultTyping.NON_FINAL); // 타입 정보 추가
-
-		GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
-
-		RedisCacheConfiguration defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
-			.entryTtl(Duration.ofHours(24))
-			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-			.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer));
-
-		return RedisCacheManager.builder(redisConnectionFactory)
-			.cacheDefaults(defaultCacheConfig)
-			.build();
-	}
+	// @Bean
+	// public RedisConnectionFactory redisConnectionFactory(RedisProperties redisProperties) {
+	// 	return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+	// }
+	//
+	// @Bean
+	// public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+	// 	RedisTemplate<String, Object> template = new RedisTemplate<>();
+	// 	template.setConnectionFactory(redisConnectionFactory);
+	//
+	// 	ObjectMapper objectMapper = new ObjectMapper();
+	// 	objectMapper.registerModule(new JavaTimeModule());
+	// 	objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식
+	// 	objectMapper.activateDefaultTyping(objectMapper.getPolymorphicTypeValidator(),
+	// 		ObjectMapper.DefaultTyping.NON_FINAL); // 타입 정보 추가
+	//
+	// 	StringRedisSerializer stringSerializer = new StringRedisSerializer();
+	// 	GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+	//
+	// 	// Key serializer 설정
+	// 	template.setKeySerializer(stringSerializer);
+	// 	template.setHashKeySerializer(stringSerializer);
+	//
+	// 	// Value serializer 설정
+	// 	template.setValueSerializer(jsonSerializer);
+	// 	template.setHashValueSerializer(jsonSerializer);
+	//
+	// 	template.afterPropertiesSet();
+	// 	return template;
+	// }
+	//
+	// @Bean
+	// public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+	// 	// 동일한 직렬화 설정 공유
+	// 	ObjectMapper objectMapper = new ObjectMapper();
+	// 	objectMapper.registerModule(new JavaTimeModule());
+	// 	objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식
+	// 	objectMapper.activateDefaultTyping(objectMapper.getPolymorphicTypeValidator(),
+	// 		ObjectMapper.DefaultTyping.NON_FINAL); // 타입 정보 추가
+	//
+	// 	GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+	//
+	// 	RedisCacheConfiguration defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+	// 		.entryTtl(Duration.ofHours(24))
+	// 		.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+	// 		.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer));
+	//
+	// 	return RedisCacheManager.builder(redisConnectionFactory)
+	// 		.cacheDefaults(defaultCacheConfig)
+	// 		.build();
+	// }
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/global/config/SecurityConfig.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/config/SecurityConfig.java
@@ -28,12 +28,6 @@ import lombok.RequiredArgsConstructor;
 @EnableWebSecurity
 public class SecurityConfig {
 
-	private final JwtTokenProvider jwtTokenProvider;
-	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-
-	@Value("${management.endpoints.web.base-path}")
-	private String actuatorEndPoint;
-
 	private static final String[] SWAGGER_URL = {
 		"/swagger-resources/**",
 		"/favicon.ico",
@@ -44,6 +38,10 @@ public class SecurityConfig {
 		"/docs/swagger-ui/index.html",
 		"/swagger-ui/swagger-ui.css",
 	};
+	private final JwtTokenProvider jwtTokenProvider;
+	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+	@Value("${management.endpoints.web.base-path}")
+	private String actuatorEndPoint;
 
 	private String[] getAuthWhitelist() {
 		return new String[] {
@@ -54,6 +52,9 @@ public class SecurityConfig {
 			"/auth/v2/**",
 			actuatorEndPoint + "/health",
 			actuatorEndPoint + "/prometheus",
+			actuatorEndPoint + "/caches/**",
+			actuatorEndPoint + "/cachecontents",
+			actuatorEndPoint + "/metrics/**",
 			"/internal/**"
 		};
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/global/config/SecurityConfig.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
 			actuatorEndPoint + "/health",
 			actuatorEndPoint + "/prometheus",
 			actuatorEndPoint + "/caches/**",
-			actuatorEndPoint + "/cachecontents",
+			actuatorEndPoint + "/cachecontents/**",
 			actuatorEndPoint + "/metrics/**",
 			"/internal/**"
 		};

--- a/main/src/main/java/org/sopt/makers/crew/main/global/config/SecurityConfig.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/config/SecurityConfig.java
@@ -27,7 +27,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
-
 	private static final String[] SWAGGER_URL = {
 		"/swagger-resources/**",
 		"/favicon.ico",

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/MeetingCacheDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/MeetingCacheDto.java
@@ -95,7 +95,7 @@ public class MeetingCacheDto {
 		this.joinableParts = joinableParts;
 	}
 
-	public static MeetingCacheDto of(Meeting meeting) {
+	public static MeetingCacheDto from(Meeting meeting) {
 		return new MeetingCacheDto(meeting.getId(), meeting.getUserId(), meeting.getTitle(), meeting.getCategory(),
 			meeting.getImageURL(), meeting.getStartDate(), meeting.getEndDate(), meeting.getCapacity(),
 			meeting.getDesc(), meeting.getProcessDesc(), meeting.getmStartDate(), meeting.getmEndDate(),

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/MeetingCacheDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/MeetingCacheDto.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import lombok.Getter;
 
 @Getter
-public class MeetingRedisDto {
+public class MeetingCacheDto {
 	private final Integer id;
 	private final Integer userId;
 	private final String title;
@@ -53,23 +53,8 @@ public class MeetingRedisDto {
 	private final Integer targetActiveGeneration;
 	private final MeetingJoinablePart[] joinableParts;
 
-	public Meeting toEntity() {
-		return new Meeting(null, userId, title, category, imageURL, startDate, endDate, capacity, desc, processDesc,
-			mStartDate, mEndDate, leaderDesc, note, isMentorNeeded, canJoinOnlyActiveGeneration,
-			createdGeneration, targetActiveGeneration, joinableParts);
-	}
-
-	public static MeetingRedisDto of(Meeting meeting) {
-		return new MeetingRedisDto(meeting.getId(), meeting.getUserId(), meeting.getTitle(), meeting.getCategory(),
-			meeting.getImageURL(), meeting.getStartDate(), meeting.getEndDate(), meeting.getCapacity(),
-			meeting.getDesc(), meeting.getProcessDesc(), meeting.getmStartDate(), meeting.getmEndDate(),
-			meeting.getLeaderDesc(), meeting.getNote(), meeting.getIsMentorNeeded(),
-			meeting.getCanJoinOnlyActiveGeneration(), meeting.getCreatedGeneration(),
-			meeting.getTargetActiveGeneration(), meeting.getJoinableParts());
-	}
-
 	@JsonCreator
-	public MeetingRedisDto(
+	public MeetingCacheDto(
 		@JsonProperty("id") Integer id,
 		@JsonProperty("userId") Integer userId,
 		@JsonProperty("title") String title,
@@ -108,6 +93,21 @@ public class MeetingRedisDto {
 		this.createdGeneration = createdGeneration;
 		this.targetActiveGeneration = targetActiveGeneration;
 		this.joinableParts = joinableParts;
+	}
+
+	public static MeetingCacheDto of(Meeting meeting) {
+		return new MeetingCacheDto(meeting.getId(), meeting.getUserId(), meeting.getTitle(), meeting.getCategory(),
+			meeting.getImageURL(), meeting.getStartDate(), meeting.getEndDate(), meeting.getCapacity(),
+			meeting.getDesc(), meeting.getProcessDesc(), meeting.getmStartDate(), meeting.getmEndDate(),
+			meeting.getLeaderDesc(), meeting.getNote(), meeting.getIsMentorNeeded(),
+			meeting.getCanJoinOnlyActiveGeneration(), meeting.getCreatedGeneration(),
+			meeting.getTargetActiveGeneration(), meeting.getJoinableParts());
+	}
+
+	public Meeting toEntity() {
+		return new Meeting(null, userId, title, category, imageURL, startDate, endDate, capacity, desc, processDesc,
+			mStartDate, mEndDate, leaderDesc, note, isMentorNeeded, canJoinOnlyActiveGeneration,
+			createdGeneration, targetActiveGeneration, joinableParts);
 	}
 
 	public LocalDateTime getmStartDate() {

--- a/main/src/main/resources/application-dev.yml
+++ b/main/src/main/resources/application-dev.yml
@@ -27,10 +27,16 @@ spring:
         format_sql: ture
       dialect: org.hibernate.dialect.PostgreSQLDialect
       storage_engine: innodb
+  cache:
+    type: caffeine
+    caffeine:
+      spec: maximumSize=500,expireAfterWrite=24h
   data:
-    redis:
-      host: redis
-      port: 6379
+#    redis:
+#      host: localhost
+#      port: 6379
+
+
 
 jwt:
   header: Authorization
@@ -86,19 +92,23 @@ management:
         exclude: "*"
     web:
       exposure:
-        include: info, health, prometheus
+        include: info, health, prometheus,caches,cachecontents
       base-path: ${ACTUATOR_PATH}
   endpoint:
     health:
       enabled: true
     info:
       enabled: true
-    prometheus:
-      enabled: true
-  prometheus:
-    metrics:
-      export:
+    caches:
         enabled: true
+    cachecontents:
+      enabled: true
+    metrics:
+        enabled: true
+    prometheus:
+      metrics:
+        export:
+          enabled: true
 
 custom:
   paths:

--- a/main/src/main/resources/application-dev.yml
+++ b/main/src/main/resources/application-dev.yml
@@ -88,7 +88,7 @@ management:
         exclude: "*"
     web:
       exposure:
-        include: info, health, prometheus,caches,cachecontents
+        include: info, health, prometheus, caches, cachecontents
       base-path: ${ACTUATOR_PATH}
   endpoint:
     health:
@@ -96,7 +96,7 @@ management:
     info:
       enabled: true
     caches:
-        enabled: true
+      enabled: true
     cachecontents:
       enabled: true
     metrics:

--- a/main/src/main/resources/application-dev.yml
+++ b/main/src/main/resources/application-dev.yml
@@ -31,10 +31,6 @@ spring:
     type: caffeine
     caffeine:
       spec: maximumSize=500,expireAfterWrite=24h
-  data:
-#    redis:
-#      host: localhost
-#      port: 6379
 
 
 

--- a/main/src/test/java/org/sopt/makers/crew/main/external/CaffeineCacheConfig.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/external/CaffeineCacheConfig.java
@@ -1,0 +1,26 @@
+package org.sopt.makers.crew.main.external;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+@TestConfiguration
+public class CaffeineCacheConfig {
+
+	@Bean
+	public CacheManager cacheManager() {
+		CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+
+		cacheManager.setCaffeine(Caffeine.newBuilder()
+			.expireAfterWrite(10, TimeUnit.MINUTES)
+			.maximumSize(100));
+
+		return cacheManager;
+	}
+	
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/external/CaffeineTestConfig.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/external/CaffeineTestConfig.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Bean;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
 @TestConfiguration
-public class CaffeineCacheConfig {
+public class CaffeineTestConfig {
 
 	@Bean
 	public CacheManager cacheManager() {
@@ -22,5 +22,5 @@ public class CaffeineCacheConfig {
 
 		return cacheManager;
 	}
-	
+
 }

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -32,7 +32,7 @@ import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.entity.user.UserRepository;
 import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
-import org.sopt.makers.crew.main.external.redisContainerBaseTest;
+import org.sopt.makers.crew.main.external.CaffeineCacheConfig;
 import org.sopt.makers.crew.main.global.annotation.IntegratedTest;
 import org.sopt.makers.crew.main.global.dto.MeetingCreatorDto;
 import org.sopt.makers.crew.main.global.dto.MeetingResponseDto;
@@ -54,13 +54,15 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingR
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingByIdResponseDto;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlGroup;
 
 @IntegratedTest
-public class MeetingV2ServiceTest extends redisContainerBaseTest {
+@Import(CaffeineCacheConfig.class)
+public class MeetingV2ServiceTest {
 
 	@Autowired
 	private MeetingV2Service meetingV2Service;

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -32,7 +32,7 @@ import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.entity.user.UserRepository;
 import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
-import org.sopt.makers.crew.main.external.CaffeineCacheConfig;
+import org.sopt.makers.crew.main.external.CaffeineTestConfig;
 import org.sopt.makers.crew.main.global.annotation.IntegratedTest;
 import org.sopt.makers.crew.main.global.dto.MeetingCreatorDto;
 import org.sopt.makers.crew.main.global.dto.MeetingResponseDto;
@@ -61,7 +61,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlGroup;
 
 @IntegratedTest
-@Import(CaffeineCacheConfig.class)
+@Import(CaffeineTestConfig.class)
 public class MeetingV2ServiceTest {
 
 	@Autowired


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->

redis -> local cache(caffiene) 으로 변환하는 과정을 수행해요!

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

이전에 회의 하였던것처럼 현재 진행하였습니다.

앞에 actuator path + 아래와 같은 path 들로 조회할 수 있습니다.
- cachecontents/caches -> cache key 종류 확인
- cachecontents/캐시명 -> 가지고 있는 id들 조회
- cachecontents/캐시명/id -> 해당 캐시 단건 조회


### cachecontents/caches

![image](https://github.com/user-attachments/assets/ece7037a-d953-4ee1-9337-84944a70bc6f)


### cachecontents/캐시명

![image](https://github.com/user-attachments/assets/0fc802a6-ec43-4c41-8e00-e41c5b92ed0b)


### cachecontents/캐시명/id

![image](https://github.com/user-attachments/assets/8fc26e57-3eeb-4557-9ff4-24762bc7dea0)


## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #596 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?