### PR TITLE
feat: lambda 핸들러 클래스 구현

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/global/config/lambda/LambdaHandler.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/config/lambda/LambdaHandler.java
@@ -1,0 +1,49 @@
+package org.sopt.makers.crew.main.global.config.lambda;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.sopt.makers.crew.main.MainApplication;
+
+import com.amazonaws.serverless.exceptions.ContainerInitializationException;
+import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
+import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
+import com.amazonaws.serverless.proxy.spring.SpringBootLambdaContainerHandler;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LambdaHandler implements RequestStreamHandler {
+
+	private static final SpringBootLambdaContainerHandler<AwsProxyRequest, AwsProxyResponse> handler;
+
+	static {
+		long startTime = System.currentTimeMillis();
+
+		try {
+			log.info("Lambda Handler 초기화 시작...");
+
+			handler = SpringBootLambdaContainerHandler.getAwsProxyHandler(MainApplication.class);
+			long duration = System.currentTimeMillis() - startTime;
+
+			log.info("Lambda Handler 초기화 완료 (소요 시간: {}ms)", duration);
+		} catch (ContainerInitializationException e) {
+			log.error("Spring Boot 애플리케이션 초기화 실패", e);
+			throw new RuntimeException("Lambda Handler 초기화 실패 - CloudWatch Logs를 확인하세요", e);
+		}
+	}
+
+	@Override
+	public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context)
+		throws IOException {
+
+		if (handler == null) {
+			throw new IllegalStateException("Handler가 초기화되지 않았습니다. static 블록을 확인하세요.");
+		}
+
+		handler.proxyStream(inputStream, outputStream, context);
+	}
+}


### PR DESCRIPTION
## 👩‍💻 Contents

<!-- 작업 내용을 적어주세요 -->
### LambdaHandler 클래스 생성 및 구현
- AWS Lambda 환경에서 Spring Boot 애플리케이션을 실행하기 위한 진입점 클래스를 구현했습니
다.
- 상세 흐름은 아래와 같습니다

```mermaid
sequenceDiagram
    autonumber
    
    box "AWS Infra" #F9F9F9
        participant User as 👤 Client
        participant APIGW as 🌐 API Gateway
    end
    
    box "Lambda Container" #E1F5FE
        participant Handler as 🛠️ LambdaHandler
        participant Adapter as 🔌 ContainerHandler
        participant Spring as 🌱 Spring Boot
    end

    Note over User, Spring: 1. 요청 시작
    User->>APIGW: HTTP 요청 (GET /api/meetings)
    APIGW->>Handler: AWS JSON 이벤트로 변환하여 호출
    
    Note over Handler, Spring: 2. 변환 및 위임
    Handler->>Adapter: proxyStream(input, output) 호출
    
    Note right of Adapter: 여기가 핵심! 💡<br/>AWS JSON → Servlet Request 변환
    Adapter->>Adapter: AWS 이벤트 파싱 & 변환
    
    Adapter->>Spring: 표준 Servlet Request 전달
    
    Note over Spring: 3. 비즈니스 로직 실행
    Spring->>Spring: Controller -> Service -> Repository 실행
    
    Note right of Adapter: Servlet Response → AWS JSON 변환
    Spring-->>Adapter: 표준 Servlet Response 반환
    
    Adapter->>Adapter: AWS 응답 형식으로 변환
    Adapter-->>Handler: Output Stream에 JSON 쓰기
    
    Note over User, Spring: 4. 응답 반환
    Handler-->>APIGW: AWS JSON 응답 반환
    APIGW-->>User: 표준 HTTP 응답 (200 OK)
```

---

### ✅ 주요 구현 사항

#### 1. RequestStreamHandler 인터페이스 구현
- Lambda의 표준 핸들러 인터페이스를 구현하여 API Gateway 요청을 처리합니다.

#### 2. SpringBootLambdaContainerHandler 초기화
- Static 블록에서 `MainApplication.class`를 기반으로 Spring Boot 컨텍스트를 Lambda 환경에 초기화합니다.
- `getAwsProxyHandler()` 메서드를 사용하여 API Gateway와 Spring Boot를 연결합니다.

#### 3. Cold Start 성능 모니터링
- 초기화 시작/완료 시간을 로깅하여 CloudWatch에서 Cold Start 성능을 추적할 수 있도록 했습니다.
- 초기화 소요 시간을 밀리초(ms) 단위로 기록합니다.

#### 4. 에러 처리 및 로깅
- `@Slf4j`(Lombok)를 사용하여 프로젝트 전체 로깅 방식과 일관성을 유지했습니다.
- 초기화 실패 시 CloudWatch Logs 확인을 유도하는 명확한 에러 메시지를 제공합니다.

#### 5. Null Safety
- `handleRequest` 메서드에서 핸들러 초기화 여부를 검증하여 NPE를 방지합니다.

---

## 📝 Review Note

### 아키텍처 결정 사항

#### 1. 패키지 위치: `global.config.lambda`

**선택 이유**  
- Lambda 핸들러는 인프라 레이어 코드이므로 도메인 로직(meeting, post 등)과 분리했습니다.

**대안 검토**
- `main` 패키지에 직접 배치 → ❌ 도메인 코드와 인프라 코드 혼재  
- `lambda` 최상위 패키지 생성 → ⚠️ 새로운 최상위 구조 추가  
- `global.config.lambda` → ✅ 기존 구조와 일관성 유지

#### 2. 프로파일 설정 방식

- 초기에는 `System.setProperty("spring.profiles.active", "lambda-dev")`를 사용하려 했으나,  
  Spring Boot 컨텍스트 초기화 타이밍 문제로 인해 제거했습니다.

- **최종 결정:**  
  SAM Template의 환경변수(`SPRING_PROFILES_ACTIVE`)를 통해 설정하도록 변경  
  (Issue #4에서 구현 예정)

#### 3. 로깅 방식: `@Slf4j`

- `private static final Logger log = ...` 대신 Lombok `@Slf4j`를 사용하여  
  코드 간결성과 프로젝트 일관성을 확보했습니다.

---

## ✅ 검증 결과

- ✅ `./gradlew compileJava` 성공  
- ✅ IDE 린트 통과  
- ✅ Import 순서 정리 (java → org → com 순서)

---

## 📣 Related Issue
- closed #785 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?