### PR TITLE
hotfix: 피드와 연결된 모임 제목 필드 생성

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/internal/dto/InternalPostResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/dto/InternalPostResponseDto.java
@@ -55,6 +55,10 @@ public record InternalPostResponseDto(
 	@NotNull
 	int meetingId,
 
+	@Schema(description = "피드와 연결된 모임 제목", example = "어서와요")
+	@NotNull
+	String meetingTitle,
+
 	@Schema(description = "해당 피드와 연결된 모임 category", example = "스터디")
 	String category
 ) {
@@ -73,6 +77,7 @@ public record InternalPostResponseDto(
 			postDetailWithPartBaseDto.getViewCount(),
 			postDetailWithPartBaseDto.getCommentCount(),
 			postDetailWithPartBaseDto.getMeeting().getId(),
+			postDetailWithPartBaseDto.getMeeting().getTitle(),
 			postDetailWithPartBaseDto.getMeeting().getCategory()
 		);
 	}


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->

피드와 연결된 모임 제목 필드 생성

<img width="897" height="317" alt="image" src="https://github.com/user-attachments/assets/4ff9744a-b6e4-435c-bc0f-809b51e6d782" />


## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #738 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?