### PR TITLE
feat: 오후 10시 이후 오전 8시 이전엔 번쩍 생성 알림이 가지 않도록 진행해요!

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/external/notification/event/NotificationTimeValidator.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/external/notification/event/NotificationTimeValidator.java
@@ -1,0 +1,13 @@
+package org.sopt.makers.crew.main.external.notification.event;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class NotificationTimeValidator {
+
+	public static boolean isPublishedTime(LocalDateTime now) {
+		LocalTime time = now.toLocalTime();
+		return !(time.isAfter(LocalTime.of(22, 0)) || time.isBefore(LocalTime.of(8, 0)));
+	}
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/flash/v2/service/FlashV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/flash/v2/service/FlashV2ServiceImpl.java
@@ -19,7 +19,9 @@ import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
 import org.sopt.makers.crew.main.entity.tag.enums.WelcomeMessageType;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.entity.user.UserReader;
+import org.sopt.makers.crew.main.external.notification.dto.event.FlashCreatedEventDto;
 import org.sopt.makers.crew.main.external.notification.dto.event.KeywordEventDto;
+import org.sopt.makers.crew.main.external.notification.event.NotificationTimeValidator;
 import org.sopt.makers.crew.main.external.notification.vo.KeywordMatchedUserDto;
 import org.sopt.makers.crew.main.flash.v2.dto.event.FlashLeaderSyncEventDto;
 import org.sopt.makers.crew.main.flash.v2.dto.mapper.FlashMapper;
@@ -27,6 +29,7 @@ import org.sopt.makers.crew.main.flash.v2.dto.request.FlashV2CreateAndUpdateFlas
 import org.sopt.makers.crew.main.flash.v2.dto.response.FlashV2CreateResponseDto;
 import org.sopt.makers.crew.main.flash.v2.dto.response.FlashV2GetFlashByMeetingIdResponseDto;
 import org.sopt.makers.crew.main.global.dto.MeetingCreatorDto;
+import org.sopt.makers.crew.main.global.dto.OrgIdListDto;
 import org.sopt.makers.crew.main.global.exception.BadRequestException;
 import org.sopt.makers.crew.main.global.exception.NotFoundException;
 import org.sopt.makers.crew.main.global.util.ActiveGenerationProvider;
@@ -92,13 +95,24 @@ public class FlashV2ServiceImpl implements FlashV2Service {
 			requestBody.welcomeMessageTypes(), requestBody.meetingKeywordTypes(),
 			flash.getId(), flash.getMeetingId());
 
+		if (NotificationTimeValidator.isPublishedTime(realTime.now())) {
+			publishFlashEvent(requestBody, flash);
+		}
+
+		return FlashV2CreateResponseDto.of(flash.getMeetingId(), tagResponseDto.tagId());
+	}
+
+	private void publishFlashEvent(FlashV2CreateAndUpdateFlashBodyDto requestBody, Flash flash) {
+		// 추후 fe 개발 이후 해당 번쩍 생성 이벤트는 사라질 예정
+		OrgIdListDto orgIdListDto = userReader.findAllOrgIds();
+		eventPublisher.publishEvent(
+			new FlashCreatedEventDto(orgIdListDto.getOrgIds(), flash.getMeetingId(), flash.getTitle()));
+
 		List<KeywordMatchedUserDto> keywordMatchedUserDtos = userReader.findByInterestingKeywordTypes(
 			requestBody.meetingKeywordTypes());
 
 		eventPublisher.publishEvent(new KeywordEventDto(keywordMatchedUserDtos
 			, flash.getMeetingId(), flash.getTitle(), MeetingCategory.FLASH));
-
-		return FlashV2CreateResponseDto.of(flash.getMeetingId(), tagResponseDto.tagId());
 	}
 
 	public FlashV2GetFlashByMeetingIdResponseDto getFlashDetail(Integer meetingId, Integer userId) {

--- a/main/src/test/java/org/sopt/makers/crew/main/external/notification/event/NotificationTimeValidatorTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/external/notification/event/NotificationTimeValidatorTest.java
@@ -1,0 +1,33 @@
+package org.sopt.makers.crew.main.external.notification.event;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NotificationTimeValidatorTest {
+
+	@Test
+	@DisplayName("22시 이후, 오전 8시 이전에는 알림을 보내지 않는다. - 알림 안 보내는 시간대")
+	void sendNotificationInvalidTime() {
+		LocalDateTime now = LocalDateTime.of(LocalDate.now(), LocalTime.of(22, 1));
+		LocalDateTime end = LocalDateTime.of(LocalDate.now(), LocalTime.of(7, 59));
+
+		Assertions.assertThat(NotificationTimeValidator.isPublishedTime(now)).isFalse();
+		Assertions.assertThat(NotificationTimeValidator.isPublishedTime(end)).isFalse();
+	}
+
+	@Test
+	@DisplayName("22시 이후, 오전 8시 이전에는 알림을 보내지 않는다. - 알림 보내는 시간대")
+	void sendNotificationvalidTime() {
+		LocalDateTime now = LocalDateTime.of(LocalDate.now(), LocalTime.of(21, 59));
+		LocalDateTime end = LocalDateTime.of(LocalDate.now(), LocalTime.of(8, 1));
+
+		Assertions.assertThat(NotificationTimeValidator.isPublishedTime(now)).isTrue();
+		Assertions.assertThat(NotificationTimeValidator.isPublishedTime(end)).isTrue();
+	}
+
+}


### PR DESCRIPTION
## 👩‍💻 Contents

### ✨ 새로운 기능
- **시간대별 알림 제어**: 22시~08시 사이에만 키워드 매칭 알림 발송하도록 시간 제한 기능 추가

### 🔧 주요 변경사항
- **알림 시간 검증 로직**: `NotificationTimeValidator`를 통한 시간대별 알림 제어

### 📁 변경된 파일
- `NotificationTimeValidator.java`: 알림 시간대 검증 로직


## 📣 Related Issue

- closed #675

## ✅ 점검사항

- [] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?