### PR TITLE
Feat/#697

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostSearchRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostSearchRepository.java
@@ -3,11 +3,14 @@ package org.sopt.makers.crew.main.entity.post;
 import org.sopt.makers.crew.main.post.v2.dto.query.PostGetPostsCommand;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailBaseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailWithPartBaseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface PostSearchRepository {
 	Page<PostDetailResponseDto> findPostList(PostGetPostsCommand queryCommand, Pageable pageable, Integer userId);
+
+	Page<PostDetailWithPartBaseDto> findPostList(Pageable pageable, Integer userId);
 
 	PostDetailBaseDto findPost(Integer userId, Integer postId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostSearchRepositoryImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostSearchRepositoryImpl.java
@@ -1,11 +1,11 @@
 package org.sopt.makers.crew.main.entity.post;
 
-import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
 import static org.sopt.makers.crew.main.entity.comment.QComment.*;
 import static org.sopt.makers.crew.main.entity.like.QLike.*;
 import static org.sopt.makers.crew.main.entity.meeting.QMeeting.*;
 import static org.sopt.makers.crew.main.entity.post.QPost.*;
 import static org.sopt.makers.crew.main.entity.user.QUser.*;
+import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -13,14 +13,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.sopt.makers.crew.main.entity.user.UserRepository;
 import org.sopt.makers.crew.main.global.exception.BadRequestException;
 import org.sopt.makers.crew.main.post.v2.dto.query.PostGetPostsCommand;
 import org.sopt.makers.crew.main.post.v2.dto.response.CommenterThumbnails;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailBaseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailWithPartBaseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.QPostDetailBaseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.QPostDetailWithPartBaseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.QPostMeetingDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.QPostWriterInfoDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.QPostWriterWithPartInfoDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -40,6 +44,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostSearchRepositoryImpl implements PostSearchRepository {
 	private final JPAQueryFactory queryFactory;
+	private final UserRepository userRepository;
 
 	@Override
 	public Page<PostDetailResponseDto> findPostList(PostGetPostsCommand queryCommand, Pageable pageable,
@@ -51,6 +56,43 @@ public class PostSearchRepositoryImpl implements PostSearchRepository {
 
 		return PageableExecutionUtils.getPage(content, PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()),
 			countQuery::fetchFirst);
+	}
+
+	/**
+	 * 플그 모임탭에서 보여주기 위한 피드들을 조회합니다.
+	 * <p>
+	 * 모임 id별로 호출하지 않고 최신순 피드들을 조회하는 역할입니다.
+	 *
+	 * @param pageable 페이지네이션용 파라미터
+	 * @return 조회되는 피드들 페이지당 take 갯수씩 제공
+	 */
+	@Override
+	public Page<PostDetailWithPartBaseDto> findPostList(Pageable pageable, Integer userId) {
+
+		JPAQuery<Long> count = getCount();
+
+		List<PostDetailWithPartBaseDto> contentList = getContentList(pageable, userId);
+
+		return PageableExecutionUtils.getPage(contentList, pageable, count::fetchFirst);
+	}
+
+	private List<PostDetailWithPartBaseDto> getContentList(Pageable pageable, Integer userId) {
+		return queryFactory.select(
+				new QPostDetailWithPartBaseDto(post.id, post.title, post.contents, post.createdDate, post.images,
+					new QPostWriterWithPartInfoDto(post.user.id, post.user.orgId, post.user.name,
+						post.user.profileImage,
+						post.user.activities
+					),
+					post.likeCount, ExpressionUtils.as(
+					JPAExpressions.selectFrom(like).where(like.postId.eq(post.id).and(like.userId.eq(userId))).exists(),
+					"isLiked"), post.viewCount, post.commentCount,
+					new QPostMeetingDto(post.meeting.id, post.meeting.title, post.meeting.category, post.meeting.imageURL,
+						post.meeting.desc)))
+			.from(post)
+			.orderBy(post.createdDate.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
 	}
 
 	@Override
@@ -121,6 +163,15 @@ public class PostSearchRepositoryImpl implements PostSearchRepository {
 
 	private JPAQuery<Long> getCount(Integer meetingId) {
 		return queryFactory.select(post.count()).from(post).where(meetingIdEq(meetingId));
+	}
+
+	/**
+	 * 모든 피드의 갯수 값을 가져온다.
+	 *
+	 * @return 모든 피드의 갯수 제공
+	 */
+	private JPAQuery<Long> getCount() {
+		return queryFactory.select(post.count()).from(post);
 	}
 
 	private BooleanExpression meetingIdEq(Integer meetingId) {

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/InternalPostApi.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/InternalPostApi.java
@@ -1,0 +1,31 @@
+package org.sopt.makers.crew.main.internal;
+
+import org.sopt.makers.crew.main.global.pagination.dto.PageOptionsDto;
+import org.sopt.makers.crew.main.internal.dto.InternalPostGetAllResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "[Internal] 피드")
+public interface InternalPostApi {
+
+	@Operation(summary = "[Internal] 피드 전체 조회", description = "플그 모임 탭에서의 모임 피드를 보여주기 위한 조회 api")
+	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "모임 목록 조회 성공")})
+	@Parameters(value = {
+		@Parameter(name = "page", description = "페이지", example = "1", required = true, schema = @Schema(type = "integer", format = "int32")),
+		@Parameter(name = "take", description = "가져올 데이터 개수", example = "10", required = true, schema = @Schema(type = "integer", format = "int32")),
+	})
+	ResponseEntity<InternalPostGetAllResponseDto> getPosts(
+		@Parameter(description = "플레이그라운드 유저 ID(orgId)", example = "1") Integer orgId,
+		@ModelAttribute @Valid @Parameter(hidden = true) PageOptionsDto pageOptionsDto
+	);
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/InternalPostController.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/InternalPostController.java
@@ -1,0 +1,29 @@
+package org.sopt.makers.crew.main.internal;
+
+import org.sopt.makers.crew.main.global.pagination.dto.PageOptionsDto;
+import org.sopt.makers.crew.main.internal.dto.InternalPostGetAllResponseDto;
+import org.sopt.makers.crew.main.internal.service.InternalPostService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/internal/post")
+@RequiredArgsConstructor
+public class InternalPostController implements InternalPostApi {
+
+	private final InternalPostService internalPostService;
+
+	@Override
+	@GetMapping("/{orgId}")
+	public ResponseEntity<InternalPostGetAllResponseDto> getPosts(@PathVariable Integer orgId,
+		@ModelAttribute @Valid PageOptionsDto pageOptionsDto) {
+		return ResponseEntity.ok(internalPostService.getPosts(pageOptionsDto, orgId));
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/dto/InternalPostGetAllResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/dto/InternalPostGetAllResponseDto.java
@@ -1,0 +1,12 @@
+package org.sopt.makers.crew.main.internal.dto;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.global.pagination.dto.PageMetaDto;
+
+public record InternalPostGetAllResponseDto(List<InternalPostResponseDto> posts, PageMetaDto pageMeta) {
+
+	public static InternalPostGetAllResponseDto from(List<InternalPostResponseDto> posts, PageMetaDto pageMeta) {
+		return new InternalPostGetAllResponseDto(posts, pageMeta);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/dto/InternalPostResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/dto/InternalPostResponseDto.java
@@ -1,0 +1,66 @@
+package org.sopt.makers.crew.main.internal.dto;
+
+import java.time.LocalDateTime;
+
+import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailWithPartBaseDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record InternalPostResponseDto(
+	@Schema(description = "피드 id", example = "1")
+	@NotNull
+	Integer id,
+	@Schema(description = "피드 제목", example = "피드 제목입니다.")
+	@NotNull
+	String title,
+
+	@Schema(description = "피드 내용", example = "피드 내용입니다.")
+	@NotNull
+	String contents,
+
+	@Schema(description = "피드 생성일자", example = "2024-07-31T15:30:00")
+	@NotNull
+	LocalDateTime createdDate,
+
+	@Schema(description = "피드 이미지", example = "[\"url1\", \"url2\"]")
+	@NotNull
+	String[] images,
+
+	@Schema(description = "피드 작성자 객체", example = "")
+	@NotNull
+	InternalPostWriterDetailInfoDto user,
+
+	@Schema(description = "피드 좋아요 갯수", example = "20")
+	@NotNull
+	int likeCount,
+
+	//* 본인이 좋아요를 눌렀는지 여부
+	@Schema(description = "피드 좋아요 여부", example = "true")
+	@NotNull
+	Boolean isLiked,
+
+	@Schema(description = "피드 조회수", example = "30")
+	@NotNull
+	int viewCount,
+
+	@Schema(description = "피드 댓글 수", example = "5")
+	@NotNull
+	int commentCount
+) {
+
+	public static InternalPostResponseDto from(PostDetailWithPartBaseDto postDetailWithPartBaseDto) {
+		return new InternalPostResponseDto(
+			postDetailWithPartBaseDto.getId(),
+			postDetailWithPartBaseDto.getTitle(),
+			postDetailWithPartBaseDto.getContents(),
+			postDetailWithPartBaseDto.getCreatedDate(),
+			postDetailWithPartBaseDto.getImages(),
+			InternalPostWriterDetailInfoDto.from(postDetailWithPartBaseDto.getUser()),
+			postDetailWithPartBaseDto.getLikeCount(),
+			postDetailWithPartBaseDto.getIsLiked(),
+			postDetailWithPartBaseDto.getViewCount(),
+			postDetailWithPartBaseDto.getCommentCount()
+		);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/dto/InternalPostWriterDetailInfoDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/dto/InternalPostWriterDetailInfoDto.java
@@ -1,0 +1,41 @@
+package org.sopt.makers.crew.main.internal.dto;
+
+import java.util.Comparator;
+
+import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
+import org.sopt.makers.crew.main.global.exception.ErrorStatus;
+import org.sopt.makers.crew.main.global.exception.ServerException;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostWriterWithPartInfoDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record InternalPostWriterDetailInfoDto(
+	@Schema(description = "작성자 id, 크루에서 사용하는 userId", example = "1")
+	Integer id,
+	@Schema(description = "작성자 org id, 메이커스 프로덕트에서 범용적으로 사용하는 userId", example = "1")
+	Integer orgId,
+	@Schema(description = "작성자 이름", example = "홍길동")
+	String name,
+	@Schema(description = "작성자 프로필 사진", example = "[url] 형식")
+	String profileImage,
+	@Schema(description = "작성자 현재 기수, 파트 ", example = "36기 서버파트")
+	UserActivityVO partInfo
+) {
+	public static InternalPostWriterDetailInfoDto from(PostWriterWithPartInfoDto postWriterWithPartInfoDto) {
+		return new InternalPostWriterDetailInfoDto(
+			postWriterWithPartInfoDto.getId(),
+			postWriterWithPartInfoDto.getOrgId(),
+			postWriterWithPartInfoDto.getName(),
+			postWriterWithPartInfoDto.getProfileImage(),
+			getRecentActivity(postWriterWithPartInfoDto)
+		);
+	}
+
+	private static UserActivityVO getRecentActivity(PostWriterWithPartInfoDto postWriterWithPartInfoDto) {
+		return postWriterWithPartInfoDto.getPartInfo().stream()
+			.filter(userActivityVO -> userActivityVO.getPart() != null)
+			.max(Comparator.comparingInt(UserActivityVO::getGeneration))
+			.orElseThrow(() -> new ServerException(ErrorStatus.INTERNAL_SERVER_ERROR.getErrorCode()));
+	}
+
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalPostService.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalPostService.java
@@ -1,0 +1,49 @@
+package org.sopt.makers.crew.main.internal.service;
+
+import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.entity.post.PostRepository;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.UserRepository;
+import org.sopt.makers.crew.main.global.exception.NotFoundException;
+import org.sopt.makers.crew.main.global.pagination.dto.PageMetaDto;
+import org.sopt.makers.crew.main.global.pagination.dto.PageOptionsDto;
+import org.sopt.makers.crew.main.internal.dto.InternalPostGetAllResponseDto;
+import org.sopt.makers.crew.main.internal.dto.InternalPostResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostDetailWithPartBaseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class InternalPostService {
+
+	private final PostRepository postRepository;
+	private final UserRepository userRepository;
+
+	public InternalPostGetAllResponseDto getPosts(PageOptionsDto pageOptionsDto, Integer orgId) {
+
+		Pageable pageRequest = PageRequest.of(pageOptionsDto.getPage() - 1, pageOptionsDto.getTake());
+
+		User user = userRepository.findByOrgId(orgId)
+			.orElseThrow(() -> new NotFoundException(NOT_FOUND_USER.getErrorCode()));
+
+		Page<PostDetailWithPartBaseDto> postList =
+			postRepository.findPostList(pageRequest, user.getId());
+
+		List<InternalPostResponseDto> list = postList.getContent()
+			.stream()
+			.map(InternalPostResponseDto::from)
+			.toList();
+
+		PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, (int)postList.getTotalElements());
+
+		return InternalPostGetAllResponseDto.from(list, pageMetaDto);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostDetailWithPartBaseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostDetailWithPartBaseDto.java
@@ -1,0 +1,77 @@
+package org.sopt.makers.crew.main.post.v2.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+@Schema(name = "PostDetailBaseDto", description = "게시글의 기본 정보를 담고 있는 Dto")
+public class PostDetailWithPartBaseDto {
+
+	@Schema(description = "게시글 id", example = "1")
+	@NotNull
+	private final Integer id;
+
+	@Schema(description = "게시글 제목", example = "게시글 제목입니다.")
+	@NotNull
+	private final String title;
+
+	@Schema(description = "게시글 내용", example = "게시글 내용입니다.")
+	@NotNull
+	private final String contents;
+
+	@Schema(description = "게시글 생성일자", example = "2024-07-31T15:30:00")
+	@NotNull
+	private final LocalDateTime createdDate;
+
+	@Schema(description = "게시글 이미지", example = "[\"url1\", \"url2\"]")
+	@NotNull
+	private final String[] images;
+
+	@Schema(description = "게시글 작성자 객체", example = "")
+	@NotNull
+	private final PostWriterWithPartInfoDto user;
+
+	@Schema(description = "게시글 좋아요 갯수", example = "20")
+	@NotNull
+	private final int likeCount;
+
+	//* 본인이 좋아요를 눌렀는지 여부
+	@Schema(description = "게시글 좋아요 여부", example = "true")
+	@NotNull
+	private final Boolean isLiked;
+
+	@Schema(description = "게시글 조회수", example = "30")
+	@NotNull
+	private final int viewCount;
+
+	@Schema(description = "게시글 댓글 수", example = "5")
+	@NotNull
+	private final int commentCount;
+
+	@Schema(description = "게시글에 대한 모임", example = "")
+	@NotNull
+	private final PostMeetingDto meeting;
+
+	@QueryProjection
+	public PostDetailWithPartBaseDto(Integer id, String title, String contents, LocalDateTime createdDate,
+		String[] images,
+		PostWriterWithPartInfoDto user, int likeCount, boolean isLiked, int viewCount, int commentCount,
+		PostMeetingDto meeting) {
+		this.id = id;
+		this.title = title;
+		this.contents = contents;
+		this.createdDate = createdDate;
+		this.images = images;
+		this.user = user;
+		this.likeCount = likeCount;
+		this.isLiked = isLiked;
+		this.viewCount = viewCount;
+		this.commentCount = commentCount;
+		this.meeting = meeting;
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostWriterWithPartInfoDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostWriterWithPartInfoDto.java
@@ -1,0 +1,46 @@
+package org.sopt.makers.crew.main.post.v2.dto.response;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+@Schema(name = "PostWriterDetailInfoDto", description = "게시글 작성자 상세 Dto")
+public class PostWriterWithPartInfoDto {
+
+	@Schema(description = "작성자 id, 크루에서 사용하는 userId", example = "1")
+	@NotNull
+	private final Integer id;
+
+	@Schema(description = "작성자 org id, 메이커스 프로덕트에서 범용적으로 사용하는 userId", example = "1")
+	@NotNull
+	private final Integer orgId;
+
+	@Schema(description = "작성자 이름", example = "홍길동")
+	@NotNull
+	private final String name;
+
+	@Schema(description = "작성자 프로필 사진", example = "[url] 형식")
+	@NotNull
+	private final String profileImage;
+
+	@Schema(description = "작성자 기수, 파트 ", example = "36기 서버파트")
+	private final List<UserActivityVO> partInfo;
+
+	@QueryProjection
+	public PostWriterWithPartInfoDto(Integer id, Integer orgId, String name, String profileImage,
+		List<UserActivityVO> partInfo) {
+		this.id = id;
+		this.orgId = orgId;
+		this.name = name;
+		this.profileImage = profileImage;
+		this.partInfo = partInfo;
+	}
+
+}


### PR DESCRIPTION
## 👩‍💻 Contents

- 플그 모임 탭용 피드 전체 조회 API 구현
  - `InternalPostApi`, `InternalPostController`, `InternalPostService` 신규 생성
  - 플그 모임 탭에서 사용할 피드 전체 조회 API 및 관련 메서드 구현
- 피드 조회용 DTO 구조 추가
  - `PostDetailWithPartBaseDto`, `PostWriterWithPartInfoDto` 신규 생성
  - `InternalPostGetAllResponseDto`, `InternalPostResponseDto`, `InternalPostWriterDetailInfoDto` 신규 생성
- Repository 레이어 확장
  - `PostSearchRepository` 인터페이스에 `findPostList(Pageable pageable, Integer userId)` 메서드 추가
  - `PostSearchRepositoryImpl`에 전체 조회 로직 구현 및 `getContentList`, `getCount` 메서드 추가
- 페이징 처리 및 응답 구조 구현
  - 플그 모임 탭에서 최신순으로 피드를 조회할 수 있는 기능 제공

## 📝 Review Note

- 플그 모임 탭에서 모임별 피드를 전체적으로 조회할 수 있는 API를 구현했습니다.
- 기존 모임별 조회와는 달리 모든 모임의 피드를 최신순으로 조회하는 기능입니다.
- 페이징 처리를 통해 성능을 최적화했습니다.
- DTO 구조를 명확히 분리하여 확장성을 고려했습니다.
- API 네이밍 및 응답 구조에 대한 피드백 환영합니다.

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #697 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?