### PR TITLE
fix: 모임 삭제 시 관련된 모든 캐시 항목을 제거하도록 수정

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserReader.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserReader.java
@@ -16,7 +16,7 @@ public class UserReader {
 
 	@Cacheable(value = "meetingLeaderCache", key = "#userId")
 	public MeetingCreatorDto getMeetingLeader(Integer userId) {
-		return MeetingCreatorDto.of(userRepository.findByIdOrThrow(userId));
+		return MeetingCreatorDto.from(userRepository.findByIdOrThrow(userId));
 	}
 
 	@Cacheable(value = "orgIdCache", key = "'allOrgIds'")

--- a/main/src/main/java/org/sopt/makers/crew/main/global/dto/MeetingCreatorDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/dto/MeetingCreatorDto.java
@@ -38,7 +38,7 @@ public class MeetingCreatorDto {
 	@NotNull
 	private final String phone;
 
-	public static MeetingCreatorDto of(User user) {
+	public static MeetingCreatorDto from(User user) {
 		return new MeetingCreatorDto(user.getId(), user.getName(), user.getOrgId(), user.getProfileImage(),
 			user.getActivities(), user.getPhone());
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/global/dto/MeetingResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/dto/MeetingResponseDto.java
@@ -83,7 +83,7 @@ public class MeetingResponseDto {
 
 	public static MeetingResponseDto of(Meeting meeting, User meetingCreator, int approvedCount, LocalDateTime now,
 		Integer activeGeneration) {
-		MeetingCreatorDto creatorDto = MeetingCreatorDto.of(meetingCreator);
+		MeetingCreatorDto creatorDto = MeetingCreatorDto.from(meetingCreator);
 		boolean canJoinOnlyActiveGeneration =
 			Objects.equals(meeting.getTargetActiveGeneration(), activeGeneration)
 				&& meeting.getCanJoinOnlyActiveGeneration();

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -326,6 +326,11 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 	 * 		  3. meeting 삭제
 	 * */
 
+	@Caching(evict = {
+		@CacheEvict(value = "meetingCache", key = "#meetingId"),
+		@CacheEvict(value = "meetingLeaderCache", key = "#userId"),
+		@CacheEvict(value = "coLeadersCache", key = "#meetingId")
+	})
 	@Override
 	@Transactional
 	public void deleteMeeting(Integer meetingId, Integer userId) {

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
@@ -1,6 +1,7 @@
 package org.sopt.makers.crew.main.user.v2.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -44,7 +45,7 @@ public record MeetingV2GetCreatedMeetingByUserResponseDto(
 	@NotNull
 	@Getter(AccessLevel.NONE)
 	boolean isCoLeader,
-	/**
+	/*
 	 * 썸네일 이미지
 	 *
 	 * @apiNote 여러개여도 첫번째 이미지만 사용
@@ -76,7 +77,7 @@ public record MeetingV2GetCreatedMeetingByUserResponseDto(
 ) {
 	public static MeetingV2GetCreatedMeetingByUserResponseDto of(Meeting meeting, boolean isCoLeader, int approvedCount,
 		LocalDateTime now, Integer activeGeneration) {
-		MeetingCreatorDto creatorDto = MeetingCreatorDto.of(meeting.getUser());
+		MeetingCreatorDto creatorDto = MeetingCreatorDto.from(meeting.getUser());
 		boolean canJoinOnlyActiveGeneration = Objects.equals(meeting.getTargetActiveGeneration(), activeGeneration)
 			&& meeting.getCanJoinOnlyActiveGeneration();
 
@@ -87,4 +88,62 @@ public record MeetingV2GetCreatedMeetingByUserResponseDto(
 			creatorDto, approvedCount, approvedCount);
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		MeetingV2GetCreatedMeetingByUserResponseDto that = (MeetingV2GetCreatedMeetingByUserResponseDto)o;
+		return status == that.status &&
+			isCoLeader == that.isCoLeader &&
+			capacity == that.capacity &&
+			appliedCount == that.appliedCount &&
+			approvedCount == that.approvedCount &&
+			Objects.equals(id, that.id) &&
+			Objects.equals(title, that.title) &&
+			Objects.equals(targetActiveGeneration, that.targetActiveGeneration) &&
+			Arrays.equals(joinableParts, that.joinableParts) &&
+			Objects.equals(category, that.category) &&
+			Objects.equals(canJoinOnlyActiveGeneration, that.canJoinOnlyActiveGeneration) &&
+			Objects.equals(imageURL, that.imageURL) &&
+			Objects.equals(isMentorNeeded, that.isMentorNeeded) &&
+			Objects.equals(mStartDate, that.mStartDate) &&
+			Objects.equals(mEndDate, that.mEndDate) &&
+			Objects.equals(user, that.user);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = Objects.hash(id, title, targetActiveGeneration, category, canJoinOnlyActiveGeneration,
+			status, isCoLeader, imageURL, isMentorNeeded, mStartDate, mEndDate,
+			capacity, user, appliedCount, approvedCount);
+		result = 31 * result + Arrays.hashCode(joinableParts);
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "MeetingV2GetCreatedMeetingByUserResponseDto[" +
+			"id=" + id + ", " +
+			"title=" + title + ", " +
+			"targetActiveGeneration=" + targetActiveGeneration + ", " +
+			"joinableParts=" + Arrays.toString(joinableParts) + ", " +
+			"category=" + category + ", " +
+			"canJoinOnlyActiveGeneration=" + canJoinOnlyActiveGeneration + ", " +
+			"status=" + status + ", " +
+			"isCoLeader=" + isCoLeader + ", " +
+			"imageURL=" + imageURL + ", " +
+			"isMentorNeeded=" + isMentorNeeded + ", " +
+			"mStartDate=" + mStartDate + ", " +
+			"mEndDate=" + mEndDate + ", " +
+			"capacity=" + capacity + ", " +
+			"user=" + user + ", " +
+			"appliedCount=" + appliedCount + ", " +
+			"approvedCount=" + approvedCount + "]";
+	}
+
+	public boolean getIsCoLeader() {
+		return isCoLeader;
+	}
 }


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->

- 모임 삭제 시 관련된 모든 캐시 항목을 제거하도록 수정했습니다. (이슈에 이유가 정리되어 있습니다)
- 위 작업을 진행하며 조그마한 개선 작업도 진행했습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

### record에 배열을 쓸 때 조심해야 한다.

https://until.blog/@octoping/record%EC%97%90%EC%84%9C-%EB%B0%B0%EC%97%B4-%EC%82%AC%EC%9A%A9%ED%95%98%EC%A7%80-%EC%95%8A%EA%B8%B0

- DTO들을 보다가 `Override equals, hashCode and toString to consider array's content in the method`라는 경고가 `MeetingV2GetCreatedMeetingByUserResponseDto`가 뜨는 것을 보고 궁금해서 조사를 해보았습니다.
- 그 결과, 흥미로운 사실을 알게 되었는데요! 배열(Array)은 참조 타입이기 때문에 Objects.equals()를 사용하면 참조가 같을 때만 true를 반환합니다. 즉, 배열의 내용을 기준으로 비교하지 않기 때문에 record의 equals 연산은 우리가 기대하던 대로 동작하지 않게 됩니다.
- 따라서 equals, hashCode, toString 메서드를 직접 오버라이드하여 배열 타입의 동등성을 정확히 판단할 수 있도록 수정했습니다.
- List 인터페이스를 구현한 컬렉션(ArrayList, LinkedList 등)은 기본적으로 내용 기반으로 equals()와 hashCode()를 구현하기에 앞으로 Record에서는 배열 사용을 지양하는게 좋을 것 같다는 생각이 들었습니다 ㅎㅎ


## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #555 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?