### PR TITLE
feat: 게시글 조회수 증가용 api 구현 진행

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Api.java
@@ -13,6 +13,7 @@ import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2ReportResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2SwitchPostLikeResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2UpdatePostResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostViewCountResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -85,4 +86,8 @@ public interface PostV2Api {
 	@Operation(summary = "모임 게시글 좋아요 토글")
 	@ApiResponse(responseCode = "201", description = "성공")
 	ResponseEntity<PostV2SwitchPostLikeResponseDto> switchPostLike(@PathVariable Integer postId, Principal principal);
+
+	@Operation(summary = "모임 게시글 조회수 증가")
+	@ApiResponse(responseCode = "200", description = "성공, 응답 : 조회수")
+	ResponseEntity<PostViewCountResponseDto> addViewCount(@PathVariable Integer postId, Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/PostV2Controller.java
@@ -14,6 +14,7 @@ import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2ReportResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2SwitchPostLikeResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2UpdatePostResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostViewCountResponseDto;
 import org.sopt.makers.crew.main.post.v2.service.PostV2Service;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -75,6 +76,13 @@ public class PostV2Controller implements PostV2Api {
 	public ResponseEntity<PostDetailBaseDto> getPost(@PathVariable Integer postId, Principal principal) {
 		Integer userId = UserUtil.getUserId(principal);
 		return ResponseEntity.ok(postV2Service.getPost(userId, postId));
+	}
+
+	@Override
+	@PostMapping("/{postId}/views")
+	@ResponseStatus(HttpStatus.OK)
+	public ResponseEntity<PostViewCountResponseDto> addViewCount(@PathVariable Integer postId, Principal principal) {
+		return ResponseEntity.ok(postV2Service.addViewCount(postId));
 	}
 
 	@Override

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostViewCountResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/PostViewCountResponseDto.java
@@ -1,0 +1,20 @@
+package org.sopt.makers.crew.main.post.v2.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@Schema(name = "PostViewCountResponseDto", description = "게시글 조회수 증가용 api 응답 Dto")
+@AllArgsConstructor
+public class PostViewCountResponseDto {
+
+	@Schema(description = "게시글 조회수", example = "30")
+	@NotNull
+	private final int viewCount;
+
+	public static PostViewCountResponseDto of(int viewCount) {
+		return new PostViewCountResponseDto(viewCount);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2Service.java
@@ -11,6 +11,7 @@ import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2ReportResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2SwitchPostLikeResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2UpdatePostResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostViewCountResponseDto;
 
 public interface PostV2Service {
 
@@ -19,6 +20,8 @@ public interface PostV2Service {
 	PostV2GetPostsResponseDto getPosts(PostGetPostsCommand queryCommand, Integer userId);
 
 	PostDetailBaseDto getPost(Integer userId, Integer postId);
+
+	PostViewCountResponseDto addViewCount(Integer postId);
 
 	void mentionUserInPost(PostV2MentionUserInPostRequestDto requestBody, Integer userId);
 

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
@@ -45,6 +45,7 @@ import org.sopt.makers.crew.main.post.v2.dto.response.PostV2GetPostsResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2ReportResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2SwitchPostLikeResponseDto;
 import org.sopt.makers.crew.main.post.v2.dto.response.PostV2UpdatePostResponseDto;
+import org.sopt.makers.crew.main.post.v2.dto.response.PostViewCountResponseDto;
 import org.sopt.makers.crew.main.user.v2.service.UserV2Service;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
@@ -174,8 +175,15 @@ public class PostV2ServiceImpl implements PostV2Service {
 	public PostDetailBaseDto getPost(Integer userId, Integer postId) {
 		PostDetailBaseDto responseDto = postRepository.findPost(userId, postId);
 		Post post = postRepository.findByIdOrThrow(postId);
-		post.increaseViewCount();
 		return responseDto;
+	}
+
+	@Override
+	@Transactional
+	public PostViewCountResponseDto addViewCount(Integer postId) {
+		Post post = postRepository.findByIdOrThrow(postId);
+		post.increaseViewCount();
+		return new PostViewCountResponseDto(post.getViewCount());
 	}
 
 	@Override


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->

- 기존에 있었던 조회 시 증가 로직을 분리하여 다른 api로써 증가시킬 수 있도록 구현

<img width="427" height="657" alt="image" src="https://github.com/user-attachments/assets/b7247533-d31e-438b-afb2-53a2fe88a445" />


## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #743 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?