### PR TITLE
fix: actuator 설정 수정

### DIFF
--- a/main/src/main/resources/application-dev.yml
+++ b/main/src/main/resources/application-dev.yml
@@ -89,23 +89,21 @@ management:
         exclude: "*"
     web:
       exposure:
-        include: info, health, prometheus, caches, cachecontents
+        include: health, info, metrics, prometheus, caches, cachecontents
       base-path: ${ACTUATOR_PATH}
   endpoint:
     health:
       enabled: true
     info:
       enabled: true
+    metrics:
+      enabled: true
+    prometheus:
+      enabled: true
     caches:
       enabled: true
     cachecontents:
       enabled: true
-    metrics:
-      enabled: true
-    prometheus:
-      metrics:
-        export:
-          enabled: true
 
 custom:
   paths:

--- a/main/src/main/resources/application-prod.yml
+++ b/main/src/main/resources/application-prod.yml
@@ -88,23 +88,21 @@ management:
         exclude: "*"
     web:
       exposure:
-        include: info, health, prometheus, caches, cachecontents
+        include: health, info, metrics, prometheus, caches, cachecontents
       base-path: ${ACTUATOR_PATH}
   endpoint:
     health:
       enabled: true
     info:
       enabled: true
+    metrics:
+      enabled: true
+    prometheus:
+      enabled: true
     caches:
       enabled: true
     cachecontents:
       enabled: true
-    metrics:
-      enabled: true
-    prometheus:
-      metrics:
-        export:
-          enabled: true
 
 custom:
   paths:

--- a/main/src/main/resources/application-test.yml
+++ b/main/src/main/resources/application-test.yml
@@ -87,23 +87,21 @@ management:
         exclude: "*"
     web:
       exposure:
-        include: info, health, prometheus, caches, cachecontents
+        include: health, info, metrics, prometheus, caches, cachecontents
       base-path: ${ACTUATOR_PATH}
   endpoint:
     health:
       enabled: true
     info:
       enabled: true
+    metrics:
+      enabled: true
+    prometheus:
+      enabled: true
     caches:
       enabled: true
     cachecontents:
       enabled: true
-    metrics:
-      enabled: true
-    prometheus:
-      metrics:
-        export:
-          enabled: true
 
 custom:
   paths:

--- a/main/src/main/resources/application-traffic.yml
+++ b/main/src/main/resources/application-traffic.yml
@@ -89,23 +89,21 @@ management:
         exclude: "*"
     web:
       exposure:
-        include: info, health, prometheus, caches, cachecontents
+        include: health, info, metrics, prometheus, caches, cachecontents
       base-path: ${ACTUATOR_PATH}
   endpoint:
     health:
       enabled: true
     info:
       enabled: true
+    metrics:
+      enabled: true
+    prometheus:
+      enabled: true
     caches:
       enabled: true
     cachecontents:
       enabled: true
-    metrics:
-      enabled: true
-    prometheus:
-      metrics:
-        export:
-          enabled: true
 
 custom:
   paths:


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 커스텀 경로로 생성한 actuator의 경우 "구성 프로퍼티를 사용할 수 없습니다" 라는 경고가 뜨는데, 해당 경로 밑으로 enable된 경로는 호출이 되지 않는 오류가 있어 metrics와 prometheus actuator가 호출되지 않았습니다.
- 그래서 해당 경로를 호출할 수 있도록 커스텀 경로(cachecontents)를 가장 하위로 내렸습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

- 커스텀 actuator 경로는 가장 밑에 두는게 앞으로 개발을 위해서 좋을 것 같습니다!

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #639 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?