### PR TITLE
chore: 일반 모임 삭제 후 존재하지 않는 meetingId로 조회 시 404 에러를 반환하도록 변경 완료

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingRepository.java
@@ -1,10 +1,10 @@
 package org.sopt.makers.crew.main.entity.meeting;
 
-import static org.sopt.makers.crew.main.global.exception.ErrorStatus.NOT_FOUND_MEETING;
+import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
 
 import java.util.List;
 
-import org.sopt.makers.crew.main.global.exception.BadRequestException;
+import org.sopt.makers.crew.main.global.exception.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -25,7 +25,7 @@ public interface MeetingRepository extends JpaRepository<Meeting, Integer>, Meet
 
 	default Meeting findByIdOrThrow(Integer meetingId) {
 		return findById(meetingId)
-			.orElseThrow(() -> new BadRequestException(NOT_FOUND_MEETING.getErrorCode()));
+			.orElseThrow(() -> new NotFoundException(NOT_FOUND_MEETING.getErrorCode()));
 	}
 
 	@Query("SELECT m FROM Meeting m JOIN FETCH m.user ORDER BY m.id DESC LIMIT 20")


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 일반 모임 삭제 후 존재하지 않는 meetingId로 조회 시 404 에러를 반환하도록 변경을 완료했습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #685 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?