### PR TITLE
feat: 번쩍 개설 및 수정 시 모임 키워드 등록 기능 구현 완료

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/tag/Tag.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/tag/Tag.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.hibernate.annotations.Type;
 import org.sopt.makers.crew.main.entity.common.BaseTimeEntity;
+import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
 import org.sopt.makers.crew.main.entity.tag.enums.TagType;
 import org.sopt.makers.crew.main.entity.tag.enums.WelcomeMessageType;
 
@@ -17,6 +18,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -52,31 +54,43 @@ public class Tag extends BaseTimeEntity {
 	@Type(JsonBinaryType.class)
 	private List<WelcomeMessageType> welcomeMessageTypes;
 
+	@Column(name = "meetingKeywordTypes", columnDefinition = "jsonb")
+	@Type(JsonBinaryType.class)
+	@Size(min = 1, max = 2)
+	private List<MeetingKeywordType> meetingKeywordTypes;
+
 	@Builder
-	private Tag(TagType tagType, Integer meetingId, Integer flashId, List<WelcomeMessageType> welcomeMessageTypes) {
+	private Tag(TagType tagType, Integer meetingId, Integer flashId,
+		List<WelcomeMessageType> welcomeMessageTypes,
+		List<MeetingKeywordType> meetingKeywordTypes) {
 		this.tagType = tagType;
 		this.meetingId = meetingId;
 		this.flashId = flashId;
 		this.welcomeMessageTypes = welcomeMessageTypes;
+		this.meetingKeywordTypes = meetingKeywordTypes;
 	}
 
 	public static Tag createGeneralMeetingTag(TagType tagType, Integer meetingId,
-		List<WelcomeMessageType> welcomeMessageTypes) {
+		List<WelcomeMessageType> welcomeMessageTypes,
+		List<MeetingKeywordType> meetingKeywordTypes) {
 		return Tag.builder()
 			.tagType(tagType)
 			.meetingId(meetingId)
 			.flashId(null)
 			.welcomeMessageTypes(welcomeMessageTypes)
+			.meetingKeywordTypes(meetingKeywordTypes)
 			.build();
 	}
 
 	public static Tag createFlashMeetingTag(TagType tagType, Integer flashId,
-		List<WelcomeMessageType> welcomeMessageTypes) {
+		List<WelcomeMessageType> welcomeMessageTypes,
+		List<MeetingKeywordType> meetingKeywordTypes) {
 		return Tag.builder()
 			.tagType(tagType)
 			.meetingId(null)
 			.flashId(flashId)
 			.welcomeMessageTypes(welcomeMessageTypes)
+			.meetingKeywordTypes(meetingKeywordTypes)
 			.build();
 	}
 

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/tag/Tag.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/tag/Tag.java
@@ -97,4 +97,8 @@ public class Tag extends BaseTimeEntity {
 	public void updateWelcomeMessageTypes(List<WelcomeMessageType> newWelcomeMessageTypes) {
 		this.welcomeMessageTypes = newWelcomeMessageTypes;
 	}
+
+	public void updateMeetingKeywordTypeEnums(List<MeetingKeywordType> newMeetingKeywordTypes) {
+		this.meetingKeywordTypes = newMeetingKeywordTypes;
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/tag/enums/MeetingKeywordType.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/tag/enums/MeetingKeywordType.java
@@ -1,0 +1,30 @@
+package org.sopt.makers.crew.main.entity.tag.enums;
+
+import org.sopt.makers.crew.main.global.exception.BadRequestException;
+import org.sopt.makers.crew.main.global.exception.ErrorStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MeetingKeywordType {
+	EXERCISE("운동"),
+	FOOD("먹방"),
+	HOBBY("취미"),
+	STUDY("학습"),
+	SELF_DEVELOPMENT("자기개발"),
+	NETWORKING("네트워킹"),
+	ETC("기타");
+
+	private final String value;
+
+	public static MeetingKeywordType ofValue(String dbData) {
+		for (MeetingKeywordType type : MeetingKeywordType.values()) {
+			if (type.getValue().equals(dbData)) {
+				return type;
+			}
+		}
+		throw new BadRequestException(ErrorStatus.INVALID_MEETING_KEYWORD_TYPE.getErrorCode());
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/tag/enums/WelcomeMessageType.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/tag/enums/WelcomeMessageType.java
@@ -1,8 +1,13 @@
 package org.sopt.makers.crew.main.entity.tag.enums;
 
+import org.sopt.makers.crew.main.global.exception.BadRequestException;
+import org.sopt.makers.crew.main.global.exception.ErrorStatus;
+
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public enum WelcomeMessageType {
 	YB_WELCOME("YB 환영"),
 	OB_WELCOME("OB 환영"),
@@ -12,16 +17,12 @@ public enum WelcomeMessageType {
 
 	private final String value;
 
-	WelcomeMessageType(String value) {
-		this.value = value;
-	}
-
 	public static WelcomeMessageType ofValue(String dbData) {
 		for (WelcomeMessageType type : WelcomeMessageType.values()) {
 			if (type.getValue().equals(dbData)) {
 				return type;
 			}
 		}
-		throw new IllegalArgumentException("Invalid WelcomeMessageType value: " + dbData);
+		throw new BadRequestException(ErrorStatus.INVALID_WELCOME_MESSAGE_TYPE.getErrorCode());
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/flash/v2/FlashV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/flash/v2/FlashV2Api.java
@@ -21,7 +21,7 @@ public interface FlashV2Api {
 
 	@Operation(summary = "번쩍 모임 생성")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "201", description = "meetingId: 10"),
+		@ApiResponse(responseCode = "201", description = "meetingId: 10, tagId: 4"),
 		@ApiResponse(responseCode = "400", description = "VALIDATION_EXCEPTION", content = @Content),
 	})
 	ResponseEntity<FlashV2CreateAndUpdateResponseDto> createFlash(
@@ -39,7 +39,7 @@ public interface FlashV2Api {
 
 	@Operation(summary = "번쩍 모임 수정")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "meetingId: 10"),
+		@ApiResponse(responseCode = "200", description = "meetingId: 10, tagId: 5"),
 		@ApiResponse(responseCode = "400", description = "VALIDATION_EXCEPTION", content = @Content),
 	})
 	ResponseEntity<FlashV2CreateAndUpdateResponseDto> updateFlash(

--- a/main/src/main/java/org/sopt/makers/crew/main/flash/v2/dto/request/FlashV2CreateAndUpdateFlashBodyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/flash/v2/dto/request/FlashV2CreateAndUpdateFlashBodyDto.java
@@ -19,6 +19,6 @@ public record FlashV2CreateAndUpdateFlashBodyDto(
 
 	@Schema(example = "[\"운동\", \"자기개발\"]", description = "모임 키워드 타입 리스트")
 	@Size(min = 1, max = 2)
-	List<String> meetingKeywordType
+	List<String> meetingKeywordTypes
 ) {
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/flash/v2/dto/request/FlashV2CreateAndUpdateFlashBodyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/flash/v2/dto/request/FlashV2CreateAndUpdateFlashBodyDto.java
@@ -5,6 +5,7 @@ import java.util.List;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Schema(name = "FlashV2CreateAndUpdateFlashBodyDto", description = "번쩍 모임 생성 및 수정 request body dto")
 public record FlashV2CreateAndUpdateFlashBodyDto(
@@ -14,6 +15,10 @@ public record FlashV2CreateAndUpdateFlashBodyDto(
 	FlashV2CreateAndUpdateFlashBodyWithoutWelcomeMessageDto flashBody,
 
 	@Schema(example = "[\"YB 환영\", \"OB 환영\"]", description = "환영 메시지 타입 리스트")
-	List<String> welcomeMessageTypes
+	List<String> welcomeMessageTypes,
+
+	@Schema(example = "[\"운동\", \"자기개발\"]", description = "모임 키워드 타입 리스트")
+	@Size(min = 1, max = 2)
+	List<String> meetingKeywordType
 ) {
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/flash/v2/dto/response/FlashV2CreateAndUpdateResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/flash/v2/dto/response/FlashV2CreateAndUpdateResponseDto.java
@@ -7,9 +7,13 @@ import jakarta.validation.constraints.NotNull;
 public record FlashV2CreateAndUpdateResponseDto(
 	@Schema(description = "모임 id - 번쩍 카테고리", example = "1")
 	@NotNull
-	Integer meetingId
+	Integer meetingId,
+
+	@Schema(description = "태그 id - 번쩍 카테고리", example = "1")
+	@NotNull
+	Integer tagId
 ) {
-	public static FlashV2CreateAndUpdateResponseDto from(Integer meetingId) {
-		return new FlashV2CreateAndUpdateResponseDto(meetingId);
+	public static FlashV2CreateAndUpdateResponseDto of(Integer meetingId, Integer tagId) {
+		return new FlashV2CreateAndUpdateResponseDto(meetingId, tagId);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/flash/v2/service/FlashV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/flash/v2/service/FlashV2ServiceImpl.java
@@ -85,7 +85,7 @@ public class FlashV2ServiceImpl implements FlashV2Service {
 			activeGenerationProvider.getActiveGeneration(), user.getId(), realTime);
 
 		flashRepository.save(flash);
-		tagV2Service.createFlashTag(requestBody.welcomeMessageTypes(), flash.getId());
+		tagV2Service.createFlashTag(requestBody.welcomeMessageTypes(), requestBody.meetingKeywordType(), flash.getId());
 
 		OrgIdListDto orgIdListDto = userReader.findAllOrgIds();
 

--- a/main/src/main/java/org/sopt/makers/crew/main/flash/v2/service/FlashV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/flash/v2/service/FlashV2ServiceImpl.java
@@ -33,6 +33,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyWholeInfoDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingLeaderUserIdDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateAndUpdateMeetingForFlashResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.service.MeetingV2Service;
+import org.sopt.makers.crew.main.tag.v2.dto.response.TagV2CreateAndUpdateFlashTagResponseDto;
 import org.sopt.makers.crew.main.tag.v2.service.TagV2Service;
 import org.sopt.makers.crew.main.user.v2.service.UserV2Service;
 import org.springframework.cache.annotation.CacheEvict;
@@ -85,7 +86,8 @@ public class FlashV2ServiceImpl implements FlashV2Service {
 			activeGenerationProvider.getActiveGeneration(), user.getId(), realTime);
 
 		flashRepository.save(flash);
-		tagV2Service.createFlashTag(requestBody.welcomeMessageTypes(), requestBody.meetingKeywordTypes(),
+		TagV2CreateAndUpdateFlashTagResponseDto tagResponseDto = tagV2Service.createFlashTag(
+			requestBody.welcomeMessageTypes(), requestBody.meetingKeywordTypes(),
 			flash.getId());
 
 		OrgIdListDto orgIdListDto = userReader.findAllOrgIds();
@@ -93,7 +95,7 @@ public class FlashV2ServiceImpl implements FlashV2Service {
 		eventPublisher.publishEvent(
 			new FlashCreatedEventDto(orgIdListDto.getOrgIds(), flash.getMeetingId(), flash.getTitle()));
 
-		return FlashV2CreateAndUpdateResponseDto.from(flash.getMeetingId());
+		return FlashV2CreateAndUpdateResponseDto.of(flash.getMeetingId(), tagResponseDto.tagId());
 	}
 
 	public FlashV2GetFlashByMeetingIdResponseDto getFlashDetail(Integer meetingId, Integer userId) {
@@ -150,9 +152,11 @@ public class FlashV2ServiceImpl implements FlashV2Service {
 
 		flash.updateFlash(updatedFlash);
 
-		// tagV2Service.updateFlashTag(requestBody.welcomeMessageTypes(), flash.getId());
+		TagV2CreateAndUpdateFlashTagResponseDto tagResponseDto = tagV2Service.updateFlashTag(
+			requestBody.welcomeMessageTypes(), requestBody.meetingKeywordTypes(),
+			flash.getId());
 
-		return FlashV2CreateAndUpdateResponseDto.from(flash.getMeetingId());
+		return FlashV2CreateAndUpdateResponseDto.of(flash.getMeetingId(), tagResponseDto.tagId());
 	}
 
 	private List<ApplyWholeInfoDto> getApplyWholeInfoDtos(Applies applies, Integer meetingId, Integer userId) {

--- a/main/src/main/java/org/sopt/makers/crew/main/flash/v2/service/FlashV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/flash/v2/service/FlashV2ServiceImpl.java
@@ -85,7 +85,8 @@ public class FlashV2ServiceImpl implements FlashV2Service {
 			activeGenerationProvider.getActiveGeneration(), user.getId(), realTime);
 
 		flashRepository.save(flash);
-		tagV2Service.createFlashTag(requestBody.welcomeMessageTypes(), requestBody.meetingKeywordType(), flash.getId());
+		tagV2Service.createFlashTag(requestBody.welcomeMessageTypes(), requestBody.meetingKeywordTypes(),
+			flash.getId());
 
 		OrgIdListDto orgIdListDto = userReader.findAllOrgIds();
 
@@ -149,7 +150,7 @@ public class FlashV2ServiceImpl implements FlashV2Service {
 
 		flash.updateFlash(updatedFlash);
 
-		tagV2Service.updateFlashTag(requestBody.welcomeMessageTypes(), flash.getId());
+		// tagV2Service.updateFlashTag(requestBody.welcomeMessageTypes(), flash.getId());
 
 		return FlashV2CreateAndUpdateResponseDto.from(flash.getMeetingId());
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
@@ -36,6 +36,7 @@ public enum ErrorStatus {
 	IO_EXCEPTION("파일 입출력 오류가 발생했습니다."),
 	INVALID_WELCOME_MESSAGE_TYPE("유효하지 않은 환영 메시지 타입입니다."),
 	INVALID_MEETING_KEYWORD_TYPE("유효하지 않은 모임 키워드 타입입니다."),
+	INVALID_MEETING_KEYWORD_SIZE("모임 키워드는 최소 1개 이상, 최대 2개까지 선택해야 합니다."),
 
 	/**
 	 * 400 BAD_REQUEST - 유효성 검사 관련 에러

--- a/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
@@ -34,6 +34,8 @@ public enum ErrorStatus {
 	LEADER_CANNOT_BE_CO_LEADER_APPLY("모임장은 공동 모임장이 될 수 없습니다."),
 	NOT_ALLOW_MEETING_APPLY("허용되지 않는 모임 신청입니다."),
 	IO_EXCEPTION("파일 입출력 오류가 발생했습니다."),
+	INVALID_WELCOME_MESSAGE_TYPE("유효하지 않은 환영 메시지 타입입니다."),
+	INVALID_MEETING_KEYWORD_TYPE("유효하지 않은 모임 키워드 타입입니다."),
 
 	/**
 	 * 400 BAD_REQUEST - 유효성 검사 관련 에러

--- a/main/src/main/java/org/sopt/makers/crew/main/tag/v2/dto/response/TagV2CreateAndUpdateFlashTagResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/tag/v2/dto/response/TagV2CreateAndUpdateFlashTagResponseDto.java
@@ -4,12 +4,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 @Schema(name = "TagV2CreateFlashTagResponseDto", description = "번쩍 모임 태그 생성 응답 Dto")
-public record TagV2CreateFlashTagResponseDto(
+public record TagV2CreateAndUpdateFlashTagResponseDto(
 	@Schema(description = "모임 태그 id", example = "1")
 	@NotNull
 	Integer tagId
 ) {
-	public static TagV2CreateFlashTagResponseDto from(Integer tagId) {
-		return new TagV2CreateFlashTagResponseDto(tagId);
+	public static TagV2CreateAndUpdateFlashTagResponseDto from(Integer tagId) {
+		return new TagV2CreateAndUpdateFlashTagResponseDto(tagId);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/tag/v2/dto/response/TagV2CreateAndUpdateFlashTagResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/tag/v2/dto/response/TagV2CreateAndUpdateFlashTagResponseDto.java
@@ -3,7 +3,7 @@ package org.sopt.makers.crew.main.tag.v2.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-@Schema(name = "TagV2CreateFlashTagResponseDto", description = "번쩍 모임 태그 생성 응답 Dto")
+@Schema(name = "TagV2CreateAndUpdateFlashTagResponseDto", description = "번쩍 모임 태그 생성 및 수정 응답 Dto")
 public record TagV2CreateAndUpdateFlashTagResponseDto(
 	@Schema(description = "모임 태그 id", example = "1")
 	@NotNull

--- a/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2Service.java
@@ -6,7 +6,8 @@ import org.sopt.makers.crew.main.entity.tag.enums.WelcomeMessageType;
 import org.sopt.makers.crew.main.tag.v2.dto.response.TagV2CreateFlashTagResponseDto;
 
 public interface TagV2Service {
-	TagV2CreateFlashTagResponseDto createFlashTag(List<String> welcomeMessageTypes, Integer flashId);
+	TagV2CreateFlashTagResponseDto createFlashTag(List<String> welcomeMessageTypes, List<String> meetingKeywordType,
+		Integer flashId);
 
 	List<WelcomeMessageType> getWelcomeMessageTypesByFlashId(Integer flashId);
 

--- a/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2Service.java
@@ -3,13 +3,16 @@ package org.sopt.makers.crew.main.tag.v2.service;
 import java.util.List;
 
 import org.sopt.makers.crew.main.entity.tag.enums.WelcomeMessageType;
-import org.sopt.makers.crew.main.tag.v2.dto.response.TagV2CreateFlashTagResponseDto;
+import org.sopt.makers.crew.main.tag.v2.dto.response.TagV2CreateAndUpdateFlashTagResponseDto;
 
 public interface TagV2Service {
-	TagV2CreateFlashTagResponseDto createFlashTag(List<String> welcomeMessageTypes, List<String> meetingKeywordTypes,
+	TagV2CreateAndUpdateFlashTagResponseDto createFlashTag(List<String> welcomeMessageTypes,
+		List<String> meetingKeywordTypes,
 		Integer flashId);
 
 	List<WelcomeMessageType> getWelcomeMessageTypesByFlashId(Integer flashId);
 
-	// TagV2CreateFlashTagResponseDto updateFlashTag(List<String> welcomeMessageTypes, List<String> meetingKeywordTypes, Integer flashId);
+	TagV2CreateAndUpdateFlashTagResponseDto updateFlashTag(List<String> welcomeMessageTypes,
+		List<String> meetingKeywordTypes,
+		Integer flashId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2Service.java
@@ -6,10 +6,10 @@ import org.sopt.makers.crew.main.entity.tag.enums.WelcomeMessageType;
 import org.sopt.makers.crew.main.tag.v2.dto.response.TagV2CreateFlashTagResponseDto;
 
 public interface TagV2Service {
-	TagV2CreateFlashTagResponseDto createFlashTag(List<String> welcomeMessageTypes, List<String> meetingKeywordType,
+	TagV2CreateFlashTagResponseDto createFlashTag(List<String> welcomeMessageTypes, List<String> meetingKeywordTypes,
 		Integer flashId);
 
 	List<WelcomeMessageType> getWelcomeMessageTypesByFlashId(Integer flashId);
 
-	TagV2CreateFlashTagResponseDto updateFlashTag(List<String> welcomeMessageTypes, Integer flashId);
+	// TagV2CreateFlashTagResponseDto updateFlashTag(List<String> welcomeMessageTypes, List<String> meetingKeywordTypes, Integer flashId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2ServiceImpl.java
@@ -38,8 +38,8 @@ public class TagV2ServiceImpl implements TagV2Service {
 			throw new BadRequestException(VALIDATION_EXCEPTION.getErrorCode());
 		}
 
-		List<MeetingKeywordType> meetingKeywordTypeEnums = toMeetingKeywordTypes(meetingKeywordTypes);
 		List<WelcomeMessageType> welcomeMessageTypeEnums = toWelcomeMessageTypes(welcomeMessageTypes);
+		List<MeetingKeywordType> meetingKeywordTypeEnums = toMeetingKeywordTypes(meetingKeywordTypes);
 
 		return saveTag(flashId, welcomeMessageTypeEnums, meetingKeywordTypeEnums);
 	}


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 번쩍 개설 및 수정 시 모임 키워드 등록 기능을 구현하였습니다.
- 현재 dev 전용 스키마에 `welcomeMessageTypes`를 jsonb 타입으로 추가한 상태입니다. (local 스키마가 없는 관계로...)
- 따라서, dev서버에서 번쩍 개설 및 수정 시 requestDTO의 meetingKeywordTypes이 null로 넘어와 작동하지 않는게 정책에는 맞지만 dev서버에서 작동하도록 하기위해 현재 null을 허용해둔 상황입니다!!

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

### 모임 키워드 포함 번쩍 개설 정상 작동 확인
![image](https://github.com/user-attachments/assets/29bbb1ca-d6bb-4f71-9b07-7c7c3c86812d)

### 모임 키워드 포함 번쩍 수정 정상 작동 확인
![image](https://github.com/user-attachments/assets/db03ce8f-473b-47e8-b2e0-3dc599406ef3)

### 모임 키워드 개수가 1~2개가 아니면 예외처리 확인
#### 빈 리스트
<img width="1267" alt="image" src="https://github.com/user-attachments/assets/828a7eba-2e39-467c-975c-2e10fe7eece6" />

#### 키워드 3개
<img width="1273" alt="image" src="https://github.com/user-attachments/assets/cdd7396f-8ac0-46d7-a80b-ac4508b66b65" />

#### 존재하지 않는 키워드
<img width="1266" alt="image" src="https://github.com/user-attachments/assets/02817629-303b-4075-a8d0-0e62693a71d8" />


## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #642 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?