### PR TITLE
fix: 모임탭에서 페이지, 키워드 동시 필터링시 빈배열이 반환되는 문제

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepository.java
@@ -8,8 +8,22 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface MeetingSearchRepository {
+	/**
+	 * 조건에 맞는 모임과 전체 개수를 함께 조회한다.
+	 */
 	Page<Meeting> findAllByQuery(MeetingV2GetAllMeetingQueryDto queryCommand, Pageable pageable, Time time,
 		Integer activeGeneration);
+
+	/**
+	 * 조건과 페이지 정보에 맞는 모임 목록만 조회한다.
+	 */
+	List<Meeting> findMeetingsByQuery(MeetingV2GetAllMeetingQueryDto queryCommand, Pageable pageable, Time time,
+		Integer activeGeneration);
+
+	/**
+	 * 조건에 맞는 모임의 전체 개수를 조회한다.
+	 */
+	long countMeetingsByQuery(MeetingV2GetAllMeetingQueryDto queryCommand, Time time, Integer activeGeneration);
 
 	List<Meeting> findRecommendMeetings(List<Integer> meetingIds, Time time);
 

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepositoryImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepositoryImpl.java
@@ -18,9 +18,9 @@ import org.sopt.makers.crew.main.global.pagination.PaginationType;
 import org.sopt.makers.crew.main.global.util.Time;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.types.Expression;
@@ -64,15 +64,13 @@ public class MeetingSearchRepositoryImpl implements MeetingSearchRepository {
 				activeGeneration);
 			JPAQuery<Long> countQuery = getCount(queryCommand, now, activeGeneration);
 
-			return PageableExecutionUtils.getPage(flashMeetings,
-				PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()), countQuery::fetchFirst);
+			return createPage(flashMeetings, pageable, countQuery);
 		}
 
 		List<Meeting> meetings = getMeetings(queryCommand, pageable, now, activeGeneration);
 		JPAQuery<Long> countQuery = getCount(queryCommand, now, activeGeneration);
 
