### PR TITLE
delete: Sentry 고도화 완료 후 필요없는 설정 제거

### DIFF
--- a/main/src/main/resources/application-dev.yml
+++ b/main/src/main/resources/application-dev.yml
@@ -113,14 +113,6 @@ sentry:
   environment: ${DEV_SENTRY_ENVIRONMENT}
   servername: ${DEV_SENTRY_SERVERNAME}
 
-logging:
-  slack:
-    webhook-uri: ${SENTRY_SLACK_WEBHOOK_URI}
-  config: classpath:logback-spring.xml
-  sentry:
-    repository-uri: ${SENTRY_REPOSITORY_URI}
-    environment: dev
-
 img:
   flash: ${FLASH_IMAGE}
 

--- a/main/src/main/resources/application-prod.yml
+++ b/main/src/main/resources/application-prod.yml
@@ -112,14 +112,6 @@ sentry:
   environment: ${PROD_SENTRY_ENVIRONMENT}
   servername: ${PROD_SENTRY_SERVERNAME}
 
-logging:
-  slack:
-    webhook-uri: ${SENTRY_SLACK_WEBHOOK_URI}
-  config: classpath:logback-spring.xml
-  sentry:
-    repository-uri: ${SENTRY_REPOSITORY_URI}
-    environment: prod
-
 img:
   flash: ${FLASH_IMAGE}
 

--- a/main/src/main/resources/application-test.yml
+++ b/main/src/main/resources/application-test.yml
@@ -111,14 +111,6 @@ sentry:
   environment: ${DEV_SENTRY_ENVIRONMENT}
   servername: ${DEV_SENTRY_SERVERNAME}
 
-logging:
-  slack:
-    webhook-uri: ${SENTRY_SLACK_WEBHOOK_URI}
-  config: classpath:logback-spring.xml
-  sentry:
-    repository-uri: ${SENTRY_REPOSITORY_URI}
-    environment: test
-
 img:
   flash: ${FLASH_IMAGE}
 

--- a/main/src/main/resources/application-traffic.yml
+++ b/main/src/main/resources/application-traffic.yml
@@ -113,14 +113,6 @@ sentry:
   environment: ${TRAFFIC_SENTRY_ENVIRONMENT}
   servername: ${TRAFFIC_SENTRY_SERVERNAME}
 
-logging:
-  slack:
-    webhook-uri: ${SENTRY_SLACK_WEBHOOK_URI}
-  config: classpath:logback-spring.xml
-  sentry:
-    repository-uri: ${SENTRY_REPOSITORY_URI}
-    environment: traffic
-
 img:
   flash: ${FLASH_IMAGE}
 

--- a/main/src/main/resources/logback-spring.xml
+++ b/main/src/main/resources/logback-spring.xml
@@ -11,28 +11,6 @@
         <minimumBreadcrumbLevel>DEBUG</minimumBreadcrumbLevel>
     </appender>
 
-    <springProperty name="SLACK_WEBHOOK_URI" source="logging.slack.webhook-uri"/>
-    <springProperty name="SENTRY_REPOSITORY_URI" source="logging.sentry.repository-uri"/>
-    <springProperty name="ENVIRONMENT" source="logging.sentry.environment"/>
-    <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
-        <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
-        <layout class="ch.qos.logback.classic.PatternLayout">
-            <pattern>*🚨[${ENVIRONMENT}] %d{yyyy-MM-dd HH:mm:ss.SSS} %-4relative [%thread] %-5level %class - %msg &lt;${SENTRY_REPOSITORY_URI}|Go-To-Sentry&gt;*
-                %n
-            </pattern>
-        </layout>
-        <username>posting bot</username>
-        <iconEmoji>:robot_face:</iconEmoji>
-        <colorCoding>true</colorCoding>
-    </appender>
-
-    <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="SLACK"/>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>ERROR</level>
-        </filter>
-    </appender>
-
     <springProfile name="local">
         <include resource="console-appender.xml"/>
         <root level="INFO">
@@ -45,7 +23,6 @@
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="Sentry"/>
-            <appender-ref ref="ASYNC_SLACK"/>
         </root>
     </springProfile>
 
@@ -54,7 +31,6 @@
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="Sentry"/>
-            <appender-ref ref="ASYNC_SLACK"/>
         </root>
     </springProfile>
 
@@ -63,7 +39,6 @@
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="Sentry"/>
-            <appender-ref ref="ASYNC_SLACK"/>
         </root>
     </springProfile>
 


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
https://github.com/sopt-makers/sentry-notifier

- 해당 레포에서 Sentry 연동 고도화 작업을 진행하였습니다.
- 기존에는 AsyncAppender를 활용해 에러 발생 시 Slack으로 에러 알림을 전송하도록 구현되어 있었습니다.
- 이 방식은 Sentry에서 에러를 트래킹하고 이를 Slack으로 전달하는 방식이 아닌, 서버에서 직접 Slack으로 알림을 보내는 구조였기에 Sentry의 상세한 오류 정보와 분석 기능을 Slack 알림에서 활용할 수 없었습니다.
- 이에 따라, 보다 정밀한 오류 분석과 통합적인 에러 관리를 위해 Sentry Webhook(무료) + API Gateway + Lambda 기능을 활용한 Slack 알림 시스템으로 전환하였습니다.
- 고도화 작업이 완료된 이후에는 기존 코드를 더 이상 사용할 필요가 없어 삭제하는 작업을 진행했습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
### AS-IS
<img width="1002" alt="image" src="https://github.com/user-attachments/assets/4426badb-6093-44b0-a368-9adc5aeede73" />
- 두 가지 설정이 모두 되어있었기에 슬랙에 동일한 알림이 중복 전송되는 문제가 발생했습니다.

### TO-BE
<img width="873" alt="image" src="https://github.com/user-attachments/assets/31212a4d-9a35-4cb3-9114-f380455ec7ba" />
- 서버에서 직접 Slack으로 알림을 보내는 코드를 삭제함으로써, 중복 알림 문제를 해결하고 Sentry 중심의 일원화된 에러 모니터링 체계를 구축할 수 있었습니다.

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #631 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [x] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?