### PR TITLE
refactor: 보안 관련 설정을 SecurityConfig 한 곳에서 통합 관리 및 allowCredentials를 false로 변경

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/global/config/SecurityConfig.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.crew.main.global.config;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.sopt.makers.crew.main.global.security.filter.JwtAuthenticationExceptionFilter;
@@ -15,6 +16,9 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import lombok.RequiredArgsConstructor;
 
@@ -73,5 +77,27 @@ public class SecurityConfig {
 			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 			.addFilterBefore(jwtAuthenticationExceptionFilter, JwtAuthenticationFilter.class);
 		return http.build();
+	}
+
+	@Bean
+	CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowCredentials(false);
+
+		configuration.setAllowedOrigins(List.of(
+			"https://playground.sopt.org",
+			"http://localhost:3000",
+			"https://sopt-internal-dev.pages.dev",
+			"https://crew.api.dev.sopt.org",
+			"https://crew.api.prod.sopt.org"
+		));
+
+		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+		configuration.setAllowedHeaders(List.of("*"));
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+
+		return source;
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/global/config/WebMvcConfig.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/config/WebMvcConfig.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.sopt.makers.crew.main.global.resolver.AuthenticatedUserIdArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import lombok.RequiredArgsConstructor;
@@ -19,20 +18,5 @@ public class WebMvcConfig implements WebMvcConfigurer {
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
 		resolvers.add(authenticatedUserIdArgumentResolver);
-	}
-
-	@Override
-	public void addCorsMappings(CorsRegistry registry) {
-		registry.addMapping("/**")
-			.allowedOrigins(
-				"https://playground.sopt.org",
-				"http://localhost:3000",
-				"https://sopt-internal-dev.pages.dev",
-				"https://crew.api.dev.sopt.org",
-				"https://crew.api.prod.sopt.org"
-			)
-			.allowedMethods("GET", "POST", "PATCH", "DELETE", "PUT", "OPTIONS")
-			.allowedHeaders("*")
-			.allowCredentials(true);
 	}
 }


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
- 보안 관련 설정을 SecurityConfig 한 곳에서 통합 관리 및 allowCredentials를 false로 변경했습니다.

## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #719 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?