### PR TITLE
fix: 유저 키워드 post 전송시 문제가 되었던 수정, get을 통한 키워드 조회 진행할 수 있도록 변경

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/User.java
@@ -20,7 +20,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -76,7 +75,6 @@ public class User extends BaseTimeEntity {
 	 */
 	@Column(name = "interestedKeywords", columnDefinition = "jsonb")
 	@Type(JsonBinaryType.class)
-	@Size(min = 1, max = 2)
 	private List<MeetingKeywordType> interestedKeywords;
 
 	@Column(name = "isAlarmed")

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserReader.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserReader.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
+import org.sopt.makers.crew.main.entity.user.projection.UserKeywrodsProjection;
 import org.sopt.makers.crew.main.external.notification.vo.KeywordMatchedUserDto;
 import org.sopt.makers.crew.main.global.dto.MeetingCreatorDto;
 import org.sopt.makers.crew.main.global.dto.OrgIdListDto;
@@ -35,10 +36,15 @@ public class UserReader {
 		List<MeetingKeywordType> meetingKeywords = meetingKeywordTypes.stream()
 			.map(MeetingKeywordType::ofValue)
 			.toList();
-		
+
 		return allUsers.stream()
 			.filter(u -> !Collections.disjoint(u.getInterestedKeywords(), meetingKeywords)
 			).map(KeywordMatchedUserDto::from).toList();
 	}
 
+	public List<MeetingKeywordType> findInterestedKeywordsByUserId(Integer userId) {
+		return userRepository.findInterestedKeywordsByUserId(userId)
+			.map(UserKeywrodsProjection::getInterestedKeywords)
+			.orElse(Collections.emptyList());
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserReader.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserReader.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
-import org.sopt.makers.crew.main.entity.user.projection.UserKeywrodsProjection;
+import org.sopt.makers.crew.main.entity.user.projection.UserKeywordsProjection;
 import org.sopt.makers.crew.main.external.notification.vo.KeywordMatchedUserDto;
 import org.sopt.makers.crew.main.global.dto.MeetingCreatorDto;
 import org.sopt.makers.crew.main.global.dto.OrgIdListDto;
@@ -44,7 +44,7 @@ public class UserReader {
 
 	public List<MeetingKeywordType> findInterestedKeywordsByUserId(Integer userId) {
 		return userRepository.findInterestedKeywordsByUserId(userId)
-			.map(UserKeywrodsProjection::getInterestedKeywords)
+			.map(UserKeywordsProjection::getInterestedKeywords)
 			.orElse(Collections.emptyList());
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserRepository.java
@@ -5,7 +5,7 @@ import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
 import java.util.List;
 import java.util.Optional;
 
-import org.sopt.makers.crew.main.entity.user.projection.UserKeywrodsProjection;
+import org.sopt.makers.crew.main.entity.user.projection.UserKeywordsProjection;
 import org.sopt.makers.crew.main.global.exception.NotFoundException;
 import org.sopt.makers.crew.main.global.exception.UnAuthorizedException;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -40,5 +40,5 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 	List<Integer> findAllOrgIds();
 
 	@Query("select u from User u where u.id = :userId")
-	Optional<UserKeywrodsProjection> findInterestedKeywordsByUserId(@Param("userId") Integer userId);
+	Optional<UserKeywordsProjection> findInterestedKeywordsByUserId(@Param("userId") Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/UserRepository.java
@@ -5,10 +5,12 @@ import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
 import java.util.List;
 import java.util.Optional;
 
+import org.sopt.makers.crew.main.entity.user.projection.UserKeywrodsProjection;
 import org.sopt.makers.crew.main.global.exception.NotFoundException;
 import org.sopt.makers.crew.main.global.exception.UnAuthorizedException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Integer> {
 
@@ -36,4 +38,7 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 
 	@Query("SELECT u.orgId FROM User u")
 	List<Integer> findAllOrgIds();
+
+	@Query("select u from User u where u.id = :userId")
+	Optional<UserKeywrodsProjection> findInterestedKeywordsByUserId(@Param("userId") Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/projection/UserKeywordsProjection.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/projection/UserKeywordsProjection.java
@@ -4,6 +4,6 @@ import java.util.List;
 
 import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
 
-public interface UserKeywrodsProjection {
+public interface UserKeywordsProjection {
 	List<MeetingKeywordType> getInterestedKeywords();
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/user/projection/UserKeywrodsProjection.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/user/projection/UserKeywrodsProjection.java
@@ -1,0 +1,9 @@
+package org.sopt.makers.crew.main.entity.user.projection;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
+
+public interface UserKeywrodsProjection {
+	List<MeetingKeywordType> getInterestedKeywords();
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Api.java
@@ -74,7 +74,7 @@ public interface UserV2Api {
 		Principal principal, UpdateUserInterestKeywordRequestDto dto
 	);
 
-	@Operation(summary = "유저 관심 키워드 설정")
+	@Operation(summary = "유저 관심 키워드 조회")
 	@ResponseStatus(HttpStatus.OK)
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "성공")

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Api.java
@@ -9,6 +9,7 @@ import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMentionUserDto
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllUserDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAppliedMeetingByUserResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetCreatedMeetingByUserResponseDto;
+import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetInterestedKeywordsResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetUserOwnProfileResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -71,6 +72,15 @@ public interface UserV2Api {
 	})
 	ResponseEntity<Void> updateUserInterestedKeyword(
 		Principal principal, UpdateUserInterestKeywordRequestDto dto
+	);
+
+	@Operation(summary = "유저 관심 키워드 설정")
+	@ResponseStatus(HttpStatus.OK)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "성공")
+	})
+	ResponseEntity<UserV2GetInterestedKeywordsResponseDto> getUserInterestedKeyword(
+		Principal principal
 	);
 
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
@@ -10,6 +10,7 @@ import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMentionUserDto
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllUserDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAppliedMeetingByUserResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetCreatedMeetingByUserResponseDto;
+import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetInterestedKeywordsResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetUserOwnProfileResponseDto;
 import org.sopt.makers.crew.main.user.v2.service.UserV2Service;
 import org.springframework.http.HttpStatus;
@@ -87,4 +88,13 @@ public class UserV2Controller implements UserV2Api {
 		userV2Service.updateInterestedKeywords(userId, dto.keywords());
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}
+
+	@Override
+	@GetMapping("/interestedKeywords")
+	public ResponseEntity<UserV2GetInterestedKeywordsResponseDto> getUserInterestedKeyword(Principal principal) {
+		Integer userId = UserUtil.getUserId(principal);
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(userV2Service.getInterestedKeywords(userId));
+	}
+
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/UserV2Controller.java
@@ -16,11 +16,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -82,7 +82,7 @@ public class UserV2Controller implements UserV2Api {
 	@Override
 	@PostMapping("/interestedKeywords")
 	public ResponseEntity<Void> updateUserInterestedKeyword(Principal principal,
-		@Valid UpdateUserInterestKeywordRequestDto dto) {
+		@RequestBody UpdateUserInterestKeywordRequestDto dto) {
 		Integer userId = UserUtil.getUserId(principal);
 		userV2Service.updateInterestedKeywords(userId, dto.keywords());
 		return ResponseEntity.status(HttpStatus.OK).build();

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/UpdateUserInterestKeywordRequestDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/UpdateUserInterestKeywordRequestDto.java
@@ -2,9 +2,5 @@ package org.sopt.makers.crew.main.user.v2.dto;
 
 import java.util.List;
 
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-
-public record UpdateUserInterestKeywordRequestDto(
-	@NotNull @NotEmpty List<String> keywords) {
+public record UpdateUserInterestKeywordRequestDto(List<String> keywords) {
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/UserV2GetInterestedKeywordsResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/UserV2GetInterestedKeywordsResponseDto.java
@@ -1,0 +1,11 @@
+package org.sopt.makers.crew.main.user.v2.dto.response;
+
+import java.util.List;
+
+public record UserV2GetInterestedKeywordsResponseDto(
+	List<String> keywords
+) {
+	public static UserV2GetInterestedKeywordsResponseDto from(List<String> keywords) {
+		return new UserV2GetInterestedKeywordsResponseDto(keywords);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2Service.java
@@ -8,6 +8,7 @@ import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMentionUserDto
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllUserDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAppliedMeetingByUserResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetCreatedMeetingByUserResponseDto;
+import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetInterestedKeywordsResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetUserOwnProfileResponseDto;
 
 public interface UserV2Service {
@@ -27,4 +28,6 @@ public interface UserV2Service {
 	User getUserByUserId(Integer userId);
 
 	void updateInterestedKeywords(Integer userId, List<String> keywords);
+
+	UserV2GetInterestedKeywordsResponseDto getInterestedKeywords(Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
@@ -1,8 +1,10 @@
 package org.sopt.makers.crew.main.user.v2.service;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -173,8 +175,13 @@ public class UserV2ServiceImpl implements UserV2Service {
 	@Transactional
 	public void updateInterestedKeywords(Integer userId, List<String> keywords) {
 		User user = userRepository.findByIdOrThrow(userId);
+
+		if (Objects.isNull(keywords)) {
+			user.updateKeywords(Collections.emptyList());
+			return;
+		}
 		List<MeetingKeywordType> updateKeywords = keywords.stream()
-			.map(MeetingKeywordType::valueOf)
+			.map(MeetingKeywordType::ofValue)
 			.toList();
 		user.updateKeywords(updateKeywords);
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
@@ -19,6 +19,7 @@ import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
 import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
 import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.UserReader;
 import org.sopt.makers.crew.main.entity.user.UserRepository;
 import org.sopt.makers.crew.main.global.exception.BaseException;
 import org.sopt.makers.crew.main.global.util.ActiveGenerationProvider;
@@ -32,6 +33,7 @@ import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllMentionUserDto
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllUserDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAppliedMeetingByUserResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetCreatedMeetingByUserResponseDto;
+import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetInterestedKeywordsResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetUserOwnProfileResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -52,6 +54,7 @@ public class UserV2ServiceImpl implements UserV2Service {
 
 	private final ActiveGenerationProvider activeGenerationProvider;
 	private final Time time;
+	private final UserReader userReader;
 
 	@Override
 	public List<UserV2GetAllMeetingByUserMeetingDto> getAllMeetingByUser(Integer userId) {
@@ -184,6 +187,15 @@ public class UserV2ServiceImpl implements UserV2Service {
 			.map(MeetingKeywordType::ofValue)
 			.toList();
 		user.updateKeywords(updateKeywords);
+	}
+
+	@Override
+	public UserV2GetInterestedKeywordsResponseDto getInterestedKeywords(Integer userId) {
+		return UserV2GetInterestedKeywordsResponseDto.from(
+			userReader.findInterestedKeywordsByUserId(userId)
+				.stream().map(MeetingKeywordType::getValue)
+				.toList()
+		);
 	}
 
 	private List<Integer> getCoLeaderMeetingIds(List<CoLeader> coLeaders) {

--- a/main/src/test/java/org/sopt/makers/crew/main/user/v2/UserServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/user/v2/UserServiceTest.java
@@ -1,10 +1,12 @@
 package org.sopt.makers.crew.main.user.v2;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.groups.Tuple.*;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart.*;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
@@ -12,7 +14,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
 import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.UserFixture;
 import org.sopt.makers.crew.main.entity.user.UserRepository;
 import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
 import org.sopt.makers.crew.main.global.annotation.IntegratedTest;
@@ -34,6 +38,35 @@ public class UserServiceTest {
 
 	@Autowired
 	private UserRepository userRepository;
+
+	@Nested
+	class 관심있는_키워드_관련_테스트 {
+		@Test
+		void 관심있는_키워드_등록_정상() {
+
+			User user = UserFixture.createStaticUser();
+			User save = userRepository.save(user);
+
+			userV2Service.updateInterestedKeywords(save.getId(), List.of("운동"));
+
+			List<MeetingKeywordType> interestedKeywords = user.getInterestedKeywords();
+			Assertions.assertThat(interestedKeywords)
+				.hasSize(1)
+				.contains(MeetingKeywordType.EXERCISE);
+		}
+
+		@Test
+		void 관심있는_키워드_없는경우도_정상처리() {
+			User user = UserFixture.createStaticUser();
+			User save = userRepository.save(user);
+
+			userV2Service.updateInterestedKeywords(save.getId(), Collections.emptyList());
+
+			List<MeetingKeywordType> interestedKeywords = user.getInterestedKeywords();
+			Assertions.assertThat(interestedKeywords)
+				.hasSize(0);
+		}
+	}
 
 	@Nested
 	class 전체_사용자_조회 {

--- a/main/src/test/java/org/sopt/makers/crew/main/user/v2/UserServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/user/v2/UserServiceTest.java
@@ -25,6 +25,7 @@ import org.sopt.makers.crew.main.user.v2.dto.response.MeetingV2GetCreatedMeeting
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAllUserDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetAppliedMeetingByUserResponseDto;
 import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetCreatedMeetingByUserResponseDto;
+import org.sopt.makers.crew.main.user.v2.dto.response.UserV2GetInterestedKeywordsResponseDto;
 import org.sopt.makers.crew.main.user.v2.service.UserV2Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
@@ -65,6 +66,22 @@ public class UserServiceTest {
 			List<MeetingKeywordType> interestedKeywords = user.getInterestedKeywords();
 			Assertions.assertThat(interestedKeywords)
 				.hasSize(0);
+		}
+
+		@Test
+		void 관심있는_키워드_조회() {
+			User user = UserFixture.createStaticUser();
+			User saveUser = userRepository.save(user);
+
+			userV2Service.updateInterestedKeywords(saveUser.getId(), List.of("운동", "먹방"));
+
+			UserV2GetInterestedKeywordsResponseDto interestedKeywords = userV2Service.getInterestedKeywords(
+				saveUser.getId());
+
+			Assertions.assertThat(interestedKeywords.keywords())
+				.hasSize(2)
+				.contains(MeetingKeywordType.EXERCISE.getValue(), MeetingKeywordType.FOOD.getValue());
+
 		}
 	}
 


### PR DESCRIPTION
## 👩‍💻 Contents

- 유저 관심 키워드(관심있는 키워드) 저장 및 조회 기능 구현
  - 관심 키워드 저장/수정 API 구현 (`UserV2ServiceImpl`, `UserV2Controller`, `UserRepository` 등)
  - 관심 키워드 조회 API 구현 및 응답 DTO 추가
  - 관련 Projection, Entity, Service, Controller, Test 코드 추가 및 수정
- 관심 키워드 관련 테스트 코드 작성

## 📝 Review Note

- 관심 키워드 저장/조회 기능이 정상적으로 동작하는지 통합 테스트를 통해 검증했습니다.
- Projection, Query, DTO 등에서 오타 및 네이밍을 한 번 더 점검하면 좋을 것 같습니다.
- 관심 키워드가 없는 경우도 정상적으로 빈 리스트로 반환됩니다.

## 📣 Related Issue

- closed #682 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?

---