### PR TITLE
fix: CI/CD 스크립트 crew 경로 지정

### DIFF
--- a/.github/workflows/prod-ci-cd.yml
+++ b/.github/workflows/prod-ci-cd.yml
@@ -80,6 +80,6 @@ jobs:
             export IMAGE_TAG="${{ steps.meta.outputs.version }}"
             export RELEASE_VERSION="${{ github.event.release.tag_name }}"
             export IMAGE_NAME="${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${IMAGE_TAG}"
-            cd ~
+            cd ~./crew
             chmod +x ./deploy.sh
             ./deploy.sh


### PR DESCRIPTION
## 👩‍💻 Contents

CI/CD 스크립트에서 /crew로 크루 경로를 다시 지정했습니다


## ✅ 점검사항

- [x] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [x] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [x] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?