-		return PageableExecutionUtils.getPage(meetings,
-			PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()), countQuery::fetchFirst);
+		return createPage(meetings, pageable, countQuery);
 	}
 
 	/**
@@ -106,8 +104,17 @@ public class MeetingSearchRepositoryImpl implements MeetingSearchRepository {
 			.limit(pageable.getPageSize())
 			.fetch();
 
-		return PageableExecutionUtils.getPage(meetings,
-			PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()), getCount()::fetchFirst);
+		return createPage(meetings, pageable, getCount());
+	}
+
+	private Page<Meeting> createPage(List<Meeting> meetings, Pageable pageable, JPAQuery<Long> countQuery) {
+		Long totalCount = countQuery.fetchOne();
+
+		return new PageImpl<>(
+			meetings,
+			PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()),
+			totalCount == null ? 0L : totalCount
+		);
 	}
 
 	/**

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepositoryImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepositoryImpl.java
@@ -42,6 +42,7 @@ public class MeetingSearchRepositoryImpl implements MeetingSearchRepository {
 	/**
 	 * @note: canJoinOnlyActiveGeneration 처리 유의
 	 * @note: status 처리 유의
+	 * @implSpec : 조건에 맞는 content와 count를 함께 조회하여 Page 객체를 생성한다.
 	 */
 	@Override
 	public Page<Meeting> findAllByQuery(MeetingV2GetAllMeetingQueryDto queryCommand, Pageable pageable, Time time,
@@ -71,6 +72,46 @@ public class MeetingSearchRepositoryImpl implements MeetingSearchRepository {
 		JPAQuery<Long> countQuery = getCount(queryCommand, now, activeGeneration);
 
 		return createPage(meetings, pageable, countQuery);
+	}
+
+	/**
+	 * @note: canJoinOnlyActiveGeneration 처리 유의
+	 * @note: status 처리 유의
+	 * @implSpec : count 조회 없이 페이지에 해당하는 모임 content만 반환한다.
+	 */
+	@Override
+	public List<Meeting> findMeetingsByQuery(MeetingV2GetAllMeetingQueryDto queryCommand, Pageable pageable, Time time,
+		Integer activeGeneration) {
+		LocalDateTime now = time.now();
+
+		List<String> categoryNames = queryCommand.getCategory();
+		List<MeetingCategory> categories = List.of();
+
+		if (categoryNames != null) {
+			categories = categoryNames.stream()
+				.map(MeetingCategory::ofValue)
+				.toList();
+		}
+
+		if (categories.size() == 1 && categories.contains(MeetingCategory.FLASH)
+			&& queryCommand.getPaginationType() == PaginationType.DEFAULT) {
+			return getFlashMeetingsForFlashCarousel(queryCommand, pageable, now, activeGeneration);
+		}
+
+		return getMeetings(queryCommand, pageable, now, activeGeneration);
+	}
+
+	/**
+	 * @note: canJoinOnlyActiveGeneration 처리 유의
+	 * @note: status 처리 유의
+	 * @implSpec : 조건에 맞는 모임의 총 개수를 직접 count query로 조회한다.
+	 */
+	@Override
+	public long countMeetingsByQuery(MeetingV2GetAllMeetingQueryDto queryCommand, Time time, Integer activeGeneration) {
+		LocalDateTime now = time.now();
+		Long totalCount = getCount(queryCommand, now, activeGeneration).fetchOne();
+
+		return totalCount == null ? 0L : totalCount;
 	}
 
 	/**
@@ -107,6 +148,9 @@ public class MeetingSearchRepositoryImpl implements MeetingSearchRepository {
 		return createPage(meetings, pageable, getCount());
 	}
 
+	/**
+	 * @implSpec : 조회된 content와 count query 결과를 조합해 Page 객체를 생성한다.
+	 */
 	private Page<Meeting> createPage(List<Meeting> meetings, Pageable pageable, JPAQuery<Long> countQuery) {
 		Long totalCount = countQuery.fetchOne();
 

--- a/main/src/main/java/org/sopt/makers/crew/main/global/pagination/AdvertisementPageableStrategy.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/pagination/AdvertisementPageableStrategy.java
@@ -8,10 +8,25 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class AdvertisementPageableStrategy implements PageableStrategy {
+	private static final int FIRST_PAGE_SIZE = 11;
+	private static final int OTHER_PAGE_SIZE = 12;
 
 	@Override
 	public Pageable createPageable(PageOptionsDto queryCommand) {
 		Sort sort = Sort.by(Sort.Direction.ASC, "id");
 		return new AdvertisementCustomPageable(queryCommand.getPage() - 1, sort);
+	}
+
+	@Override
+	public int calculatePageCount(int itemCount, int take) {
+		if (itemCount == 0) {
+			return 0;
+		}
+
+		if (itemCount <= FIRST_PAGE_SIZE) {
+			return 1;
+		}
+
+		return 1 + (int)Math.ceil((double)(itemCount - FIRST_PAGE_SIZE) / OTHER_PAGE_SIZE);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/global/pagination/DefaultPageableStrategy.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/pagination/DefaultPageableStrategy.java
@@ -14,4 +14,9 @@ public class DefaultPageableStrategy implements PageableStrategy {
 		Sort sort = Sort.by(Sort.Direction.ASC, "id");
 		return new CustomPageable(queryCommand.getPage() - 1, queryCommand.getTake(), sort);
 	}
+
+	@Override
+	public int calculatePageCount(int itemCount, int take) {
+		return (int)Math.ceil((double)itemCount / take);
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/global/pagination/PageableStrategy.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/pagination/PageableStrategy.java
@@ -13,7 +13,7 @@ public interface PageableStrategy {
 		int pageCount = calculatePageCount(itemCount, queryCommand.getTake());
 
 		if (pageCount == 0) {
-			return queryCommand.getPage();
+			return 1;
 		}
 
 		return Math.min(queryCommand.getPage(), pageCount);

--- a/main/src/main/java/org/sopt/makers/crew/main/global/pagination/PageableStrategy.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/pagination/PageableStrategy.java
@@ -1,8 +1,30 @@
 package org.sopt.makers.crew.main.global.pagination;
 
 import org.sopt.makers.crew.main.global.pagination.dto.PageOptionsDto;
+import org.sopt.makers.crew.main.global.pagination.dto.PageMetaDto;
 import org.springframework.data.domain.Pageable;
 
 public interface PageableStrategy {
 	Pageable createPageable(PageOptionsDto queryCommand);
+
+	int calculatePageCount(int itemCount, int take);
+
+	default int normalizePage(PageOptionsDto queryCommand, int itemCount) {
+		int pageCount = calculatePageCount(itemCount, queryCommand.getTake());
+
+		if (pageCount == 0) {
+			return queryCommand.getPage();
+		}
+
+		return Math.min(queryCommand.getPage(), pageCount);
+	}
+
+	default PageMetaDto createPageMeta(Pageable pageable, int itemCount, int take) {
+		return new PageMetaDto(
+			pageable.getPageNumber() + 1,
+			pageable.getPageSize(),
+			itemCount,
+			calculatePageCount(itemCount, take)
+		);
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/global/pagination/dto/PageMetaDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/pagination/dto/PageMetaDto.java
@@ -32,10 +32,19 @@ public class PageMetaDto {
 	private boolean hasNextPage;
 
 	public PageMetaDto(PageOptionsDto pageOptionsDto, int itemCount) {
-		this.page = pageOptionsDto.getPage();
-		this.take = pageOptionsDto.getTake();
+		this(pageOptionsDto.getPage(), pageOptionsDto.getTake(), itemCount,
+			(int)Math.ceil((double)itemCount / pageOptionsDto.getTake()));
+	}
+
+	public PageMetaDto(PageOptionsDto pageOptionsDto, int itemCount, int pageCount) {
+		this(pageOptionsDto.getPage(), pageOptionsDto.getTake(), itemCount, pageCount);
+	}
+
+	public PageMetaDto(int page, int take, int itemCount, int pageCount) {
+		this.page = page;
+		this.take = take;
 		this.itemCount = itemCount;
-		this.pageCount = (int)Math.ceil((double)this.itemCount / this.take);
+		this.pageCount = pageCount;
 		this.hasPreviousPage = this.page > 1;
 		this.hasNextPage = this.page < this.pageCount;
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -411,16 +411,23 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 	@Override
 	public MeetingV2GetAllMeetingDto getMeetings(MeetingV2GetAllMeetingQueryDto queryCommand) {
 		PageableStrategy pageableStrategy = getPageableStrategy(queryCommand);
-		Page<Meeting> meetings = findMeetings(queryCommand, pageableStrategy);
+		int totalMeetingCount = (int)meetingRepository.countMeetingsByQuery(
+			queryCommand,
+			time,
+			activeGenerationProvider.getActiveGeneration()
+		);
 		MeetingV2GetAllMeetingQueryDto effectiveQueryCommand = adjustPageWhenOutOfRange(
 			queryCommand,
-			(int)meetings.getTotalElements(),
+			totalMeetingCount,
 			pageableStrategy
 		);
-
-		if (effectiveQueryCommand != queryCommand) {
-			meetings = findMeetings(effectiveQueryCommand, pageableStrategy);
-		}
+		Pageable pageable = pageableStrategy.createPageable(effectiveQueryCommand);
+		List<Meeting> meetings = meetingRepository.findMeetingsByQuery(
+			effectiveQueryCommand,
+			pageable,
+			time,
+			activeGenerationProvider.getActiveGeneration()
+		);
 
 		List<Integer> meetingIds = meetings.stream()
 			.map(Meeting::getId)
@@ -431,7 +438,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		Map<Integer, TagV2MeetingTagsResponseDto> allTagsResponseDto = tagV2Service.getMeetingTagsByMeetingIds(
 			meetingIds);
 
-		List<MeetingResponseDto> meetingResponseDtos = meetings.getContent().stream()
+		List<MeetingResponseDto> meetingResponseDtos = meetings.stream()
 			.map(meeting -> MeetingResponseDto.of(
 				meeting,
 				meeting.getUser(),
@@ -443,8 +450,8 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 			.toList();
 
 		PageMetaDto pageMetaDto = pageableStrategy.createPageMeta(
-			meetings.getPageable(),
-			(int)meetings.getTotalElements(),
+			pageable,
+			totalMeetingCount,
 			effectiveQueryCommand.getTake()
 		);
 
@@ -721,13 +728,6 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		}
 
 		return copyQueryWithPage(queryCommand, normalizedPage);
-	}
-
-	private Page<Meeting> findMeetings(MeetingV2GetAllMeetingQueryDto queryCommand, PageableStrategy pageableStrategy) {
-		Pageable pageable = pageableStrategy.createPageable(queryCommand);
-
-		return meetingRepository.findAllByQuery(queryCommand, pageable, time,
-			activeGenerationProvider.getActiveGeneration());
 	}
 
 	private MeetingV2GetAllMeetingQueryDto copyQueryWithPage(MeetingV2GetAllMeetingQueryDto source, int page) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -149,6 +149,8 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
 	private final ImageSettingProperties imageSettingProperties;
 	private final ActiveGenerationProvider activeGenerationProvider;
+	private final AdvertisementPageableStrategy advertisementPageableStrategy;
+	private final DefaultPageableStrategy defaultPageableStrategy;
 
 	private final Time time;
 
@@ -409,10 +411,16 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 	@Override
 	public MeetingV2GetAllMeetingDto getMeetings(MeetingV2GetAllMeetingQueryDto queryCommand) {
 		PageableStrategy pageableStrategy = getPageableStrategy(queryCommand);
-		Pageable pageable = pageableStrategy.createPageable(queryCommand);
+		Page<Meeting> meetings = findMeetings(queryCommand, pageableStrategy);
+		MeetingV2GetAllMeetingQueryDto effectiveQueryCommand = adjustPageWhenOutOfRange(
+			queryCommand,
+			(int)meetings.getTotalElements(),
+			pageableStrategy
+		);
 
-		Page<Meeting> meetings = meetingRepository.findAllByQuery(queryCommand, pageable, time,
-			activeGenerationProvider.getActiveGeneration());
+		if (effectiveQueryCommand != queryCommand) {
+			meetings = findMeetings(effectiveQueryCommand, pageableStrategy);
+		}
 
 		List<Integer> meetingIds = meetings.stream()
 			.map(Meeting::getId)
@@ -434,9 +442,11 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 			)
 			.toList();
 
-		PageOptionsDto pageOptionsDto = new PageOptionsDto(meetings.getPageable().getPageNumber() + 1,
-			meetings.getPageable().getPageSize());
-		PageMetaDto pageMetaDto = new PageMetaDto(pageOptionsDto, (int)meetings.getTotalElements());
+		PageMetaDto pageMetaDto = pageableStrategy.createPageMeta(
+			meetings.getPageable(),
+			(int)meetings.getTotalElements(),
+			effectiveQueryCommand.getTake()
+		);
 
 		return MeetingV2GetAllMeetingDto.of(meetingResponseDtos, pageMetaDto);
 	}
@@ -691,11 +701,41 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 	}
 
 	private PageableStrategy getPageableStrategy(MeetingV2GetAllMeetingQueryDto queryCommand) {
-		if (queryCommand.getPaginationType().equals(PaginationType.ADVERTISEMENT)) {
-			return new AdvertisementPageableStrategy();
-		} else {
-			return new DefaultPageableStrategy();
+		if (queryCommand.getPaginationType() == PaginationType.ADVERTISEMENT) {
+			return advertisementPageableStrategy;
 		}
+
+		return defaultPageableStrategy;
+	}
+
+	private MeetingV2GetAllMeetingQueryDto adjustPageWhenOutOfRange(MeetingV2GetAllMeetingQueryDto queryCommand,
+		int itemCount, PageableStrategy pageableStrategy) {
+		int normalizedPage = pageableStrategy.normalizePage(queryCommand, itemCount);
+
+		if (normalizedPage == queryCommand.getPage()) {
+			return queryCommand;
+		}
+
+		return copyQueryWithPage(queryCommand, normalizedPage);
+	}
+
+	private Page<Meeting> findMeetings(MeetingV2GetAllMeetingQueryDto queryCommand, PageableStrategy pageableStrategy) {
+		Pageable pageable = pageableStrategy.createPageable(queryCommand);
+
+		return meetingRepository.findAllByQuery(queryCommand, pageable, time,
+			activeGenerationProvider.getActiveGeneration());
+	}
+
+	private MeetingV2GetAllMeetingQueryDto copyQueryWithPage(MeetingV2GetAllMeetingQueryDto source, int page) {
+		MeetingV2GetAllMeetingQueryDto queryDto = new MeetingV2GetAllMeetingQueryDto(page, source.getTake());
+		queryDto.setCategory(source.getCategory());
+		queryDto.setKeyword(source.getKeyword());
+		queryDto.setStatus(source.getStatus());
+		queryDto.setIsOnlyActiveGeneration(source.getIsOnlyActiveGeneration());
+		queryDto.setJoinableParts(source.getJoinableParts());
+		queryDto.setQuery(source.getQuery());
+		queryDto.setPaginationType(source.getPaginationType());
+		return queryDto;
 	}
 
 	private Page<ApplyInfoDetailDto> madeApplyInfoDetails(MeetingGetAppliesQueryDto queryCommand, Integer meetingId,

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -710,6 +710,10 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
 	private MeetingV2GetAllMeetingQueryDto adjustPageWhenOutOfRange(MeetingV2GetAllMeetingQueryDto queryCommand,
 		int itemCount, PageableStrategy pageableStrategy) {
+		if (itemCount == 0 && queryCommand.getPage() > 1) {
+			return copyQueryWithPage(queryCommand, 1);
+		}
+
 		int normalizedPage = pageableStrategy.normalizePage(queryCommand, itemCount);
 
 		if (normalizedPage == queryCommand.getPage()) {

--- a/main/src/main/resources/application-test.yml
+++ b/main/src/main/resources/application-test.yml
@@ -129,6 +129,3 @@ img:
 thread-pool:
   core-size: ${DEV_THREAD_CORE_SIZE}
   thread-name-prefix: ${DEV_THREAD_NAME_PREFIX}
-
-api:
-  secret: ${API_TEST_SECRET}

--- a/main/src/main/resources/application-test.yml
+++ b/main/src/main/resources/application-test.yml
@@ -130,6 +130,5 @@ thread-pool:
   core-size: ${DEV_THREAD_CORE_SIZE}
   thread-name-prefix: ${DEV_THREAD_NAME_PREFIX}
 
-
-
-
+api:
+  secret: ${API_TEST_SECRET}

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImplPageTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImplPageTest.java
@@ -5,6 +5,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.sopt.makers.crew.main.global.pagination.DefaultPageableStrategy;
+import org.sopt.makers.crew.main.global.pagination.PageableStrategy;
+import org.sopt.makers.crew.main.global.pagination.dto.PageMetaDto;
+import org.sopt.makers.crew.main.global.pagination.dto.PageOptionsDto;
+import org.springframework.data.domain.Pageable;
 
 class MeetingV2ServiceImplPageTest {
 
@@ -36,6 +41,23 @@ class MeetingV2ServiceImplPageTest {
 
 		Assertions.assertThat(applyNumbers.getAndIncrement()).isEqualTo(21);
 		Assertions.assertThat(applyNumbers.get()).isEqualTo(22);
+	}
+
+	@Test
+	@DisplayName("빈 결과에서는 page를 1로 정규화하고 이전/다음 페이지를 모두 false로 만든다")
+	void normalizeEmptyResultPage() {
+		PageableStrategy pageableStrategy = new DefaultPageableStrategy();
+		PageOptionsDto pageOptionsDto = new PageOptionsDto(5, 12);
+
+		int normalizedPage = pageableStrategy.normalizePage(pageOptionsDto, 0);
+		Pageable pageable = pageableStrategy.createPageable(new PageOptionsDto(normalizedPage, pageOptionsDto.getTake()));
+		PageMetaDto pageMetaDto = pageableStrategy.createPageMeta(pageable, 0, pageOptionsDto.getTake());
+
+		Assertions.assertThat(normalizedPage).isEqualTo(1);
+		Assertions.assertThat(pageMetaDto.getPage()).isEqualTo(1);
+		Assertions.assertThat(pageMetaDto.getPageCount()).isZero();
+		Assertions.assertThat(pageMetaDto.isHasPreviousPage()).isFalse();
+		Assertions.assertThat(pageMetaDto.isHasNextPage()).isFalse();
 	}
 
 }

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -861,7 +861,7 @@ public class MeetingV2ServiceTest {
 			// then
 			Assertions.assertThat(meetingDto.meetings())
 				.extracting(MeetingResponseDto::getTitle)
-				.containsExactly("운동 스터디");
+				.containsExactly("스터디 구합니다1");
 			Assertions.assertThat(meetingDto.meta().getPage()).isEqualTo(1);
 			Assertions.assertThat(meetingDto.meta().getPageCount()).isEqualTo(1);
 			Assertions.assertThat(meetingDto.meta().isHasPreviousPage()).isFalse();

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -869,6 +869,30 @@ public class MeetingV2ServiceTest {
 		}
 
 		@Test
+		@DisplayName("status 필터 결과가 첫 페이지에만 존재하면 두 번째 페이지 요청은 첫 페이지로 보정한다.")
+		void outOfRangeStatusPage_getMeetings_firstPage() {
+			User user = userRepository.findByIdOrThrow(5);
+
+			for (int i = 0; i < 10; i++) {
+				Meeting meeting = createMeetingFixture(i, user);
+				meetingRepository.save(meeting);
+			}
+
+			MeetingV2GetAllMeetingQueryDto queryDto = new MeetingV2GetAllMeetingQueryDto(2, 12);
+			queryDto.setIsOnlyActiveGeneration(false);
+			queryDto.setStatus(List.of(String.valueOf(EnMeetingStatus.BEFORE_START.getValue())));
+
+			MeetingV2GetAllMeetingDto meetingDto = meetingV2Service.getMeetings(queryDto);
+
+			Assertions.assertThat(meetingDto.meetings()).hasSize(11);
+			Assertions.assertThat(meetingDto.meta().getPage()).isEqualTo(1);
+			Assertions.assertThat(meetingDto.meta().getItemCount()).isEqualTo(11);
+			Assertions.assertThat(meetingDto.meta().getPageCount()).isEqualTo(1);
+			Assertions.assertThat(meetingDto.meta().isHasPreviousPage()).isFalse();
+			Assertions.assertThat(meetingDto.meta().isHasNextPage()).isFalse();
+		}
+
+		@Test
 		@DisplayName("페이지네이션에서 page 1일 경우, 11개의 모임목록을 반환한다.")
 		void pageIs1_getMeetings_11meetings() {
 			// given

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -846,6 +846,29 @@ public class MeetingV2ServiceTest {
 		}
 
 		@Test
+		@DisplayName("검색 결과보다 큰 page를 요청하면 마지막 페이지로 보정하여 반환한다.")
+		void pageGreaterThanKeywordSearchResult_getMeetings_lastPage() {
+			// given
+			int page = 5;
+			int take = 12;
+			MeetingV2GetAllMeetingQueryDto queryDto = new MeetingV2GetAllMeetingQueryDto(page, take);
+			queryDto.setIsOnlyActiveGeneration(false);
+			queryDto.setKeyword(List.of("기타"));
+
+			// when
+			MeetingV2GetAllMeetingDto meetingDto = meetingV2Service.getMeetings(queryDto);
+
+			// then
+			Assertions.assertThat(meetingDto.meetings())
+				.extracting(MeetingResponseDto::getTitle)
+				.containsExactly("운동 스터디");
+			Assertions.assertThat(meetingDto.meta().getPage()).isEqualTo(1);
+			Assertions.assertThat(meetingDto.meta().getPageCount()).isEqualTo(1);
+			Assertions.assertThat(meetingDto.meta().isHasPreviousPage()).isFalse();
+			Assertions.assertThat(meetingDto.meta().isHasNextPage()).isFalse();
+		}
+
+		@Test
 		@DisplayName("페이지네이션에서 page 1일 경우, 11개의 모임목록을 반환한다.")
 		void pageIs1_getMeetings_11meetings() {
 			// given
@@ -889,6 +912,29 @@ public class MeetingV2ServiceTest {
 
 			// then
 			Assertions.assertThat(meetings).hasSize(12);
+		}
+
+		@Test
+		@DisplayName("ADVERTISEMENT 페이지네이션의 pageCount는 현재 페이지 크기와 무관하게 계산된다.")
+		void advertisementPagination_getMeetings_consistentPageCount() {
+			// given
+			User user = userRepository.findByIdOrThrow(5);
+
+			for (int i = 0; i < 20; i++) {
+				Meeting meeting = createMeetingFixture(i, user);
+				meetingRepository.save(meeting);
+			}
+
+			MeetingV2GetAllMeetingQueryDto queryDto = new MeetingV2GetAllMeetingQueryDto(2, 12);
+			queryDto.setIsOnlyActiveGeneration(false);
+
+			// when
+			MeetingV2GetAllMeetingDto meetingDto = meetingV2Service.getMeetings(queryDto);
+
+			// then
+			Assertions.assertThat(meetingDto.meetings()).hasSize(12);
+			Assertions.assertThat(meetingDto.meta().getPage()).isEqualTo(2);
+			Assertions.assertThat(meetingDto.meta().getPageCount()).isEqualTo(3);
 		}
 	}
 


### PR DESCRIPTION
## 👩‍💻 Contents

기획 스펙상 카테고리/키워드/상태/파트/활동기수 5개의 값으로 필터링을 걸 수있고, 
한 페이지당 12개씩 모임이 노출됩니다

하지만 모임 시작전으로 필터링했을때의 모임 개수가 12개보다 작다면 ? 
2번째 페이지는 자연스럽게 존재하지 않는 페이지입니다

즉, 오류 재현 스텝은 아래와 같습니다

모임 시작전으로 필터링 했을시, 모임의 개수가 11개인 상황
1. 유저가 존재하지 않는 페이지인 2번째 페이지 클릭
2. 모임 시작전(`status=0`) 필터링 설정 
3. 오류발생

따라서 수정된 내용은, 앞서 설명드린 케이스로 예시를 들면
`page=2&statues=0`으로 검색한 검색 결과는 존재하지 않는 값이기 때문에, 
`page=1&statues=0`의 모임값을 반환

결론적으로 빈배열이 반환되지않고, 유저가 의도한 대로 모임 시작전 `statues=0`으로 필터링 되어
11개의 모임이 정상적으로 반환되게 됩니다

## 📝 Review Note

1. 수정하면서 서비스 impl 안에서 pageCount를 직접 계산하고 있었던 로직을 `strategy` 쪽으로 옮기고,
service단에서는 조회 후 page보정이 필요한지만 판단하도록 정리했어요

2. 또한 해당 이슈를 수정하기 위해서 범위 밖 page면 빈배열이 아니라, 마지막 페이지로 보정하도록 수정하였는데
해당 응답에 사이드 이펙트가 생길 수 있는 API가 있는지 크로스 체크 부탁드립니다

## 📣 Related Issue

- closed #825 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?