### PR TITLE
fix: Flash 리더 정보 동기화 로직을 이벤트 기반 비동기 처리 방식으로 개선

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/flash/v2/dto/event/FlashLeaderSyncEventDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/flash/v2/dto/event/FlashLeaderSyncEventDto.java
@@ -1,0 +1,11 @@
+package org.sopt.makers.crew.main.flash.v2.dto.event;
+
+public record FlashLeaderSyncEventDto(
+	Integer meetingId,
+	Integer oldLeaderUserId,
+	Integer newLeaderUserId
+) {
+	public static FlashLeaderSyncEventDto of(Integer meetingId, Integer oldLeaderUserId, Integer newLeaderUserId) {
+		return new FlashLeaderSyncEventDto(meetingId, oldLeaderUserId, newLeaderUserId);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/flash/v2/event/FlashLeaderSyncEventListener.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/flash/v2/event/FlashLeaderSyncEventListener.java
@@ -49,8 +49,8 @@ public class FlashLeaderSyncEventListener {
 			flashRepository.save(flash);
 
 			meetingV2Service.evictMeetingCache(event.meetingId());
-			meetingV2Service.evictLeaderCache(event.oldLeaderUserId());
-			meetingV2Service.evictLeaderCache(event.newLeaderUserId());
+			meetingV2Service.evictMeetingLeaderCache(event.oldLeaderUserId());
+			meetingV2Service.evictMeetingLeaderCache(event.newLeaderUserId());
 
 			log.info("Flash 리더 업데이트 완료 - meetingId: {}, newLeaderId: {}",
 				event.meetingId(), event.newLeaderUserId());

--- a/main/src/main/java/org/sopt/makers/crew/main/flash/v2/event/FlashLeaderSyncEventListener.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/flash/v2/event/FlashLeaderSyncEventListener.java
@@ -1,0 +1,62 @@
+package org.sopt.makers.crew.main.flash.v2.event;
+
+import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
+
+import java.util.Objects;
+
+import org.sopt.makers.crew.main.entity.flash.Flash;
+import org.sopt.makers.crew.main.entity.flash.FlashRepository;
+import org.sopt.makers.crew.main.flash.v2.dto.event.FlashLeaderSyncEventDto;
+import org.sopt.makers.crew.main.global.exception.NotFoundException;
+import org.sopt.makers.crew.main.meeting.v2.service.MeetingV2Service;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FlashLeaderSyncEventListener {
+
+	private final MeetingV2Service meetingV2Service;
+	private final FlashRepository flashRepository;
+
+	@Async("taskExecutor")
+	@Transactional
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleFlashLeaderSyncEvent(FlashLeaderSyncEventDto event) {
+		log.info("FlashLeaderSyncEvent 수신 - meetingId: {}, oldLeaderId: {}, newLeaderId: {}",
+			event.meetingId(), event.oldLeaderUserId(), event.newLeaderUserId());
+
+		try {
+			synchronizeFlashLeader(event);
+		} catch (Exception e) {
+			log.error("Flash 리더 동기화 중 오류 발생 - meetingId: {}", event.meetingId(), e);
+		}
+	}
+
+	private void synchronizeFlashLeader(FlashLeaderSyncEventDto event) {
+		Flash flash = flashRepository.findByMeetingId(event.meetingId())
+			.orElseThrow(() -> new NotFoundException(NOT_FOUND_FLASH.getErrorCode()));
+
+		if (!Objects.equals(flash.getLeaderUserId(), event.newLeaderUserId())) {
+			flash.updateLeaderUserId(event.newLeaderUserId());
+			flashRepository.save(flash);
+
+			meetingV2Service.evictMeetingCache(event.meetingId());
+			meetingV2Service.evictLeaderCache(event.oldLeaderUserId());
+			meetingV2Service.evictLeaderCache(event.newLeaderUserId());
+
+			log.info("Flash 리더 업데이트 완료 - meetingId: {}, newLeaderId: {}",
+				event.meetingId(), event.newLeaderUserId());
+		} else {
+			log.info("이미 리더가 동기화되어 있습니다 - meetingId: {}, leaderId: {}",
+				event.meetingId(), event.newLeaderUserId());
+		}
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -62,5 +62,7 @@ public interface MeetingV2Service {
 
 	MeetingLeaderUserIdDto getMeetingLeaderUserIdByMeetingId(Integer meetingId);
 
-	void evictMeetingRelatedCaches(Integer meetingId, Integer userId);
+	void evictMeetingCache(Integer meetingId);
+
+	void evictLeaderCache(Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -64,5 +64,5 @@ public interface MeetingV2Service {
 
 	void evictMeetingCache(Integer meetingId);
 
-	void evictLeaderCache(Integer userId);
+	void evictMeetingLeaderCache(Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -547,7 +547,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 	@Caching(evict = {
 		@CacheEvict(value = "meetingLeaderCache", key = "#userId"),
 	})
-	public void evictLeaderCache(Integer userId) {
+	public void evictMeetingLeaderCache(Integer userId) {
 	}
 
 	private PageableStrategy getPageableStrategy(MeetingV2GetAllMeetingQueryDto queryCommand) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -539,9 +539,15 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 	@Override
 	@Caching(evict = {
 		@CacheEvict(value = "meetingCache", key = "#meetingId"),
+	})
+	public void evictMeetingCache(Integer meetingId) {
+	}
+
+	@Override
+	@Caching(evict = {
 		@CacheEvict(value = "meetingLeaderCache", key = "#userId"),
 	})
-	public void evictMeetingRelatedCaches(Integer meetingId, Integer userId) {
+	public void evictLeaderCache(Integer userId) {
 	}
 
 	private PageableStrategy getPageableStrategy(MeetingV2GetAllMeetingQueryDto queryCommand) {


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->

### 작업
- 번쩍 상세 조회 시 userId update로직을 별도의 이벤트 클래로 분리를 진행하였습니다.
- 기존에 Transactional(readOnly = true)옵션에서 getFlashDetail 메서드가 호출되는데, private 메서드는 호출하는 상위 메서드의 트랜잭션 속성을 상속받기에 readOnly 속성을 그대로 가져오게 되는 문제가 있었습니다.
- 따라서 번쩍 상세 조회 시, userId 정합성 문제가 발생하면 이를 이벤트로 별도의 쓰레드에서 userId를 수정하도록 변경하였습니다.

### 이벤트를 사용한 이유
- 처음에는 readOnly 특성으로 인해 userId update 로직을 새로운 서비스로 분리하고 이를 Transactional + public으로 열어두어 호출하도록 할 생각이었습니다.
- 하지만, 이는 결국 상세 조회 response 시간에 영향을 받게 되고, Transactional(readOnly = true)의 효과를 누리지 못한다고 판단했습니다.
- 비동기 이벤트 방식(이벤트 리스너 + AFTER_COMMIT + Async)을 사용함으로써 사용자 응답 시간에 영향을 주지 않으면서도 데이터 정합성을 유지할 수 있습니다.
- 또한, 이벤트 방식은 관심사 분리 원칙에도 부합합니다. 조회 로직은 조회에만 집중하고, 동기화 로직은 별도로 처리됩니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #626 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?