### PR TITLE
feat : 플크루 협업 작업을 위한 api 중 get 메서드 작업 진행

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepository.java
@@ -12,4 +12,6 @@ public interface MeetingSearchRepository {
 		Integer activeGeneration);
 
 	List<Meeting> findRecommendMeetings(List<Integer> meetingIds, Time time);
+
+	Page<Meeting> findAllByQuery(Pageable pageable);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/InternalMeetingApi.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/InternalMeetingApi.java
@@ -1,12 +1,13 @@
 package org.sopt.makers.crew.main.internal;
 
+import org.sopt.makers.crew.main.global.pagination.dto.PageOptionsDto;
 import org.sopt.makers.crew.main.internal.dto.InternalMeetingGetAllMeetingDto;
+import org.sopt.makers.crew.main.internal.dto.InternalMeetingGetAllWritingPostResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -31,4 +32,15 @@ public interface InternalMeetingApi {
 	ResponseEntity<InternalMeetingGetAllMeetingDto> getMeetings(
 		@ModelAttribute @Valid @Parameter(hidden = true) MeetingV2GetAllMeetingQueryDto queryCommand,
 		@RequestParam @Valid Integer orgId);
+
+	@Operation(summary = "[Internal] 모임 전체 조회", description = "플그 피드 작성시 크루 모임 전체 조회를 위한 api")
+	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "모임 목록 조회 성공")})
+	@Parameters(value = {
+		@Parameter(name = "page", description = "페이지", example = "1", required = true, schema = @Schema(type = "integer", format = "int32")),
+		@Parameter(name = "take", description = "가져올 데이터 개수", example = "10", required = true, schema = @Schema(type = "integer", format = "int32")),
+	})
+	ResponseEntity<InternalMeetingGetAllWritingPostResponseDto> getMeetingsForWritingPost(
+		@ModelAttribute @Valid @Parameter(hidden = true) PageOptionsDto pageOptionsDto
+	);
+
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/InternalMeetingController.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/InternalMeetingController.java
@@ -33,7 +33,7 @@ public class InternalMeetingController implements InternalMeetingApi {
 	@Override
 	@GetMapping("/post")
 	public ResponseEntity<InternalMeetingGetAllWritingPostResponseDto> getMeetingsForWritingPost(
-		PageOptionsDto pageOptionsDto) {
+		@ModelAttribute @Valid PageOptionsDto pageOptionsDto) {
 		return ResponseEntity.ok().body(internalMeetingService.getMeetingsForWritingPost(pageOptionsDto));
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/InternalMeetingController.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/InternalMeetingController.java
@@ -1,7 +1,8 @@
 package org.sopt.makers.crew.main.internal;
 
+import org.sopt.makers.crew.main.global.pagination.dto.PageOptionsDto;
 import org.sopt.makers.crew.main.internal.dto.InternalMeetingGetAllMeetingDto;
-import org.sopt.makers.crew.main.internal.dto.UserOrgIdRequestDto;
+import org.sopt.makers.crew.main.internal.dto.InternalMeetingGetAllWritingPostResponseDto;
 import org.sopt.makers.crew.main.internal.service.InternalMeetingService;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
 import org.springframework.http.ResponseEntity;
@@ -27,5 +28,12 @@ public class InternalMeetingController implements InternalMeetingApi {
 		@RequestParam @Valid Integer orgId) {
 
 		return ResponseEntity.ok().body(internalMeetingService.getMeetings(queryCommand, orgId));
+	}
+
+	@Override
+	@GetMapping("/post")
+	public ResponseEntity<InternalMeetingGetAllWritingPostResponseDto> getMeetingsForWritingPost(
+		PageOptionsDto pageOptionsDto) {
+		return ResponseEntity.ok().body(internalMeetingService.getMeetingsForWritingPost(pageOptionsDto));
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/dto/InternalMeetingForWritingPostDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/dto/InternalMeetingForWritingPostDto.java
@@ -1,0 +1,26 @@
+package org.sopt.makers.crew.main.internal.dto;
+
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "InternalMeetingForWritingPostDto", description = "[Internal] 모임 피드 작성시 모임 전체 조회 응답 Dto")
+public record InternalMeetingForWritingPostDto(
+	@Schema(description = "모임 제목", example = "오늘 21시 강남 스터디")
+	String title,
+	@Schema(description = "모임 분류, [스터디 or 행사 or 세미나 or 번쩍 or 강연]", example = "스터디", allowableValues = {"스터디", "행사",
+		"세미나", " 번쩍", " 강연"})
+	MeetingCategory category,
+	@Schema(description = "모임 이미지", example = "[url 형식]")
+	String imageUrl,
+	@Schema(description = "모임 설명", example = "해당 모임은 이런 모임이에요~~")
+	String description) {
+
+	public static InternalMeetingForWritingPostDto from(Meeting entity) {
+		return new InternalMeetingForWritingPostDto(entity.getTitle(),
+			entity.getCategory(),
+			entity.getImageURL().get(0).getUrl(),
+			entity.getDesc());
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/dto/InternalMeetingGetAllWritingPostResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/dto/InternalMeetingGetAllWritingPostResponseDto.java
@@ -1,0 +1,15 @@
+package org.sopt.makers.crew.main.internal.dto;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.global.pagination.dto.PageMetaDto;
+
+public record InternalMeetingGetAllWritingPostResponseDto(
+	List<InternalMeetingForWritingPostDto> meetings,
+	PageMetaDto pageMetaData
+) {
+	public static InternalMeetingGetAllWritingPostResponseDto from(List<InternalMeetingForWritingPostDto> meetings,
+		PageMetaDto metaDto) {
+		return new InternalMeetingGetAllWritingPostResponseDto(meetings, metaDto);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingService.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingService.java
@@ -11,10 +11,13 @@ import org.sopt.makers.crew.main.global.pagination.dto.PageOptionsDto;
 import org.sopt.makers.crew.main.global.util.ActiveGenerationProvider;
 import org.sopt.makers.crew.main.global.util.CustomPageable;
 import org.sopt.makers.crew.main.global.util.Time;
+import org.sopt.makers.crew.main.internal.dto.InternalMeetingForWritingPostDto;
 import org.sopt.makers.crew.main.internal.dto.InternalMeetingGetAllMeetingDto;
+import org.sopt.makers.crew.main.internal.dto.InternalMeetingGetAllWritingPostResponseDto;
 import org.sopt.makers.crew.main.internal.dto.InternalMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,7 +38,7 @@ public class InternalMeetingService {
 	 * [for. APP BE] 모일 리스트 페이지네이션 조회 (10개)
 	 *
 	 * @param queryCommand 게시글 조회를 위한 쿼리 명령 객체
-	 * @param orgId 플레이그라운드 orgId
+	 * @param orgId        플레이그라운드 orgId
 	 * @return 게시글 정보(게시글 객체 + 댓글 단 사람의 썸네일 + 차단된 유저의 게시물 여부)와 페이지 메타 정보를 포함한 응답 DTO
 	 * @apiNote 사용자가 차단한 유저의 모임은 해당 모임에 대한 차단 여부를 함께 반환
 	 */
@@ -64,5 +67,25 @@ public class InternalMeetingService {
 		PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, (int)meetings.getTotalElements());
 
 		return new InternalMeetingGetAllMeetingDto(meetingResponseDtos, pageMetaDto);
+	}
+
+	/**
+	 * [for. PG BE] 모임 리스트 페이지네이션 조회 (10개)
+	 *
+	 * @param pageDto 페이지네이션 정보
+	 * @return 게시글 정보(게시글 객체 + 댓글 단 사람의 썸네일 + 차단된 유저의 게시물 여부)와 페이지 메타 정보를 포함한 응답 DTO
+	 */
+	public InternalMeetingGetAllWritingPostResponseDto getMeetingsForWritingPost(PageOptionsDto pageDto) {
+
+		Page<Meeting> pagedMeetings = meetingRepository.findAllByQuery(
+			PageRequest.of(pageDto.getPage() - 1, pageDto.getTake()));
+
+		List<InternalMeetingForWritingPostDto> meetings = pagedMeetings.getContent().stream()
+			.map(InternalMeetingForWritingPostDto::from)
+			.toList();
+
+		PageMetaDto pageMetaDto = new PageMetaDto(pageDto, (int)pagedMeetings.getTotalElements());
+
+		return InternalMeetingGetAllWritingPostResponseDto.from(meetings, pageMetaDto);
 	}
 }


### PR DESCRIPTION
## 👩‍💻 Contents

- Internal 용 모임 전체 조회(피드 작성용) API 추가  
  - `InternalMeetingApi`, `InternalMeetingController`, `InternalMeetingService`에 모임 전체 조회 API 및 관련 메서드 구현
- 전체 조회용 DTO 추가  
  - `InternalMeetingForWritingPostDto`, `InternalMeetingGetAllWritingPostResponseDto` 신규 생성
- 레포지토리 전체 조회 메서드 추가  
  - `MeetingSearchRepository`, `MeetingSearchRepositoryImpl`에 `findAllByQuery(Pageable)` 메서드 및 관련 로직 구현

## 📝 Review Note

- 내부 피드 작성 시 모임 전체 조회가 필요한 요구사항을 반영했습니다.
- 페이징 처리 및 DTO 구조를 단순화하여 확장성을 고려했습니다.
- 네이밍 및 API 경로에 대한 피드백 환영합니다.

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #692 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?