### PR TITLE
feat: Lambda 배포를 위한 Gradle 빌드 설정 추가

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -132,6 +132,11 @@ dependencies {
     // Library for parsing JWT/JWK tokens and verifying their signatures
     implementation 'com.nimbusds:nimbus-jose-jwt:9.37.3'
 
+    // ===== AWS Lambda Dependencies (for Serverless deployment) =====
+    implementation 'com.amazonaws.serverless:aws-serverless-java-container-springboot3:2.1.5'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.4.0'
+    implementation 'com.amazonaws:aws-lambda-java-events:3.16.1'
+
 }
 
 tasks.named('test') {
@@ -199,6 +204,45 @@ jacocoTestCoverageVerification {
                     '*.response'
                     // ...
             ]
+        }
+    }
+}
+
+// ===== JAR Configuration =====
+// EC2 배포용 bootJar와 Lambda 배포용 lambdaJar 모두 활성화
+jar {
+    enabled = true
+    archiveClassifier = ''
+}
+
+bootJar {
+    enabled = true
+}
+
+// ===== Lambda ZIP Build Task =====
+// Lambda 배포를 위한 ZIP 패키징 태스크
+// 실행: ./gradlew clean lambdaJar -x test
+task lambdaJar(type: Zip) {
+    dependsOn jar
+    archiveClassifier = 'lambda'
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    zip64 = true  // 대용량 ZIP 파일 지원
+
+    into('lib') {
+        from(jar)
+        from(configurations.runtimeClasspath) {
+            // Lambda에서 불필요한 Tomcat 의존성 제외
+            exclude "**/tomcat-embed-*.jar"
+            exclude "org/apache/tomcat/**"
+
+            // 서명 파일 제외 (Lambda 배포 시 충돌 방지)
+            exclude "META-INF/*.SF"
+            exclude "META-INF/*.DSA"
+            exclude "META-INF/*.RSA"
+            exclude "META-INF/MANIFEST.MF"
+
+            // 모듈 정보 제외
+            exclude "**/module-info.class"
         }
     }
 }


### PR DESCRIPTION
## 👩‍💻 Contents

## 1. Build 설정 수정 (`build.gradle`)

하이브리드 아키텍처(Dev: Lambda, Prod: EC2)를 지원하기 위해 빌드 설정을 이원화했습니다.

### ✅ AWS Lambda 의존성 추가
- `aws-serverless-java-container-springboot3:2.1.5`
- `aws-lambda-java-core:1.4.0`
- `aws-lambda-java-events:3.16.1`
- 기존 `spring-boot-starter-web`은 유지하여 EC2 배포(Tomcat) 호환성을 보장했습니다.

---

### ✅ Lambda 전용 빌드 태스크 (`lambdaJar`) 추가

- 역할: ./gradlew lambdaJar 실행 시 AWS Lambda 업로드용 ZIP 파일을 생성합니다.
- 구조: Lambda 환경에 맞춰 root에는 애플리케이션 클래스, lib/에는 의존성 JAR가 평탄화(flattened)된 구조를 가집니다.
- 최적화:
    - Tomcat 관련 의존성(tomcat-embed-*.jar, tomcat-embed-websocket 등)을 ZIP 패키징 단계에서 제외하여 용량을 줄이고 충돌을 방지했습니다.
   - 불필요한 메타데이터 파일(.SF, .DSA, MANIFEST.MF 등)을 제외했습니다.

---

### ✅ JAR 빌드 태스크 활성화 (`jar.enabled = true`)

- Spring Boot 플러그인 적용 시 기본적으로 비활성화되는 jar 태스크를 강제로 활성화했습니다.
- 이유: bootJar(Fat JAR)는 중첩된 구조(BOOT-INF/lib)를 가져 Lambda에서 로딩이 비효율적이므로, jar(Plain JAR)를 기반으로 lambdaJar를 구성하기 위함입니다.
- 결과:
    - bootJar → EC2 배포용 (Tomcat 포함)
    - lambdaJar → Lambda 배포용 (Tomcat 제외)
---

## 📝 Review Note

### 의사결정 과정: Tomcat 제외 방식
처음에는 build.gradle의 dependencies 블록에서 spring-boot-starter-web 선언 시 아예 Tomcat을 제외하려고 했으나, 이 경우 기존 EC2(Prod) 배포 시 내장 톰캣이 사라져 실행이 불가능해지는 문제가 있습니다. 따라서, 의존성은 그대로 두고 lambdaJar 태스크가 ZIP을 묶을 때만 물리적으로 Tomcat 파일들을 빼버리는 방식을 선택하여 하나의 코드베이스로 두 환경을 모두 지원하도록 구현했습니다.

### 참고: spring-boot-starter-tomcat JAR 포함 여부
빌드 결과물인 ZIP 파일에 spring-boot-starter-tomcat-3.x.x.jar 파일이 여전히 포함되어 보일 수 있습니다. 확인 결과 이는 메타데이터만 담긴 빈 껍데기 JAR(약 4KB)에 불과하며, 실제 서블릿 컨테이너 구현체인 tomcat-embed-core 등은 정상적으로 제거되었으므로 Lambda 실행에는 전혀 문제가 없습니다.

---

## 📣 Related Issue
- closed #784 

---

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?