### PR TITLE
feat: 모임 생성/조회 API 개선

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -69,7 +69,8 @@ public class Meeting extends BaseTimeEntity {
 	/**
 	 * 모임 부제목
 	 */
-	@Column(name = "subTitle")
+	@Size(min = 1, max = 30)
+	@Column(name = "subTitle", length = 30)
 	private String subTitle;
 
 	/**
@@ -158,7 +159,7 @@ public class Meeting extends BaseTimeEntity {
 	/**
 	 * 참여 정보
 	 */
-	@Column(name = "joinInfo")
+	@Column(name = "joinInfo", columnDefinition = "jsonb")
 	@Type(JsonBinaryType.class)
 	private MeetingJoinInfo joinInfo;
 

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -13,6 +13,7 @@ import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.global.exception.BadRequestException;
 import org.sopt.makers.crew.main.global.exception.ForbiddenException;
@@ -64,6 +65,12 @@ public class Meeting extends BaseTimeEntity {
 	 */
 	@Column(nullable = false)
 	private String title;
+
+	/**
+	 * 모임 부제목
+	 */
+	@Column(name = "subTitle")
+	private String subTitle;
 
 	/**
 	 * 모임 카테고리
@@ -149,6 +156,13 @@ public class Meeting extends BaseTimeEntity {
 	private Boolean canJoinOnlyActiveGeneration;
 
 	/**
+	 * 참여 정보
+	 */
+	@Column(name = "joinInfo")
+	@Type(JsonBinaryType.class)
+	private MeetingJoinInfo joinInfo;
+
+	/**
 	 * 모임 기수
 	 */
 	@Column(name = "createdGeneration", nullable = false)
@@ -170,15 +184,16 @@ public class Meeting extends BaseTimeEntity {
 	private MeetingJoinablePart[] joinableParts;
 
 	@Builder
-	public Meeting(User user, Integer userId, String title, MeetingCategory category,
+	public Meeting(User user, Integer userId, String title, String subTitle, MeetingCategory category,
 		List<ImageUrlVO> imageURL, LocalDateTime startDate, LocalDateTime endDate, Integer capacity,
 		String desc, String processDesc, LocalDateTime mStartDate, LocalDateTime mEndDate,
 		String leaderDesc, String note, Boolean isMentorNeeded,
-		Boolean canJoinOnlyActiveGeneration, Integer createdGeneration,
+		Boolean canJoinOnlyActiveGeneration, MeetingJoinInfo joinInfo, Integer createdGeneration,
 		Integer targetActiveGeneration, MeetingJoinablePart[] joinableParts) {
 		this.user = user;
 		this.userId = userId;
 		this.title = title;
+		this.subTitle = subTitle;
 		this.category = category;
 		this.imageURL = imageURL;
 		this.startDate = startDate;
@@ -192,6 +207,7 @@ public class Meeting extends BaseTimeEntity {
 		this.note = note;
 		this.isMentorNeeded = isMentorNeeded;
 		this.canJoinOnlyActiveGeneration = canJoinOnlyActiveGeneration;
+		this.joinInfo = joinInfo;
 		this.createdGeneration = createdGeneration;
 		this.targetActiveGeneration = targetActiveGeneration;
 		this.joinableParts = joinableParts;
@@ -241,6 +257,7 @@ public class Meeting extends BaseTimeEntity {
 	public void updateMeeting(Meeting updateMeeting) {
 
 		this.title = updateMeeting.getTitle();
+		this.subTitle = updateMeeting.getSubTitle();
 		this.category = updateMeeting.getCategory();
 		this.imageURL = updateMeeting.getImageURL();
 		this.startDate = updateMeeting.getStartDate();
@@ -254,6 +271,7 @@ public class Meeting extends BaseTimeEntity {
 		this.note = updateMeeting.getNote();
 		this.isMentorNeeded = updateMeeting.getIsMentorNeeded();
 		this.canJoinOnlyActiveGeneration = updateMeeting.getCanJoinOnlyActiveGeneration();
+		this.joinInfo = updateMeeting.getJoinInfo();
 		this.targetActiveGeneration = updateMeeting.getTargetActiveGeneration();
 		this.joinableParts = updateMeeting.getJoinableParts();
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -277,6 +277,67 @@ public class Meeting extends BaseTimeEntity {
 		this.joinableParts = updateMeeting.getJoinableParts();
 	}
 
+	public void patchMeeting(String title, String subTitle, MeetingCategory category,
+		List<ImageUrlVO> imageURL, LocalDateTime startDate, LocalDateTime endDate, Integer capacity,
+		String desc, String processDesc, LocalDateTime mStartDate, LocalDateTime mEndDate,
+		String leaderDesc, String note, Boolean isMentorNeeded,
+		Boolean canJoinOnlyActiveGeneration, Integer targetActiveGeneration,
+		MeetingJoinInfo joinInfo, MeetingJoinablePart[] joinableParts) {
+
+		if (title != null) {
+			this.title = title;
+		}
+		if (subTitle != null) {
+			this.subTitle = subTitle;
+		}
+		if (category != null) {
+			this.category = category;
+		}
+		if (imageURL != null) {
+			this.imageURL = imageURL;
+		}
+		if (startDate != null) {
+			this.startDate = startDate;
+		}
+		if (endDate != null) {
+			this.endDate = endDate;
+		}
+		if (capacity != null) {
+			this.capacity = capacity;
+		}
+		if (desc != null) {
+			this.desc = desc;
+		}
+		if (processDesc != null) {
+			this.processDesc = processDesc;
+		}
+		if (mStartDate != null) {
+			this.mStartDate = mStartDate;
+		}
+		if (mEndDate != null) {
+			this.mEndDate = mEndDate;
+		}
+		if (leaderDesc != null) {
+			this.leaderDesc = leaderDesc;
+		}
+		if (note != null) {
+			this.note = note;
+		}
+		if (isMentorNeeded != null) {
+			this.isMentorNeeded = isMentorNeeded;
+		}
+		if (canJoinOnlyActiveGeneration != null) {
+			this.canJoinOnlyActiveGeneration = canJoinOnlyActiveGeneration;
+			this.targetActiveGeneration = targetActiveGeneration;
+		}
+		if (joinInfo != null) {
+			this.joinInfo = joinInfo;
+		}
+		if (joinableParts != null) {
+			this.joinableParts = joinableParts;
+		}
+	}
+
 	public LocalDateTime getmStartDate() {
 		return mStartDate;
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/enums/MeetingFrequency.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/enums/MeetingFrequency.java
@@ -1,0 +1,31 @@
+package org.sopt.makers.crew.main.entity.meeting.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import lombok.Getter;
+
+@Getter
+public enum MeetingFrequency {
+	LIGHT("가볍게"),
+	// TODO: 추후 스펙 크로스 체크 후 변경 예정
+	STEADY("꾸준히"),
+	IMMERSIVE("몰입형");
+
+	@JsonValue
+	private final String value;
+
+	MeetingFrequency(String value) {
+		this.value = value;
+	}
+
+	@JsonCreator
+	public static MeetingFrequency ofValue(String dbData) {
+		for (MeetingFrequency meetingFrequency : MeetingFrequency.values()) {
+			if (meetingFrequency.getValue().equals(dbData)) {
+				return meetingFrequency;
+			}
+		}
+		throw new IllegalArgumentException("Invalid MeetingFrequency value: " + dbData);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/enums/MeetingType.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/enums/MeetingType.java
@@ -1,0 +1,30 @@
+package org.sopt.makers.crew.main.entity.meeting.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import lombok.Getter;
+
+@Getter
+public enum MeetingType {
+	ONLINE("온라인"),
+	OFFLINE("오프라인"),
+	ONLINE_OFFLINE("온-오프");
+
+	@JsonValue
+	private final String value;
+
+	MeetingType(String value) {
+		this.value = value;
+	}
+
+	@JsonCreator
+	public static MeetingType ofValue(String dbData) {
+		for (MeetingType meetingType : MeetingType.values()) {
+			if (meetingType.getValue().equals(dbData)) {
+				return meetingType;
+			}
+		}
+		throw new IllegalArgumentException("Invalid MeetingType value: " + dbData);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/vo/MeetingJoinInfo.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/vo/MeetingJoinInfo.java
@@ -1,0 +1,21 @@
+package org.sopt.makers.crew.main.entity.meeting.vo;
+
+import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
+
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingFrequency;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingType;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record MeetingJoinInfo(
+	@JsonProperty("meetingType") MeetingType meetingType,
+	@JsonProperty("meetingFrequency") MeetingFrequency meetingFrequency
+) {
+	@JsonCreator
+	public MeetingJoinInfo {
+		if (meetingType == null || meetingFrequency == null) {
+			throw new IllegalArgumentException(INVALID_INPUT_VALUE.getErrorCode());
+		}
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/global/dto/MeetingResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/dto/MeetingResponseDto.java
@@ -33,6 +33,9 @@ public class MeetingResponseDto {
 	@NotNull
 	private final String title;
 
+	@Schema(description = "모임 부제목", example = "모임 부제목입니다")
+	private final String subTitle;
+
 	@Schema(description = "대상 기수", example = "33")
 	@NotNull
 	private final Integer targetActiveGeneration;
@@ -117,6 +120,7 @@ public class MeetingResponseDto {
 		return new MeetingResponseDto(
 			meeting.getId(),
 			meeting.getTitle(),
+			meeting.getSubTitle(),
 			meeting.getTargetActiveGeneration(),
 			meeting.getJoinableParts(),
 			meeting.getCategory().getValue(),

--- a/main/src/main/java/org/sopt/makers/crew/main/global/util/UserPartUtil.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/util/UserPartUtil.java
@@ -10,6 +10,7 @@ public class UserPartUtil {
     public static MeetingJoinablePart getMeetingJoinablePart(UserPart userPart) {
         switch (userPart) {
             case PLAN:
+            case PM:
             case PM_LEADER:
                 return MeetingJoinablePart.PM;
             case DESIGN:
@@ -22,9 +23,11 @@ public class UserPartUtil {
             case ANDROID_LEADER:
                 return MeetingJoinablePart.ANDROID;
             case SERVER:
+            case BACKEND:
             case SERVER_LEADER:
                 return MeetingJoinablePart.SERVER;
             case WEB:
+            case FRONTEND:
             case WEB_LEADER:
                 return MeetingJoinablePart.WEB;
             default:

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -24,6 +24,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetRecommendDt
 import org.sopt.makers.crew.main.meeting.v2.dto.response.PreSignedUrlResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -117,7 +118,8 @@ public interface MeetingV2Api {
 	@Operation(summary = "모임 삭제", description = "모임 삭제합니다.")
 	ResponseEntity<Void> deleteMeeting(@PathVariable Integer meetingId, Principal principal);
 
-	@Operation(summary = "모임 수정", description = "모임 내용을 수정합니다.")
+	@Operation(summary = "모임 수정", description = "모임 내용을 부분 수정합니다.")
+	@PatchMapping("/{meetingId}")
 	ResponseEntity<Void> updateMeeting(@PathVariable Integer meetingId,
 		@RequestBody @Valid MeetingV2UpdateMeetingBodyDto requestBody, Principal principal);
 

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -9,7 +9,8 @@ import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOr
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.ApplyV2UpdateStatusBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
-import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateAndUpdateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2UpdateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.AppliesCsvFileUrlResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
@@ -57,7 +58,7 @@ public interface MeetingV2Api {
 	@ApiResponses(value = {@ApiResponse(responseCode = "201", description = "성공"),
 		@ApiResponse(responseCode = "400", description = "\"이미지 파일이 없습니다.\" or \"한 개 이상의 파트를 입력해주세요\" or \"프로필을 입력해주세요\"", content = @Content),})
 	ResponseEntity<MeetingV2CreateMeetingResponseDto> createMeeting(
-		@Valid @RequestBody MeetingV2CreateAndUpdateMeetingBodyDto requestBody,
+		@Valid @RequestBody MeetingV2CreateMeetingBodyDto requestBody,
 		Principal principal);
 
 	@Operation(summary = "일반 모임 지원")
@@ -117,7 +118,7 @@ public interface MeetingV2Api {
 
 	@Operation(summary = "모임 수정", description = "모임 내용을 수정합니다.")
 	ResponseEntity<Void> updateMeeting(@PathVariable Integer meetingId,
-		@RequestBody @Valid MeetingV2CreateAndUpdateMeetingBodyDto requestBody, Principal principal);
+		@RequestBody @Valid MeetingV2UpdateMeetingBodyDto requestBody, Principal principal);
 
 	@Operation(summary = "모임 지원자 상태 변경", description = "모임 지원자의 지원 상태를 변경합니다.")
 	ResponseEntity<Void> updateApplyStatus(@PathVariable Integer meetingId,

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Api.java
@@ -19,6 +19,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingB
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingByIdResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingPartMembersResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetRecommendDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.PreSignedUrlResponseDto;
 import org.springframework.http.ResponseEntity;
@@ -141,6 +142,12 @@ public interface MeetingV2Api {
 	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "모임 상세 조회 성공"),
 		@ApiResponse(responseCode = "400", description = "모임이 없습니다.", content = @Content),})
 	ResponseEntity<MeetingV2GetMeetingByIdResponseDto> getMeetingById(@PathVariable Integer meetingId,
+		Principal principal);
+
+	@Operation(summary = "모임 내 같은 파트 참여 멤버 리스트 조회", description = "조회자와 같은 파트 기준으로 참여중인 멤버 리스트를 조회합니다.")
+	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "모임 내 같은 파트 참여 멤버 리스트 조회 성공"),
+		@ApiResponse(responseCode = "400", description = "모임이 없습니다.", content = @Content),})
+	ResponseEntity<MeetingV2GetMeetingPartMembersResponseDto> getMeetingPartMembers(@PathVariable Integer meetingId,
 		Principal principal);
 
 	@Operation(summary = "추천 모임 목록 조회", description = "추천 모임 목록 조회, 쿼리파라미터가 없는 경우 '지금 모집중인 모임' 반환")

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -11,7 +11,8 @@ import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOr
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.ApplyV2UpdateStatusBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
-import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateAndUpdateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2UpdateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.AppliesCsvFileUrlResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
@@ -75,7 +76,7 @@ public class MeetingV2Controller implements MeetingV2Api {
 	@Override
 	@PostMapping
 	public ResponseEntity<MeetingV2CreateMeetingResponseDto> createMeeting(
-		@Valid @RequestBody MeetingV2CreateAndUpdateMeetingBodyDto requestBody,
+		@Valid @RequestBody MeetingV2CreateMeetingBodyDto requestBody,
 		Principal principal) {
 		Integer userId = UserUtil.getUserId(principal);
 		return ResponseEntity.status(HttpStatus.CREATED).body(meetingV2Service.createMeeting(requestBody, userId));
@@ -160,7 +161,7 @@ public class MeetingV2Controller implements MeetingV2Api {
 	@PutMapping("/{meetingId}")
 	public ResponseEntity<Void> updateMeeting(
 		@PathVariable Integer meetingId,
-		@RequestBody @Valid MeetingV2CreateAndUpdateMeetingBodyDto requestBody,
+		@RequestBody @Valid MeetingV2UpdateMeetingBodyDto requestBody,
 		Principal principal) {
 
 		Integer userId = UserUtil.getUserId(principal);

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -21,6 +21,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingB
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingByIdResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingPartMembersResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetRecommendDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.PreSignedUrlResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.service.MeetingV2Service;
@@ -217,6 +218,15 @@ public class MeetingV2Controller implements MeetingV2Api {
 		Integer userId = UserUtil.getUserId(principal);
 
 		return ResponseEntity.ok(meetingV2Service.getMeetingDetail(meetingId, userId));
+	}
+
+	@Override
+	@GetMapping("/{meetingId}/members")
+	public ResponseEntity<MeetingV2GetMeetingPartMembersResponseDto> getMeetingPartMembers(
+		@PathVariable Integer meetingId, Principal principal) {
+		Integer userId = UserUtil.getUserId(principal);
+
+		return ResponseEntity.ok(meetingV2Service.getMeetingPartMembers(meetingId, userId));
 	}
 
 	@Override

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/MeetingV2Controller.java
@@ -31,6 +31,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -159,7 +160,7 @@ public class MeetingV2Controller implements MeetingV2Api {
 	}
 
 	@Override
-	@PutMapping("/{meetingId}")
+	@PatchMapping("/{meetingId}")
 	public ResponseEntity<Void> updateMeeting(
 		@PathVariable Integer meetingId,
 		@RequestBody @Valid MeetingV2UpdateMeetingBodyDto requestBody,

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/FlashMeetingMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/FlashMeetingMapper.java
@@ -34,6 +34,8 @@ public interface FlashMeetingMapper {
 	@Mapping(target = "note", constant = "") // null 대신 빈 문자열로 NPE 방지
 	@Mapping(target = "isMentorNeeded", constant = "false") // 번쩍 정책에 맞게 false
 	@Mapping(target = "canJoinOnlyActiveGeneration", constant = "false") // 번쩍 정책에 맞게 false
+	@Mapping(target = "subTitle", ignore = true)
+	@Mapping(target = "joinInfo", ignore = true)
 	@Mapping(target = "targetActiveGeneration", expression = "java(null)") // 번쩍 정책에 맞게 null
 	@Mapping(target = "joinableParts", expression = "java(org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart.values())")
 		// 번쩍 정책에 맞게 모든 파트 허용

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/MeetingMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/MeetingMapper.java
@@ -15,7 +15,6 @@ import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
-import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2UpdateMeetingBodyDto;
 
 @Mapper(componentModel = "spring")
 public interface MeetingMapper {
@@ -58,16 +57,5 @@ public interface MeetingMapper {
 	@Mapping(source = "requestBody.mEndDate", target = "mEndDate", qualifiedByName = "getEndDate")
 	@Mapping(source = "requestBody.joinInfo", target = "joinInfo")
 	Meeting toMeetingEntity(MeetingV2CreateMeetingBodyDto requestBody, Integer targetActiveGeneration,
-		Integer createdGeneration, User user, Integer userId);
-
-	@Mapping(source = "requestBody.subTitle", target = "subTitle")
-	@Mapping(source = "requestBody.files", target = "imageURL", qualifiedByName = "getImageURL")
-	@Mapping(source = "requestBody.category", target = "category", qualifiedByName = "getCategory")
-	@Mapping(source = "requestBody.startDate", target = "startDate", qualifiedByName = "getStartDate")
-	@Mapping(source = "requestBody.endDate", target = "endDate", qualifiedByName = "getEndDate")
-	@Mapping(source = "requestBody.mStartDate", target = "mStartDate", qualifiedByName = "getStartDate")
-	@Mapping(source = "requestBody.mEndDate", target = "mEndDate", qualifiedByName = "getEndDate")
-	@Mapping(source = "requestBody.joinInfo", target = "joinInfo")
-	Meeting toMeetingEntity(MeetingV2UpdateMeetingBodyDto requestBody, Integer targetActiveGeneration,
 		Integer createdGeneration, User user, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/MeetingMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/MeetingMapper.java
@@ -14,7 +14,8 @@ import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 import org.sopt.makers.crew.main.entity.user.User;
-import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateAndUpdateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2UpdateMeetingBodyDto;
 
 @Mapper(componentModel = "spring")
 public interface MeetingMapper {
@@ -48,12 +49,25 @@ public interface MeetingMapper {
 
 	}
 
+	@Mapping(source = "requestBody.subTitle", target = "subTitle")
 	@Mapping(source = "requestBody.files", target = "imageURL", qualifiedByName = "getImageURL")
 	@Mapping(source = "requestBody.category", target = "category", qualifiedByName = "getCategory")
 	@Mapping(source = "requestBody.startDate", target = "startDate", qualifiedByName = "getStartDate")
 	@Mapping(source = "requestBody.endDate", target = "endDate", qualifiedByName = "getEndDate")
 	@Mapping(source = "requestBody.mStartDate", target = "mStartDate", qualifiedByName = "getStartDate")
 	@Mapping(source = "requestBody.mEndDate", target = "mEndDate", qualifiedByName = "getEndDate")
-	Meeting toMeetingEntity(MeetingV2CreateAndUpdateMeetingBodyDto requestBody, Integer targetActiveGeneration,
+	@Mapping(source = "requestBody.joinInfo", target = "joinInfo")
+	Meeting toMeetingEntity(MeetingV2CreateMeetingBodyDto requestBody, Integer targetActiveGeneration,
+		Integer createdGeneration, User user, Integer userId);
+
+	@Mapping(source = "requestBody.subTitle", target = "subTitle")
+	@Mapping(source = "requestBody.files", target = "imageURL", qualifiedByName = "getImageURL")
+	@Mapping(source = "requestBody.category", target = "category", qualifiedByName = "getCategory")
+	@Mapping(source = "requestBody.startDate", target = "startDate", qualifiedByName = "getStartDate")
+	@Mapping(source = "requestBody.endDate", target = "endDate", qualifiedByName = "getEndDate")
+	@Mapping(source = "requestBody.mStartDate", target = "mStartDate", qualifiedByName = "getStartDate")
+	@Mapping(source = "requestBody.mEndDate", target = "mEndDate", qualifiedByName = "getEndDate")
+	@Mapping(source = "requestBody.joinInfo", target = "joinInfo")
+	Meeting toMeetingEntity(MeetingV2UpdateMeetingBodyDto requestBody, Integer targetActiveGeneration,
 		Integer createdGeneration, User user, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/MeetingCacheDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/MeetingCacheDto.java
@@ -7,6 +7,7 @@ import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -22,6 +23,7 @@ public class MeetingCacheDto {
 	private final Integer id;
 	private final Integer userId;
 	private final String title;
+	private final String subTitle;
 	private final MeetingCategory category;
 	private final List<ImageUrlVO> imageURL;
 
@@ -49,6 +51,7 @@ public class MeetingCacheDto {
 	private final String note;
 	private final Boolean isMentorNeeded;
 	private final Boolean canJoinOnlyActiveGeneration;
+	private final MeetingJoinInfo joinInfo;
 	private final Integer createdGeneration;
 	private final Integer targetActiveGeneration;
 	private final MeetingJoinablePart[] joinableParts;
@@ -58,6 +61,7 @@ public class MeetingCacheDto {
 		@JsonProperty("id") Integer id,
 		@JsonProperty("userId") Integer userId,
 		@JsonProperty("title") String title,
+		@JsonProperty("subTitle") String subTitle,
 		@JsonProperty("category") MeetingCategory category,
 		@JsonProperty("imageURL") List<ImageUrlVO> imageURL,
 		@JsonProperty("startDate") LocalDateTime startDate,
@@ -71,12 +75,14 @@ public class MeetingCacheDto {
 		@JsonProperty("note") String note,
 		@JsonProperty("isMentorNeeded") Boolean isMentorNeeded,
 		@JsonProperty("canJoinOnlyActiveGeneration") Boolean canJoinOnlyActiveGeneration,
+		@JsonProperty("joinInfo") MeetingJoinInfo joinInfo,
 		@JsonProperty("createdGeneration") Integer createdGeneration,
 		@JsonProperty("targetActiveGeneration") Integer targetActiveGeneration,
 		@JsonProperty("joinableParts") MeetingJoinablePart[] joinableParts) {
 		this.id = id;
 		this.userId = userId;
 		this.title = title;
+		this.subTitle = subTitle;
 		this.category = category;
 		this.imageURL = imageURL;
 		this.startDate = startDate;
@@ -90,17 +96,19 @@ public class MeetingCacheDto {
 		this.note = note;
 		this.isMentorNeeded = isMentorNeeded;
 		this.canJoinOnlyActiveGeneration = canJoinOnlyActiveGeneration;
+		this.joinInfo = joinInfo;
 		this.createdGeneration = createdGeneration;
 		this.targetActiveGeneration = targetActiveGeneration;
 		this.joinableParts = joinableParts;
 	}
 
 	public static MeetingCacheDto from(Meeting meeting) {
-		return new MeetingCacheDto(meeting.getId(), meeting.getUserId(), meeting.getTitle(), meeting.getCategory(),
+		return new MeetingCacheDto(meeting.getId(), meeting.getUserId(), meeting.getTitle(), meeting.getSubTitle(),
+			meeting.getCategory(),
 			meeting.getImageURL(), meeting.getStartDate(), meeting.getEndDate(), meeting.getCapacity(),
 			meeting.getDesc(), meeting.getProcessDesc(), meeting.getmStartDate(), meeting.getmEndDate(),
 			meeting.getLeaderDesc(), meeting.getNote(), meeting.getIsMentorNeeded(),
-			meeting.getCanJoinOnlyActiveGeneration(), meeting.getCreatedGeneration(),
+			meeting.getCanJoinOnlyActiveGeneration(), meeting.getJoinInfo(), meeting.getCreatedGeneration(),
 			meeting.getTargetActiveGeneration(), meeting.getJoinableParts());
 	}
 
@@ -108,6 +116,7 @@ public class MeetingCacheDto {
 		return Meeting.builder()
 			.userId(userId)
 			.title(title)
+			.subTitle(subTitle)
 			.category(category)
 			.imageURL(imageURL)
 			.startDate(startDate)
@@ -121,6 +130,7 @@ public class MeetingCacheDto {
 			.note(note)
 			.isMentorNeeded(isMentorNeeded)
 			.canJoinOnlyActiveGeneration(canJoinOnlyActiveGeneration)
+			.joinInfo(joinInfo)
 			.createdGeneration(createdGeneration)
 			.targetActiveGeneration(targetActiveGeneration)
 			.joinableParts(joinableParts)

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/MeetingV2CreateMeetingBodyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/MeetingV2CreateMeetingBodyDto.java
@@ -108,47 +108,6 @@ public class MeetingV2CreateMeetingBodyDto {
 	@Size(min = 1, max = 2)
 	private List<String> meetingKeywordTypes;
 
-	public MeetingV2CreateMeetingBodyDto(
-		String title,
-		List<String> files,
-		String category,
-		String startDate,
-		String endDate,
-		Integer capacity,
-		String desc,
-		String processDesc,
-		String mStartDate,
-		String mEndDate,
-		String leaderDesc,
-		String note,
-		Boolean isMentorNeeded,
-		Boolean canJoinOnlyActiveGeneration,
-		MeetingJoinablePart[] joinableParts,
-		List<Integer> coLeaderUserIds,
-		List<String> welcomeMessageTypes,
-		List<String> meetingKeywordTypes
-	) {
-		this.title = title;
-		this.subTitle = title;
-		this.files = files;
-		this.category = category;
-		this.startDate = startDate;
-		this.endDate = endDate;
-		this.capacity = capacity;
-		this.desc = desc;
-		this.processDesc = processDesc;
-		this.mStartDate = mStartDate;
-		this.mEndDate = mEndDate;
-		this.leaderDesc = leaderDesc;
-		this.note = note;
-		this.isMentorNeeded = isMentorNeeded;
-		this.canJoinOnlyActiveGeneration = canJoinOnlyActiveGeneration;
-		this.joinInfo = new MeetingJoinInfo(MeetingType.ONLINE_OFFLINE, MeetingFrequency.STEADY);
-		this.joinableParts = joinableParts;
-		this.coLeaderUserIds = coLeaderUserIds;
-		this.meetingKeywordTypes = meetingKeywordTypes;
-	}
-
 	public String getmStartDate() {
 		return mStartDate;
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/MeetingV2CreateMeetingBodyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/MeetingV2CreateMeetingBodyDto.java
@@ -1,0 +1,159 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.request;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingFrequency;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingType;
+import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "모임 생성 request body dto")
+public class MeetingV2CreateMeetingBodyDto {
+
+	@Schema(example = "알고보면 쓸데있는 개발 프로세스", description = "모임 제목")
+	@NotNull
+	private String title;
+
+	@Schema(example = "평양 냉면 스터디 2기입니다.", description = "모임 부제목")
+	@NotNull
+	@Size(min = 1, max = 30)
+	private String subTitle;
+
+	@Schema(example = """
+		["https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2023/04/12/7bd87736-b557-4b26-a0d5-9b09f1f1d7df"]
+		""", description = "모임 이미지 리스트, 최대 6개")
+	@NotEmpty
+	@Size(min = 1, max = 6)
+	private List<String> files;
+
+	@Schema(example = "스터디", description = "모임 카테고리")
+	@NotNull
+	private String category;
+
+	@Schema(example = "2022.10.08", description = "모집 기간 시작 날짜")
+	@NotNull
+	private String startDate;
+
+	@Schema(example = "2022.10.09", description = "모집 기간 끝 날짜")
+	@NotNull
+	private String endDate;
+
+	@Schema(example = "5", description = "모집 인원")
+	@NotNull
+	private Integer capacity;
+
+	@Schema(example = "api 가 터졌다고? 깃이 터졌다고?", description = "모집 정보")
+	@NotNull
+	private String desc;
+
+	@Schema(example = "소요 시간 : 1시간 예상", description = "진행 방식 소개")
+	private String processDesc;
+
+	@Schema(example = "2022.10.29", description = "모임 활동 시작 날짜", name = "mStartDate")
+	@Getter(AccessLevel.NONE)
+	private String mStartDate;
+
+	@Schema(example = "2022.10.30", description = "모임 활동 종료 날짜", name = "mEndDate")
+	@Getter(AccessLevel.NONE)
+	private String mEndDate;
+
+	@Schema(example = "안녕하세요 기획 파트 000입니다", description = "개설자 소개")
+	private String leaderDesc;
+
+	@Schema(example = "유의할 사항", description = "유의할 사항")
+	private String note;
+
+	@Schema(example = "false", description = "멘토 필요 여부")
+	@NotNull
+	private Boolean isMentorNeeded;
+
+	@Schema(example = "false", description = "활동기수만 지원 가능 여부")
+	@NotNull
+	private Boolean canJoinOnlyActiveGeneration;
+
+	@Schema(example = """
+		{
+		  "meetingType": "온라인",
+		  "meetingFrequency": "꾸준히"
+		}
+		""", description = "참여 정보")
+	@NotNull
+	private MeetingJoinInfo joinInfo;
+
+	@Schema(example = """
+		["ANDROID", "IOS"]
+		""", description = "대상 파트 목록")
+	@NotNull
+	@Size(min = 1, max = 6)
+	private MeetingJoinablePart[] joinableParts;
+
+	@Schema(example = """
+		[1304, 1305]
+		""", description = "공동 모임장 userId (크루에서 사용하는 userId)")
+	private List<Integer> coLeaderUserIds;
+
+	@Schema(example = """
+		["운동", "자기계발"]
+		""", description = "모임 키워드 타입 리스트")
+	@Size(min = 1, max = 2)
+	private List<String> meetingKeywordTypes;
+
+	public MeetingV2CreateMeetingBodyDto(
+		String title,
+		List<String> files,
+		String category,
+		String startDate,
+		String endDate,
+		Integer capacity,
+		String desc,
+		String processDesc,
+		String mStartDate,
+		String mEndDate,
+		String leaderDesc,
+		String note,
+		Boolean isMentorNeeded,
+		Boolean canJoinOnlyActiveGeneration,
+		MeetingJoinablePart[] joinableParts,
+		List<Integer> coLeaderUserIds,
+		List<String> welcomeMessageTypes,
+		List<String> meetingKeywordTypes
+	) {
+		this.title = title;
+		this.subTitle = title;
+		this.files = files;
+		this.category = category;
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.capacity = capacity;
+		this.desc = desc;
+		this.processDesc = processDesc;
+		this.mStartDate = mStartDate;
+		this.mEndDate = mEndDate;
+		this.leaderDesc = leaderDesc;
+		this.note = note;
+		this.isMentorNeeded = isMentorNeeded;
+		this.canJoinOnlyActiveGeneration = canJoinOnlyActiveGeneration;
+		this.joinInfo = new MeetingJoinInfo(MeetingType.ONLINE_OFFLINE, MeetingFrequency.STEADY);
+		this.joinableParts = joinableParts;
+		this.coLeaderUserIds = coLeaderUserIds;
+		this.meetingKeywordTypes = meetingKeywordTypes;
+	}
+
+	public String getmStartDate() {
+		return mStartDate;
+	}
+
+	public String getmEndDate() {
+		return mEndDate;
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/MeetingV2UpdateMeetingBodyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/MeetingV2UpdateMeetingBodyDto.java
@@ -3,6 +3,7 @@ package org.sopt.makers.crew.main.meeting.v2.dto.request;
 import java.util.List;
 
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
@@ -14,12 +15,17 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-@Schema(description = "모임 생성 및 수정 request body dto")
-public class MeetingV2CreateAndUpdateMeetingBodyDto {
+@Schema(description = "모임 수정 request body dto")
+public class MeetingV2UpdateMeetingBodyDto {
 
 	@Schema(example = "알고보면 쓸데있는 개발 프로세스", description = "모임 제목")
 	@NotNull
 	private String title;
+
+	@Schema(example = "평양 냉면 스터디 2기입니다.", description = "모임 부제목")
+	@NotNull
+	@Size(min = 1, max = 30)
+	private String subTitle;
 
 	@Schema(example = """
 		["https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2023/04/12/7bd87736-b557-4b26-a0d5-9b09f1f1d7df"]
@@ -74,6 +80,15 @@ public class MeetingV2CreateAndUpdateMeetingBodyDto {
 	private Boolean canJoinOnlyActiveGeneration;
 
 	@Schema(example = """
+		{
+		  "meetingType": "온라인",
+		  "meetingFrequency": "꾸준히"
+		}
+		""", description = "참여 정보")
+	@NotNull
+	private MeetingJoinInfo joinInfo;
+
+	@Schema(example = """
 		["ANDROID", "IOS"]
 		""", description = "대상 파트 목록")
 	@NotNull
@@ -84,17 +99,6 @@ public class MeetingV2CreateAndUpdateMeetingBodyDto {
 		[1304, 1305]
 		""", description = "공동 모임장 userId (크루에서 사용하는 userId)")
 	private List<Integer> coLeaderUserIds;
-
-	@Schema(example = """
-		["YB 환영", "OB 환영"]
-		""", description = "환영 메시지 타입 리스트")
-	private List<String> welcomeMessageTypes;
-
-	@Schema(example = """
-		["운동", "자기계발"]
-		""", description = "모임 키워드 타입 리스트")
-	@Size(min = 1, max = 2)
-	private List<String> meetingKeywordTypes;
 
 	public String getmStartDate() {
 		return mStartDate;

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/MeetingV2UpdateMeetingBodyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/MeetingV2UpdateMeetingBodyDto.java
@@ -6,63 +6,53 @@ import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@Schema(description = "모임 수정 request body dto")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "모임 부분 수정 request body dto")
 public class MeetingV2UpdateMeetingBodyDto {
 
 	@Schema(example = "알고보면 쓸데있는 개발 프로세스", description = "모임 제목")
-	@NotNull
 	private String title;
 
 	@Schema(example = "평양 냉면 스터디 2기입니다.", description = "모임 부제목")
-	@NotNull
 	@Size(min = 1, max = 30)
 	private String subTitle;
 
 	@Schema(example = """
 		["https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2023/04/12/7bd87736-b557-4b26-a0d5-9b09f1f1d7df"]
 		""", description = "모임 이미지 리스트, 최대 6개")
-	@NotEmpty
 	@Size(min = 1, max = 6)
 	private List<String> files;
 
 	@Schema(example = "스터디", description = "모임 카테고리")
-	@NotNull
 	private String category;
 
 	@Schema(example = "2022.10.08", description = "모집 기간 시작 날짜")
-	@NotNull
 	private String startDate;
 
 	@Schema(example = "2022.10.09", description = "모집 기간 끝 날짜")
-	@NotNull
 	private String endDate;
 
 	@Schema(example = "5", description = "모집 인원")
-	@NotNull
 	private Integer capacity;
 
 	@Schema(example = "api 가 터졌다고? 깃이 터졌다고?", description = "모집 정보")
-	@NotNull
 	private String desc;
 
 	@Schema(example = "소요 시간 : 1시간 예상", description = "진행 방식 소개")
 	private String processDesc;
 
 	@Schema(example = "2022.10.29", description = "모임 활동 시작 날짜", name = "mStartDate")
-	@Getter(AccessLevel.NONE)
 	private String mStartDate;
 
 	@Schema(example = "2022.10.30", description = "모임 활동 종료 날짜", name = "mEndDate")
-	@Getter(AccessLevel.NONE)
 	private String mEndDate;
 
 	@Schema(example = "안녕하세요 기획 파트 000입니다", description = "개설자 소개")
@@ -72,11 +62,9 @@ public class MeetingV2UpdateMeetingBodyDto {
 	private String note;
 
 	@Schema(example = "false", description = "멘토 필요 여부")
-	@NotNull
 	private Boolean isMentorNeeded;
 
 	@Schema(example = "false", description = "활동기수만 지원 가능 여부")
-	@NotNull
 	private Boolean canJoinOnlyActiveGeneration;
 
 	@Schema(example = """
@@ -85,13 +73,11 @@ public class MeetingV2UpdateMeetingBodyDto {
 		  "meetingFrequency": "꾸준히"
 		}
 		""", description = "참여 정보")
-	@NotNull
 	private MeetingJoinInfo joinInfo;
 
 	@Schema(example = """
 		["ANDROID", "IOS"]
 		""", description = "대상 파트 목록")
-	@NotNull
 	@Size(min = 1, max = 6)
 	private MeetingJoinablePart[] joinableParts;
 
@@ -99,6 +85,11 @@ public class MeetingV2UpdateMeetingBodyDto {
 		[1304, 1305]
 		""", description = "공동 모임장 userId (크루에서 사용하는 userId)")
 	private List<Integer> coLeaderUserIds;
+
+	@Schema(example = """
+		["YB 환영", "OB 환영"]
+		""", description = "환영 메시지 타입 리스트")
+	private List<String> welcomeMessageTypes;
 
 	public String getmStartDate() {
 		return mStartDate;

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingBannerResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingBannerResponseDto.java
@@ -33,6 +33,9 @@ public class MeetingV2GetMeetingBannerResponseDto {
 	@NotNull
 	private final String title;
 
+	@Schema(description = "모임 부제목", example = "모임 부제목입니다")
+	private final String subTitle;
+
 	/**
 	 * 모임 카테고리
 	 *
@@ -114,6 +117,7 @@ public class MeetingV2GetMeetingBannerResponseDto {
 		long applicantCount, long approvedUserCount, MeetingV2GetMeetingBannerResponseUserDto meetingCreator, LocalDateTime now) {
 
 		return new MeetingV2GetMeetingBannerResponseDto(meeting.getId(), meeting.getUserId(), meeting.getTitle(),
+			meeting.getSubTitle(),
 			meeting.getCategory(),
 			meeting.getImageURL(), meeting.getmStartDate(), meeting.getmEndDate(), meeting.getStartDate(),
 			meeting.getEndDate(), meeting.getCapacity(), recentActivityDate, meeting.getTargetActiveGeneration(),

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
@@ -90,6 +90,9 @@ public class MeetingV2GetMeetingByIdResponseDto {
 	@Schema(description = "참여 정보")
 	private final MeetingJoinInfo joinInfo;
 
+	@Schema(description = "조회자와 같은 파트 참여 정보")
+	private final MeetingV2ParticipatingPartInfoDto participatingPartInfo;
+
 	@Schema(description = "개설 기수", example = "36")
 	@NotNull
 	private final Integer createdGeneration;
@@ -163,6 +166,7 @@ public class MeetingV2GetMeetingByIdResponseDto {
 		Boolean isHost,
 		Boolean isApply,
 		Boolean isApproved,
+		MeetingV2ParticipatingPartInfoDto participatingPartInfo,
 		MeetingCreatorDto meetingCreatorDto,
 		List<ApplyWholeInfoDto> appliedInfo,
 		List<WelcomeMessageType> welcomeMessageTypes,
@@ -202,6 +206,7 @@ public class MeetingV2GetMeetingByIdResponseDto {
 			.isMentorNeeded(meeting.getIsMentorNeeded())
 			.canJoinOnlyActiveGeneration(meeting.getCanJoinOnlyActiveGeneration())
 			.joinInfo(meeting.getJoinInfo())
+			.participatingPartInfo(participatingPartInfo)
 			.createdGeneration(meeting.getCreatedGeneration())
 			.targetActiveGeneration(meeting.getTargetActiveGeneration())
 			.joinableParts(meeting.getJoinableParts())

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
@@ -7,6 +7,7 @@ import org.sopt.makers.crew.main.entity.meeting.CoLeader;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
 import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
 import org.sopt.makers.crew.main.entity.tag.enums.WelcomeMessageType;
 import org.sopt.makers.crew.main.global.dto.MeetingCreatorDto;
@@ -35,6 +36,9 @@ public class MeetingV2GetMeetingByIdResponseDto {
 	@Schema(description = "모임 제목", example = "모임 제목입니다.")
 	@NotNull
 	private final String title;
+
+	@Schema(description = "모임 부제목", example = "모임 부제목입니다.")
+	private final String subTitle;
 
 	@Schema(description = "모임 카테고리", example = "스터디")
 	@NotNull
@@ -82,6 +86,9 @@ public class MeetingV2GetMeetingByIdResponseDto {
 	@Schema(description = "활동 기수만 신청가능한 여부", example = "false")
 	@NotNull
 	private final Boolean canJoinOnlyActiveGeneration;
+
+	@Schema(description = "참여 정보")
+	private final MeetingJoinInfo joinInfo;
 
 	@Schema(description = "개설 기수", example = "36")
 	@NotNull
@@ -180,6 +187,7 @@ public class MeetingV2GetMeetingByIdResponseDto {
 			.id(meetingId)
 			.userId(meeting.getUserId())
 			.title(meeting.getTitle())
+			.subTitle(meeting.getSubTitle())
 			.category(meeting.getCategory().getValue())
 			.imageURL(meeting.getImageURL())
 			.startDate(meeting.getStartDate())
@@ -193,6 +201,7 @@ public class MeetingV2GetMeetingByIdResponseDto {
 			.note(meeting.getNote())
 			.isMentorNeeded(meeting.getIsMentorNeeded())
 			.canJoinOnlyActiveGeneration(meeting.getCanJoinOnlyActiveGeneration())
+			.joinInfo(meeting.getJoinInfo())
 			.createdGeneration(meeting.getCreatedGeneration())
 			.targetActiveGeneration(meeting.getTargetActiveGeneration())
 			.joinableParts(meeting.getJoinableParts())

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingPartMembersResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingPartMembersResponseDto.java
@@ -1,0 +1,20 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "모임 내 같은 파트 참여 멤버 리스트 조회 dto")
+public record MeetingV2GetMeetingPartMembersResponseDto(
+	@Schema(description = "조회자 기준 파트", example = "서버")
+	String part,
+	@Schema(description = "참여중인 같은 파트 인원수", example = "2")
+	int participantCount,
+	@Schema(description = "참여중인 같은 파트 멤버 이름 리스트", example = "[\"이지훈\", \"김효준\"]")
+	List<String> memberNames
+) {
+	public static MeetingV2GetMeetingPartMembersResponseDto of(String part, int participantCount,
+		List<String> memberNames) {
+		return new MeetingV2GetMeetingPartMembersResponseDto(part, participantCount, memberNames);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2ParticipatingPartInfoDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2ParticipatingPartInfoDto.java
@@ -1,0 +1,15 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "조회자와 같은 파트 참여 정보")
+public record MeetingV2ParticipatingPartInfoDto(
+	@Schema(description = "조회자 기준 파트", example = "서버")
+	String part,
+	@Schema(description = "참여중인 같은 파트 인원수", example = "3")
+	int participantCount
+) {
+	public static MeetingV2ParticipatingPartInfoDto of(String part, int participantCount) {
+		return new MeetingV2ParticipatingPartInfoDto(part, participantCount);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingPartNormalizer.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingPartNormalizer.java
@@ -1,0 +1,19 @@
+package org.sopt.makers.crew.main.meeting.v2.service;
+
+import java.util.Objects;
+
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.user.enums.UserPart;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MeetingPartNormalizer {
+
+	public String normalize(String part) {
+		if (Objects.equals(part, UserPart.SERVER.getValue()) || Objects.equals(part, UserPart.BACKEND.getValue())) {
+			return MeetingJoinablePart.SERVER.name();
+		}
+
+		return part;
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingPartNormalizer.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingPartNormalizer.java
@@ -1,17 +1,22 @@
 package org.sopt.makers.crew.main.meeting.v2.service;
 
-import java.util.Objects;
-
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.user.enums.UserPart;
+import org.sopt.makers.crew.main.global.exception.BadRequestException;
+import org.sopt.makers.crew.main.global.util.UserPartUtil;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MeetingPartNormalizer {
 
 	public String normalize(String part) {
-		if (Objects.equals(part, UserPart.SERVER.getValue()) || Objects.equals(part, UserPart.BACKEND.getValue())) {
-			return MeetingJoinablePart.SERVER.name();
+		try {
+			MeetingJoinablePart meetingJoinablePart = UserPartUtil.getMeetingJoinablePart(UserPart.ofValue(part));
+			if (meetingJoinablePart != null) {
+				return meetingJoinablePart.name();
+			}
+		} catch (BadRequestException exception) {
+			return part;
 		}
 
 		return part;

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -8,7 +8,8 @@ import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOr
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.ApplyV2UpdateStatusBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
-import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateAndUpdateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2UpdateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.AppliesCsvFileUrlResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingLeaderUserIdDto;
@@ -28,7 +29,7 @@ public interface MeetingV2Service {
 
 	List<MeetingV2GetMeetingBannerResponseDto> getMeetingBanner();
 
-	MeetingV2CreateMeetingResponseDto createMeeting(MeetingV2CreateAndUpdateMeetingBodyDto requestBody, Integer userId);
+	MeetingV2CreateMeetingResponseDto createMeeting(MeetingV2CreateMeetingBodyDto requestBody, Integer userId);
 
 	MeetingV2ApplyMeetingResponseDto applyGeneralMeeting(MeetingV2ApplyMeetingDto requestBody, Integer userId);
 
@@ -50,7 +51,7 @@ public interface MeetingV2Service {
 
 	void deleteMeeting(Integer meetingId, Integer userId);
 
-	void updateMeeting(Integer meetingId, MeetingV2CreateAndUpdateMeetingBodyDto requestBody, Integer userId);
+	void updateMeeting(Integer meetingId, MeetingV2UpdateMeetingBodyDto requestBody, Integer userId);
 
 	void updateApplyStatus(Integer meetingId, ApplyV2UpdateStatusBodyDto requestBody, Integer userId);
 

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2Service.java
@@ -20,6 +20,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingB
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingByIdResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingPartMembersResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetRecommendDto;
 
 public interface MeetingV2Service {
@@ -59,6 +60,8 @@ public interface MeetingV2Service {
 		Integer userId);
 
 	MeetingV2GetMeetingByIdResponseDto getMeetingDetail(Integer meetingId, Integer userId);
+
+	MeetingV2GetMeetingPartMembersResponseDto getMeetingPartMembers(Integer meetingId, Integer userId);
 
 	MeetingV2GetRecommendDto getRecommendMeetingsByIds(List<Integer> meetingIds, Integer userId);
 

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -99,6 +100,8 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingD
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBannerResponseUserDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingByIdResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingPartMembersResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ParticipatingPartInfoDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetRecommendDto;
 import org.sopt.makers.crew.main.tag.v2.dto.response.TagV2CreateGeneralMeetingTagResponseDto;
 import org.sopt.makers.crew.main.tag.v2.dto.response.TagV2MeetingTagsResponseDto;
@@ -588,14 +591,17 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		MeetingCreatorDto meetingLeader = userReader.getMeetingLeader(meeting.getUserId());
 		CoLeaders coLeaders = coLeaderReader.getCoLeaders(meetingId).toEntity();
 
-		Applies applies = new Applies(
-			applyRepository.findAllByMeetingIdWithUser(meetingId, List.of(WAITING, APPROVE, REJECT), ORDER_ASC));
+		List<Apply> meetingApplies = applyRepository.findAllByMeetingIdWithUser(meetingId, List.of(WAITING, APPROVE,
+			REJECT), ORDER_ASC);
+		Applies applies = new Applies(meetingApplies);
+		List<Apply> participatingApplies = getParticipatingApplies(meetingId);
 
 		Boolean isHost = meeting.checkMeetingLeader(user.getId());
 		Boolean isApply = applies.isApply(meetingId, user.getId());
 		Boolean isApproved = applies.isApproved(meetingId, user.getId());
 		boolean isCoLeader = coLeaders.isCoLeader(meetingId, userId);
 		long approvedCount = applies.getApprovedCount(meetingId);
+		MeetingV2ParticipatingPartInfoDto participatingPartInfo = createParticipatingPartInfo(user, participatingApplies);
 
 		List<ApplyWholeInfoDto> applyWholeInfoDtos = new ArrayList<>();
 		if (applies.hasApplies(meetingId)) {
@@ -611,8 +617,18 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		List<MeetingKeywordType> meetingKeywordTypes = tagV2Service.getMeetingKeywordsTypesByMeetingId(meetingId);
 
 		return MeetingV2GetMeetingByIdResponseDto.of(meetingId, meeting, coLeaders.getCoLeaders(meetingId), isCoLeader,
-			approvedCount, isHost, isApply, isApproved,
+			approvedCount, isHost, isApply, isApproved, participatingPartInfo,
 			meetingLeader, applyWholeInfoDtos, welcomeMessageTypes, meetingKeywordTypes, time.now());
+	}
+
+	@Override
+	public MeetingV2GetMeetingPartMembersResponseDto getMeetingPartMembers(Integer meetingId, Integer userId) {
+		User user = userRepository.findByIdOrThrow(userId);
+		meetingRepository.findByIdOrThrow(meetingId);
+
+		List<Apply> participatingApplies = getParticipatingApplies(meetingId);
+
+		return createMeetingPartMembersResponse(user, participatingApplies);
 	}
 
 	@Override
@@ -841,6 +857,93 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		}
 
 		return now.isEqual(mStartDate) || (now.isAfter(mStartDate) && now.isBefore(mEndDate));
+	}
+
+	private List<Apply> filterParticipatingApplies(List<Apply> meetingApplies) {
+		return meetingApplies.stream()
+			.filter(this::isParticipatingApply)
+			.sorted(Comparator.comparing(Apply::getAppliedDate))
+			.toList();
+	}
+
+	private List<Apply> getParticipatingApplies(Integer meetingId) {
+		List<Apply> participatingMeetingApplies = applyRepository.findAllByMeetingIdWithUser(meetingId, List.of(WAITING,
+			APPROVE), ORDER_ASC);
+		return filterParticipatingApplies(participatingMeetingApplies);
+	}
+
+	private boolean isParticipatingApply(Apply apply) {
+		return WAITING.equals(apply.getStatus()) || APPROVE.equals(apply.getStatus());
+	}
+
+	private MeetingV2ParticipatingPartInfoDto createParticipatingPartInfo(User requestUser,
+		List<Apply> participatingApplies) {
+		UserActivityVO requestUserActivity = getRequestUserActivity(requestUser);
+		if (requestUserActivity == null) {
+			return MeetingV2ParticipatingPartInfoDto.of(null, 0);
+		}
+
+		String requestUserPart = requestUserActivity.getPart();
+		String normalizedRequestUserPart = normalizeParticipatingPart(requestUserPart);
+		int participantCount = (int)participatingApplies.stream()
+			.filter(apply -> isSamePartParticipatingApply(apply, normalizedRequestUserPart))
+			.count();
+
+		return MeetingV2ParticipatingPartInfoDto.of(requestUserPart, participantCount);
+	}
+
+	private MeetingV2GetMeetingPartMembersResponseDto createMeetingPartMembersResponse(User requestUser,
+		List<Apply> participatingApplies) {
+		UserActivityVO requestUserActivity = getRequestUserActivity(requestUser);
+		if (requestUserActivity == null) {
+			return MeetingV2GetMeetingPartMembersResponseDto.of(null, 0, List.of());
+		}
+
+		String requestUserPart = requestUserActivity.getPart();
+		String normalizedRequestUserPart = normalizeParticipatingPart(requestUserPart);
+		List<String> memberNames = participatingApplies.stream()
+			.filter(apply -> isSamePartParticipatingApply(apply, normalizedRequestUserPart))
+			.map(apply -> apply.getUser().getName())
+			.toList();
+
+		return MeetingV2GetMeetingPartMembersResponseDto.of(requestUserPart, memberNames.size(), memberNames);
+	}
+
+	private boolean isSamePartParticipatingApply(Apply apply, String normalizedRequestUserPart) {
+		UserActivityVO participatingUserActivity = getParticipatingUserActivity(apply.getUser());
+		if (participatingUserActivity == null) {
+			return false;
+		}
+
+		String normalizedParticipatingUserPart = normalizeParticipatingPart(participatingUserActivity.getPart());
+		return Objects.equals(normalizedParticipatingUserPart, normalizedRequestUserPart);
+	}
+
+	private UserActivityVO getRequestUserActivity(User requestUser) {
+		if (requestUser.getActivities() == null || requestUser.getActivities().isEmpty()) {
+			return null;
+		}
+
+		return requestUser.getActivities().stream()
+			.filter(userActivityVO -> userActivityVO.getGeneration() == activeGenerationProvider.getActiveGeneration())
+			.findFirst()
+			.orElseGet(requestUser::getRecentActivityVO);
+	}
+
+	private UserActivityVO getParticipatingUserActivity(User participatingUser) {
+		if (participatingUser.getActivities() == null || participatingUser.getActivities().isEmpty()) {
+			return null;
+		}
+
+		return participatingUser.getRecentActivityVO();
+	}
+
+	private String normalizeParticipatingPart(String part) {
+		if (Objects.equals(part, UserPart.SERVER.getValue()) || Objects.equals(part, UserPart.BACKEND.getValue())) {
+			return MeetingJoinablePart.SERVER.name();
+		}
+
+		return part;
 	}
 
 	private Integer createTargetActiveGeneration(Boolean canJoinOnlyActiveGeneration) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -151,6 +151,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 	private final MeetingMapper meetingMapper;
 	private final FlashMeetingMapper flashMeetingMapper;
 	private final ApplyMapper applyMapper;
+	private final MeetingPartNormalizer meetingPartNormalizer;
 
 	private final ImageSettingProperties imageSettingProperties;
 	private final ActiveGenerationProvider activeGenerationProvider;
@@ -635,7 +636,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		List<Apply> meetingApplies = applyRepository.findAllByMeetingIdWithUser(meetingId, List.of(WAITING, APPROVE,
 			REJECT), ORDER_ASC);
 		Applies applies = new Applies(meetingApplies);
-		List<Apply> participatingApplies = getParticipatingApplies(meetingId);
+		List<Apply> participatingApplies = filterParticipatingApplies(meetingApplies);
 
 		Boolean isHost = meeting.checkMeetingLeader(user.getId());
 		Boolean isApply = applies.isApply(meetingId, user.getId());
@@ -925,7 +926,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		}
 
 		String requestUserPart = requestUserActivity.getPart();
-		String normalizedRequestUserPart = normalizeParticipatingPart(requestUserPart);
+		String normalizedRequestUserPart = meetingPartNormalizer.normalize(requestUserPart);
 		int participantCount = (int)participatingApplies.stream()
 			.filter(apply -> isSamePartParticipatingApply(apply, normalizedRequestUserPart))
 			.count();
@@ -941,7 +942,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		}
 
 		String requestUserPart = requestUserActivity.getPart();
-		String normalizedRequestUserPart = normalizeParticipatingPart(requestUserPart);
+		String normalizedRequestUserPart = meetingPartNormalizer.normalize(requestUserPart);
 		List<String> memberNames = participatingApplies.stream()
 			.filter(apply -> isSamePartParticipatingApply(apply, normalizedRequestUserPart))
 			.map(apply -> apply.getUser().getName())
@@ -956,7 +957,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 			return false;
 		}
 
-		String normalizedParticipatingUserPart = normalizeParticipatingPart(participatingUserActivity.getPart());
+		String normalizedParticipatingUserPart = meetingPartNormalizer.normalize(participatingUserActivity.getPart());
 		return Objects.equals(normalizedParticipatingUserPart, normalizedRequestUserPart);
 	}
 
@@ -977,14 +978,6 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		}
 
 		return participatingUser.getRecentActivityVO();
-	}
-
-	private String normalizeParticipatingPart(String part) {
-		if (Objects.equals(part, UserPart.SERVER.getValue()) || Objects.equals(part, UserPart.BACKEND.getValue())) {
-			return MeetingJoinablePart.SERVER.name();
-		}
-
-		return part;
 	}
 
 	private Integer createTargetActiveGeneration(Boolean canJoinOnlyActiveGeneration) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -45,6 +45,7 @@ import org.sopt.makers.crew.main.entity.meeting.MeetingReader;
 import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 import org.sopt.makers.crew.main.entity.post.Post;
 import org.sopt.makers.crew.main.entity.post.PostRepository;
 import org.sopt.makers.crew.main.entity.tag.TagRepository;
@@ -519,19 +520,59 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 	@Transactional
 	public void updateMeeting(Integer meetingId, MeetingV2UpdateMeetingBodyDto requestBody,
 		Integer userId) {
-		User user = userRepository.findByIdOrThrow(userId);
-
 		Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
 		meeting.validateMeetingCreator(userId);
 
-		updateCoLeaders(requestBody.getCoLeaderUserIds(), meeting);
+		if (requestBody.getCoLeaderUserIds() != null) {
+			updateCoLeaders(requestBody.getCoLeaderUserIds(), meeting);
+		}
 
-		Meeting updatedMeeting = meetingMapper.toMeetingEntity(requestBody,
-			createTargetActiveGeneration(requestBody.getCanJoinOnlyActiveGeneration()),
-			activeGenerationProvider.getActiveGeneration(), user,
-			user.getId());
+		MeetingCategory updatedCategory = requestBody.getCategory() != null
+			? MeetingMapper.getCategory(requestBody.getCategory())
+			: null;
+		List<ImageUrlVO> updatedImageURL = requestBody.getFiles() != null
+			? MeetingMapper.getImageURL(requestBody.getFiles())
+			: null;
+		LocalDateTime updatedStartDate = requestBody.getStartDate() != null
+			? MeetingMapper.getStartDate(requestBody.getStartDate())
+			: null;
+		LocalDateTime updatedEndDate = requestBody.getEndDate() != null
+			? MeetingMapper.getEndDate(requestBody.getEndDate())
+			: null;
+		LocalDateTime updatedMeetingStartDate = requestBody.getmStartDate() != null
+			? MeetingMapper.getStartDate(requestBody.getmStartDate())
+			: null;
+		LocalDateTime updatedMeetingEndDate = requestBody.getmEndDate() != null
+			? MeetingMapper.getEndDate(requestBody.getmEndDate())
+			: null;
+		Integer updatedTargetActiveGeneration = requestBody.getCanJoinOnlyActiveGeneration() != null
+			? createTargetActiveGeneration(requestBody.getCanJoinOnlyActiveGeneration())
+			: null;
 
-		meeting.updateMeeting(updatedMeeting);
+		meeting.patchMeeting(
+			requestBody.getTitle(),
+			requestBody.getSubTitle(),
+			updatedCategory,
+			updatedImageURL,
+			updatedStartDate,
+			updatedEndDate,
+			requestBody.getCapacity(),
+			requestBody.getDesc(),
+			requestBody.getProcessDesc(),
+			updatedMeetingStartDate,
+			updatedMeetingEndDate,
+			requestBody.getLeaderDesc(),
+			requestBody.getNote(),
+			requestBody.getIsMentorNeeded(),
+			requestBody.getCanJoinOnlyActiveGeneration(),
+			updatedTargetActiveGeneration,
+			requestBody.getJoinInfo(),
+			requestBody.getJoinableParts()
+		);
+
+		if (requestBody.getWelcomeMessageTypes() != null) {
+			tagV2Service.updateGeneralMeetingWelcomeMessageTypes(requestBody.getWelcomeMessageTypes(), meetingId);
+		}
 	}
 
 	private void updateCoLeaders(List<Integer> coLeaderUserIds, Meeting updatedMeeting) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -82,7 +82,8 @@ import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingByOr
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.ApplyV2UpdateStatusBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
-import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateAndUpdateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2UpdateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.AppliesCsvFileUrlResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDetailDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDto;
@@ -213,7 +214,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
 	@Override
 	@Transactional
-	public MeetingV2CreateMeetingResponseDto createMeeting(MeetingV2CreateAndUpdateMeetingBodyDto requestBody,
+	public MeetingV2CreateMeetingResponseDto createMeeting(MeetingV2CreateMeetingBodyDto requestBody,
 		Integer userId) {
 		User user = userRepository.findByIdOrThrow(userId);
 
@@ -240,7 +241,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		}
 
 		TagV2CreateGeneralMeetingTagResponseDto tagResponseDto = tagV2Service.createGeneralMeetingTag(
-			requestBody.getWelcomeMessageTypes(), requestBody.getMeetingKeywordTypes(), meeting.getId());
+			List.of(), requestBody.getMeetingKeywordTypes(), meeting.getId());
 
 		if (NotificationTimeValidator.isPublishedTime(time.now())) {
 			publishMeetingEvent(requestBody, meeting);
@@ -249,7 +250,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		return MeetingV2CreateMeetingResponseDto.of(savedMeeting.getId(), tagResponseDto.tagId());
 	}
 
-	private void publishMeetingEvent(MeetingV2CreateAndUpdateMeetingBodyDto requestBody, Meeting meeting) {
+	private void publishMeetingEvent(MeetingV2CreateMeetingBodyDto requestBody, Meeting meeting) {
 		List<KeywordMatchedUserDto> keywordMatchedUserDtos = userReader.findByInterestingKeywordTypes(
 			requestBody.getMeetingKeywordTypes());
 		eventPublisher.publishEvent(new KeywordEventDto(keywordMatchedUserDtos
@@ -513,7 +514,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 	})
 	@Override
 	@Transactional
-	public void updateMeeting(Integer meetingId, MeetingV2CreateAndUpdateMeetingBodyDto requestBody,
+	public void updateMeeting(Integer meetingId, MeetingV2UpdateMeetingBodyDto requestBody,
 		Integer userId) {
 		User user = userRepository.findByIdOrThrow(userId);
 
@@ -528,9 +529,6 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 			user.getId());
 
 		meeting.updateMeeting(updatedMeeting);
-
-		tagV2Service.updateGeneralMeetingTag(requestBody.getWelcomeMessageTypes(), requestBody.getMeetingKeywordTypes(),
-			meeting.getId());
 	}
 
 	private void updateCoLeaders(List<Integer> coLeaderUserIds, Meeting updatedMeeting) {

--- a/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2Service.java
@@ -27,6 +27,8 @@ public interface TagV2Service {
 	void updateGeneralMeetingTag(List<String> welcomeMessageTypes,
 		List<String> meetingKeywordTypes, Integer meetingId);
 
+	void updateGeneralMeetingWelcomeMessageTypes(List<String> welcomeMessageTypes, Integer meetingId);
+
 	void updateFlashMeetingTag(List<String> welcomeMessageTypes,
 		List<String> meetingKeywordTypes, Integer flashId);
 

--- a/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/tag/v2/service/TagV2ServiceImpl.java
@@ -121,6 +121,17 @@ public class TagV2ServiceImpl implements TagV2Service {
 
 	@Override
 	@Transactional
+	public void updateGeneralMeetingWelcomeMessageTypes(List<String> welcomeMessageTypes, Integer meetingId) {
+		List<WelcomeMessageType> welcomeMessageTypeEnums = toWelcomeMessageTypes(welcomeMessageTypes);
+
+		Tag tag = tagRepository.findTagByMeetingId(meetingId)
+			.orElseGet(() -> tagRepository.save(Tag.createGeneralMeetingTag(meetingId, welcomeMessageTypeEnums, null)));
+
+		tag.updateWelcomeMessageTypes(welcomeMessageTypeEnums);
+	}
+
+	@Override
+	@Transactional
 	public void updateFlashMeetingTag(List<String> welcomeMessageTypes,
 		List<String> meetingKeywordTypes, Integer flashId) {
 		Tag tag = tagRepository.findTagByFlashId(flashId)

--- a/main/src/main/resources/schema.sql
+++ b/main/src/main/resources/schema.sql
@@ -47,6 +47,7 @@ create table if not exists meeting
     references "user"
     on delete cascade,
     title                         varchar   not null,
+    "subTitle"                    varchar,
     category                      varchar   not null,
     "imageURL"                    jsonb     not null,
     "startDate"                   timestamp not null,
@@ -60,6 +61,7 @@ create table if not exists meeting
     note                          varchar,
     "isMentorNeeded"              boolean   not null,
     "canJoinOnlyActiveGeneration" boolean   not null,
+    "joinInfo"                    jsonb,
     "targetActiveGeneration"      integer,
     "joinableParts"               meeting_joinableparts_enum[],
     "createdGeneration"           integer   default 32,

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -27,8 +27,11 @@ import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
 import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingFrequency;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingType;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.entity.user.UserRepository;
 import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
@@ -45,7 +48,8 @@ import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingGetAppliesQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.query.MeetingV2GetAllMeetingQueryDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.ApplyV2UpdateStatusBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto;
-import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateAndUpdateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2UpdateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyWholeInfoDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
@@ -53,6 +57,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingRe
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingByIdResponseDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingPartMembersResponseDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
@@ -141,15 +146,15 @@ public class MeetingV2ServiceTest {
 				MeetingJoinablePart.IOS
 			};
 
-			// 환영 태그 목록
-			List<String> welcomeMessageTypes = List.of("YB 환영", "초면 환영");
-
 			// 모임 키워드 목록
 			List<String> meetingKeywordTypes = List.of("자기계발", "네트워킹");
 
+			MeetingJoinInfo joinInfo = new MeetingJoinInfo(MeetingType.ONLINE, MeetingFrequency.STEADY);
+
 			// DTO 생성
-			MeetingV2CreateAndUpdateMeetingBodyDto meetingDto = new MeetingV2CreateAndUpdateMeetingBodyDto(
+			MeetingV2CreateMeetingBodyDto meetingDto = new MeetingV2CreateMeetingBodyDto(
 				"알고보면 쓸데있는 개발 프로세스", // title
+				"백엔드 실전 설계부터 배포까지", // subTitle
 				files, // files (모임 이미지 리스트)
 				"스터디", // category
 				"2024.10.01", // startDate (모집 시작 날짜)
@@ -163,9 +168,9 @@ public class MeetingV2ServiceTest {
 				"준비물은 노트북과 열정입니다.", // note (유의할 사항)
 				false, // isMentorNeeded (멘토 필요 여부)
 				canJoinOnlyActiveGeneration, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
+				joinInfo, // joinInfo (참여 정보)
 				joinableParts, // joinableParts (대상 파트 목록)
 				null, // coLeaders (공동모임장 리스트)
-				welcomeMessageTypes, // welcomeMessageTypes (환영 태그 리스트)
 				meetingKeywordTypes // meetingKeywordTypes (모임 키워드 태그 리스트)
 			);
 
@@ -180,14 +185,15 @@ public class MeetingV2ServiceTest {
 			Assertions.assertThat(foundMeeting)
 				.isNotNull()
 				.extracting(
-					"user", "userId", "title", "category", "startDate", "endDate", "capacity", "desc",
+					"user", "userId", "title", "subTitle", "category", "startDate", "endDate", "capacity", "desc",
 					"processDesc", "mStartDate", "mEndDate", "leaderDesc", "note", "isMentorNeeded",
-					"canJoinOnlyActiveGeneration", "createdGeneration", "targetActiveGeneration", "joinableParts"
+					"canJoinOnlyActiveGeneration", "joinInfo", "createdGeneration", "targetActiveGeneration", "joinableParts"
 				)
 				.containsExactly(
 					savedUser,  // user 필드
 					savedUser.getId(),  // userId 필드
 					"알고보면 쓸데있는 개발 프로세스",  // title 필드
+					"백엔드 실전 설계부터 배포까지", // subTitle 필드
 					MeetingCategory.STUDY,  // category 필드
 					LocalDateTime.of(2024, 10, 1, 0, 0, 0),  // startDate 필드
 					LocalDateTime.of(2024, 10, 15, 23, 59, 59),  // endDate 필드
@@ -200,6 +206,7 @@ public class MeetingV2ServiceTest {
 					"준비물은 노트북과 열정입니다.",  // note 필드
 					false,  // isMentorNeeded 필드
 					canJoinOnlyActiveGeneration,  // canJoinOnlyActiveGeneration 필드
+					joinInfo, // joinInfo 필드
 					activeGenerationProvide.getActiveGeneration(),  // createdGeneration 필드
 					canJoinOnlyActiveGeneration ? activeGenerationProvide.getActiveGeneration() : null,
 					// targetActiveGeneration 필드
@@ -263,7 +270,7 @@ public class MeetingV2ServiceTest {
 			List<String> meetingKeywordTypes = List.of("자기계발", "네트워킹");
 
 			// DTO 생성
-			MeetingV2CreateAndUpdateMeetingBodyDto meetingDto = new MeetingV2CreateAndUpdateMeetingBodyDto(
+			MeetingV2CreateMeetingBodyDto meetingDto = new MeetingV2CreateMeetingBodyDto(
 				"알고보면 쓸데있는 개발 프로세스", // title
 				files, // files (모임 이미지 리스트)
 				"스터디", // category
@@ -335,7 +342,7 @@ public class MeetingV2ServiceTest {
 			List<String> meetingKeywordTypes = List.of("자기계발", "네트워킹");
 
 			// DTO 생성
-			MeetingV2CreateAndUpdateMeetingBodyDto meetingDto = new MeetingV2CreateAndUpdateMeetingBodyDto(
+			MeetingV2CreateMeetingBodyDto meetingDto = new MeetingV2CreateMeetingBodyDto(
 				"알고보면 쓸데있는 개발 프로세스", // title
 				files, // files (모임 이미지 리스트)
 				"스터디", // category
@@ -395,7 +402,7 @@ public class MeetingV2ServiceTest {
 			List<String> meetingKeywordTypes = List.of("자기계발", "네트워킹");
 
 			// DTO 생성
-			MeetingV2CreateAndUpdateMeetingBodyDto meetingDto = new MeetingV2CreateAndUpdateMeetingBodyDto(
+			MeetingV2CreateMeetingBodyDto meetingDto = new MeetingV2CreateMeetingBodyDto(
 				"알고보면 쓸데있는 개발 프로세스", // title
 				files, // files (모임 이미지 리스트)
 				"스터디", // category
@@ -455,7 +462,7 @@ public class MeetingV2ServiceTest {
 			List<String> meetingKeywordTypes = List.of("자기계발", "네트워킹");
 
 			// DTO 생성
-			MeetingV2CreateAndUpdateMeetingBodyDto meetingDto = new MeetingV2CreateAndUpdateMeetingBodyDto(
+			MeetingV2CreateMeetingBodyDto meetingDto = new MeetingV2CreateMeetingBodyDto(
 				"알고보면 쓸데있는 개발 프로세스", // title
 				files, // files (모임 이미지 리스트)
 				"스터디", // category
@@ -509,7 +516,7 @@ public class MeetingV2ServiceTest {
 			List<String> meetingKeywordTypes = List.of("자기계발", "네트워킹");
 
 			// DTO 생성
-			MeetingV2CreateAndUpdateMeetingBodyDto meetingDto = new MeetingV2CreateAndUpdateMeetingBodyDto(
+			MeetingV2CreateMeetingBodyDto meetingDto = new MeetingV2CreateMeetingBodyDto(
 				"알고보면 쓸데있는 개발 프로세스", // title
 				files, // files (모임 이미지 리스트)
 				"스터디", // category
@@ -564,7 +571,7 @@ public class MeetingV2ServiceTest {
 			List<String> meetingKeywordTypes = List.of("자기계발", "네트워킹");
 
 			// DTO 생성
-			MeetingV2CreateAndUpdateMeetingBodyDto meetingDto = new MeetingV2CreateAndUpdateMeetingBodyDto(
+			MeetingV2CreateMeetingBodyDto meetingDto = new MeetingV2CreateMeetingBodyDto(
 				"알고보면 쓸데있는 개발 프로세스", // title
 				files, // files (모임 이미지 리스트)
 				"스터디", // category
@@ -617,30 +624,30 @@ public class MeetingV2ServiceTest {
 			// then
 			Assertions.assertThat(meetings)
 				.extracting(
-					"title", "category", "canJoinOnlyActiveGeneration",
+					"title", "subTitle", "category", "canJoinOnlyActiveGeneration",
 					"mStartDate", "mEndDate",
 					"capacity", "isMentorNeeded", "targetActiveGeneration",
 					"joinableParts", "status", "approvedCount"
 				).containsExactly(
-					tuple("스터디 구합니다1", "행사", true,
+					tuple("스터디 구합니다1", "스터디 부제목1", "행사", true,
 						LocalDateTime.of(2024, 5, 29, 0, 0),
 						LocalDateTime.of(2024, 5, 31, 23, 59, 59),
 						10, true, 35,
 						new MeetingJoinablePart[] {PM, SERVER}, 1, 2
 					),
-					tuple("스터디 구합니다 - 신청전", "스터디", false,
+					tuple("스터디 구합니다 - 신청전", "스터디 부제목2", "스터디", false,
 						LocalDateTime.of(2024, 5, 29, 0, 0),
 						LocalDateTime.of(2024, 5, 31, 23, 59, 59),
 						10, false, null,
 						new MeetingJoinablePart[] {PM, SERVER}, 0, 0
 					),
-					tuple("세미나 구합니다 - 신청후", "세미나", false,
+					tuple("세미나 구합니다 - 신청후", "세미나 부제목4", "세미나", false,
 						LocalDateTime.of(2024, 5, 29, 0, 0),
 						LocalDateTime.of(2024, 5, 31, 23, 59, 59),
 						13, false, null,
 						new MeetingJoinablePart[] {WEB, IOS}, 2, 0
 					),
-					tuple("스터디 구합니다 - 신청후", "스터디", false,
+					tuple("스터디 구합니다 - 신청후", "스터디 부제목3", "스터디", false,
 						LocalDateTime.of(2024, 5, 29, 0, 0),
 						LocalDateTime.of(2024, 5, 31, 23, 59, 59),
 						10, false, null,
@@ -986,11 +993,11 @@ public class MeetingV2ServiceTest {
 			// then
 			Assertions.assertThat(responseDto)
 				.extracting(
-					"id", "userId", "title", "category",
+					"id", "userId", "title", "subTitle", "category",
 					"startDate", "endDate",
 					"capacity", "desc", "processDesc",
 					"mStartDate", "mEndDate",
-					"leaderDesc", "note", "isMentorNeeded", "canJoinOnlyActiveGeneration",
+					"leaderDesc", "note", "isMentorNeeded", "canJoinOnlyActiveGeneration", "joinInfo",
 					"createdGeneration", "targetActiveGeneration",
 					"joinableParts",
 					"status", "approvedApplyCount",
@@ -998,13 +1005,14 @@ public class MeetingV2ServiceTest {
 					"user.id", "user.name", "user.profileImage", "user.activities", "user.phone"
 				)
 				.containsExactly(
-					1, 1, "스터디 구합니다1", "행사",
+					1, 1, "스터디 구합니다1", "스터디 부제목1", "행사",
 					LocalDateTime.of(2024, 4, 24, 0, 0, 0),
 					LocalDateTime.of(2024, 5, 24, 23, 59, 59),
 					10, "스터디 설명입니다.", "스터디 진행방식입니다.",
 					LocalDateTime.of(2024, 5, 29, 0, 0, 0),
 					LocalDateTime.of(2024, 5, 31, 23, 59, 59),
 					"스터디장 설명입니다.", "시간지키세요.", true, true,
+					new MeetingJoinInfo(MeetingType.ONLINE, MeetingFrequency.STEADY),
 					35, 35,
 					new MeetingJoinablePart[] {MeetingJoinablePart.PM, MeetingJoinablePart.SERVER},
 					1, 2L,
@@ -1161,6 +1169,56 @@ public class MeetingV2ServiceTest {
 		}
 
 		@Test
+		@DisplayName("활동 기수가 아닌 조회자는 마지막 활동 파트 기준 같은 파트 참여 정보를 반환한다.")
+		void nonActiveGenerationUser_getMeetingById_participantPartInfo() {
+			// given
+			Integer meetingId = 1;
+			Integer userId = 1;
+
+			// when
+			MeetingV2GetMeetingByIdResponseDto responseDto = meetingV2Service.getMeetingDetail(meetingId, userId);
+
+			// then
+			Assertions.assertThat(responseDto.getParticipatingPartInfo().part()).isEqualTo("서버");
+			Assertions.assertThat(responseDto.getParticipatingPartInfo().participantCount()).isEqualTo(0);
+		}
+
+		@Test
+		@DisplayName("서버 조회자는 백엔드 신청자를 같은 파트 참여자로 집계한다.")
+		void serverUser_getMeetingById_backendApplicant_samePart() {
+			// given
+			Integer meetingId = 1;
+			Integer userId = 1;
+
+			User backendUser = User.builder()
+				.name("백엔드신청자")
+				.orgId(999)
+				.activities(List.of(new UserActivityVO("백엔드", 38)))
+				.profileImage("backend-profile.jpg")
+				.phone("010-9999-9999")
+				.build();
+			User savedBackendUser = userRepository.save(backendUser);
+
+			Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
+			Apply apply = Apply.builder()
+				.type(EnApplyType.APPLY)
+				.meeting(meeting)
+				.meetingId(meetingId)
+				.user(savedBackendUser)
+				.userId(savedBackendUser.getId())
+				.content("백엔드 신청합니다.")
+				.build();
+			applyRepository.save(apply);
+
+			// when
+			MeetingV2GetMeetingByIdResponseDto responseDto = meetingV2Service.getMeetingDetail(meetingId, userId);
+
+			// then
+			Assertions.assertThat(responseDto.getParticipatingPartInfo().part()).isEqualTo("서버");
+			Assertions.assertThat(responseDto.getParticipatingPartInfo().participantCount()).isEqualTo(1);
+		}
+
+		@Test
 		@DisplayName("모임 신청기간 전인 경우, status 0 를 반환한다.")
 		void beforeApply_getMeetingById_success() {
 			// given
@@ -1244,6 +1302,69 @@ public class MeetingV2ServiceTest {
 			Assertions.assertThat(applyNumbers).isEqualTo(expectedNumbers);
 		}
 
+	}
+
+	@Nested
+	@SqlGroup({
+		@Sql(value = "/sql/meeting-service-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
+		@Sql(value = "/sql/delete-all-data.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+
+	})
+	class 모임_같은_파트_참여_멤버_조회 {
+
+		@Test
+		@DisplayName("활동 기수 조회자는 현재 활동 기수 파트 기준 참여중인 멤버 리스트를 반환한다.")
+		void activeGenerationUser_getMeetingPartMembers_success() {
+			// given
+			Integer meetingId = 1;
+			Integer userId = 5;
+
+			// when
+			MeetingV2GetMeetingPartMembersResponseDto responseDto = meetingV2Service.getMeetingPartMembers(meetingId,
+				userId);
+
+			// then
+			Assertions.assertThat(responseDto.part()).isEqualTo("iOS");
+			Assertions.assertThat(responseDto.participantCount()).isEqualTo(1);
+			Assertions.assertThat(responseDto.memberNames()).containsExactly("대기신청자");
+		}
+
+		@Test
+		@DisplayName("서버 조회자는 백엔드 신청자를 같은 파트 멤버로 조회한다.")
+		void serverUser_getMeetingPartMembers_backendApplicant_samePart() {
+			// given
+			Integer meetingId = 1;
+			Integer userId = 1;
+
+			User backendUser = User.builder()
+				.name("백엔드신청자")
+				.orgId(1000)
+				.activities(List.of(new UserActivityVO("백엔드", 38)))
+				.profileImage("backend-profile.jpg")
+				.phone("010-0000-0000")
+				.build();
+			User savedBackendUser = userRepository.save(backendUser);
+
+			Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
+			Apply apply = Apply.builder()
+				.type(EnApplyType.APPLY)
+				.meeting(meeting)
+				.meetingId(meetingId)
+				.user(savedBackendUser)
+				.userId(savedBackendUser.getId())
+				.content("백엔드 신청합니다.")
+				.build();
+			applyRepository.save(apply);
+
+			// when
+			MeetingV2GetMeetingPartMembersResponseDto responseDto = meetingV2Service.getMeetingPartMembers(meetingId,
+				userId);
+
+			// then
+			Assertions.assertThat(responseDto.part()).isEqualTo("서버");
+			Assertions.assertThat(responseDto.participantCount()).isEqualTo(1);
+			Assertions.assertThat(responseDto.memberNames()).containsExactly("백엔드신청자");
+		}
 	}
 
 	@Nested
@@ -2070,15 +2191,11 @@ public class MeetingV2ServiceTest {
 				MeetingJoinablePart.IOS
 			};
 
-			// 환영 태그 목록
-			List<String> welcomeMessageTypes = List.of("YB 환영", "초면 환영");
+			MeetingJoinInfo joinInfo = new MeetingJoinInfo(MeetingType.ONLINE, MeetingFrequency.STEADY);
 
-			// 모임 키워드 목록
-			List<String> meetingKeywordTypes = List.of("자기계발", "네트워킹");
-
-			// DTO 생성
-			MeetingV2CreateAndUpdateMeetingBodyDto dto = new MeetingV2CreateAndUpdateMeetingBodyDto(
+			MeetingV2UpdateMeetingBodyDto dto = new MeetingV2UpdateMeetingBodyDto(
 				"알고보면 쓸데있는 개발 프로세스", // title
+				"백엔드 실전 설계부터 배포까지", // subTitle
 				files, // files (모임 이미지 리스트)
 				"스터디", // category
 				"2024.10.01", // startDate (모집 시작 날짜)
@@ -2092,10 +2209,9 @@ public class MeetingV2ServiceTest {
 				"준비물은 노트북과 열정입니다.", // note (유의할 사항)
 				false, // isMentorNeeded (멘토 필요 여부)
 				true, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
+				joinInfo, // joinInfo (참여 정보)
 				joinableParts, // joinableParts (대상 파트 목록)
-				null, // coLeaders (공동모임장 리스트)
-				welcomeMessageTypes, // welcomeMessageTypes (환영 태그 리스트)
-				meetingKeywordTypes // meetingKeywordTypes (모임 키워드 태그 리스트)
+				null // coLeaders (공동모임장 리스트)
 			);
 			// when, then
 			Assertions.assertThatThrownBy(
@@ -2122,15 +2238,11 @@ public class MeetingV2ServiceTest {
 				MeetingJoinablePart.IOS
 			};
 
-			// 환영 태그 목록
-			List<String> welcomeMessageTypes = List.of("YB 환영", "초면 환영");
+			MeetingJoinInfo joinInfo = new MeetingJoinInfo(MeetingType.OFFLINE, MeetingFrequency.IMMERSIVE);
 
-			// 모임 키워드 목록
-			List<String> meetingKeywordTypes = List.of("운동", "먹방");
-
-			// DTO 생성
-			MeetingV2CreateAndUpdateMeetingBodyDto dto = new MeetingV2CreateAndUpdateMeetingBodyDto(
+			MeetingV2UpdateMeetingBodyDto dto = new MeetingV2UpdateMeetingBodyDto(
 				"수정1", // title
+				"수정 부제목", // subTitle
 				files, // files (모임 이미지 리스트)
 				"행사", // category
 				"2024.12.12", // startDate (모집 시작 날짜)
@@ -2144,10 +2256,9 @@ public class MeetingV2ServiceTest {
 				"준비물은 노트북과 열정입니다.", // note (유의할 사항)
 				false, // isMentorNeeded (멘토 필요 여부)
 				true, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
+				joinInfo, // joinInfo (참여 정보)
 				joinableParts, // joinableParts (대상 파트 목록)
-				List.of(3, 4), // coLeaders (공동모임장 리스트)
-				welcomeMessageTypes, // welcomeMessageTypes (환영 태그 리스트)
-				meetingKeywordTypes // meetingKeywordTypes (모임 키워드 태그 리스트)
+				List.of(3, 4) // coLeaders (공동모임장 리스트)
 			);
 
 			// when
@@ -2156,8 +2267,8 @@ public class MeetingV2ServiceTest {
 			// then
 			Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
 			Assertions.assertThat(meeting)
-				.extracting("title", "category", "startDate", "endDate")
-				.containsExactly("수정1", MeetingCategory.EVENT,
+				.extracting("title", "subTitle", "joinInfo", "category", "startDate", "endDate")
+				.containsExactly("수정1", "수정 부제목", joinInfo, MeetingCategory.EVENT,
 					LocalDateTime.of(2024, 12, 12, 0, 0, 0),
 					LocalDateTime.of(2024, 12, 25, 23, 59, 59));
 

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -58,6 +58,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2CreateMeetingR
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetAllMeetingDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingByIdResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingPartMembersResponseDto;
+import org.sopt.makers.crew.main.tag.v2.service.TagV2Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
@@ -89,6 +90,9 @@ public class MeetingV2ServiceTest {
 
 	@Autowired
 	private ActiveGenerationProvider activeGenerationProvide;
+
+	@Autowired
+	private TagV2Service tagV2Service;
 
 	private Meeting createMeetingFixture(Integer index, User user) {
 
@@ -2202,38 +2206,26 @@ public class MeetingV2ServiceTest {
 			// given
 			Integer coLeaderId = 5;
 
-			// 모임 이미지 리스트
-			List<String> files = Arrays.asList(
-				"https://example.com/image1.jpg"
-			);
-
-			// 대상 파트 목록
-			MeetingJoinablePart[] joinableParts = {
-				MeetingJoinablePart.SERVER,
-				MeetingJoinablePart.IOS
-			};
-
-			MeetingJoinInfo joinInfo = new MeetingJoinInfo(MeetingType.ONLINE, MeetingFrequency.STEADY);
-
 			MeetingV2UpdateMeetingBodyDto dto = new MeetingV2UpdateMeetingBodyDto(
-				"알고보면 쓸데있는 개발 프로세스", // title
-				"백엔드 실전 설계부터 배포까지", // subTitle
-				files, // files (모임 이미지 리스트)
-				"스터디", // category
-				"2024.10.01", // startDate (모집 시작 날짜)
-				"2024.10.15", // endDate (모집 끝 날짜)
-				10, // capacity (모집 인원)
-				"백엔드 개발에 관심 있는 사람들을 위한 스터디입니다.", // desc (모집 정보)
-				"매주 온라인으로 진행되며, 발표와 토론이 포함됩니다.", // processDesc (진행 방식 소개)
-				"2024.10.16", // mStartDate (모임 활동 시작 날짜)
-				"2024.12.30", // mEndDate (모임 활동 종료 날짜)
-				"5년차 백엔드 개발자입니다.", // leaderDesc (개설자 소개)
-				"준비물은 노트북과 열정입니다.", // note (유의할 사항)
-				false, // isMentorNeeded (멘토 필요 여부)
-				true, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
-				joinInfo, // joinInfo (참여 정보)
-				joinableParts, // joinableParts (대상 파트 목록)
-				null // coLeaders (공동모임장 리스트)
+				null, // title
+				null, // subTitle
+				null, // files
+				null, // category
+				null, // startDate
+				null, // endDate
+				null, // capacity
+				null, // desc
+				null, // processDesc
+				null, // mStartDate
+				null, // mEndDate
+				null, // leaderDesc
+				null, // note
+				null, // isMentorNeeded
+				null, // canJoinOnlyActiveGeneration
+				null, // joinInfo
+				null, // joinableParts
+				null, // coLeaderUserIds
+				List.of("초면 환영") // welcomeMessageTypes
 			);
 			// when, then
 			Assertions.assertThatThrownBy(
@@ -2243,44 +2235,34 @@ public class MeetingV2ServiceTest {
 		}
 
 		@Test
-		@DisplayName("모임 수정을 할 수 있다.")
-		void modifyMeeting_Success() {
+		@DisplayName("새로운 모임 수정 페이지는 부제목과 참여 정보만 수정할 수 있다.")
+		void patchMeeting_newPage_success() {
 			// given
 			Integer userId = 1;
 			Integer meetingId = 1;
 
-			// 모임 이미지 리스트
-			List<String> files = Arrays.asList(
-				"https://example.com/image1.jpg"
-			);
-
-			// 대상 파트 목록
-			MeetingJoinablePart[] joinableParts = {
-				MeetingJoinablePart.SERVER,
-				MeetingJoinablePart.IOS
-			};
-
 			MeetingJoinInfo joinInfo = new MeetingJoinInfo(MeetingType.OFFLINE, MeetingFrequency.IMMERSIVE);
 
 			MeetingV2UpdateMeetingBodyDto dto = new MeetingV2UpdateMeetingBodyDto(
-				"수정1", // title
+				null, // title
 				"수정 부제목", // subTitle
-				files, // files (모임 이미지 리스트)
-				"행사", // category
-				"2024.12.12", // startDate (모집 시작 날짜)
-				"2024.12.25", // endDate (모집 끝 날짜)
-				10, // capacity (모집 인원)
-				"백엔드 개발에 관심 있는 사람들을 위한 스터디입니다.", // desc (모집 정보)
-				"매주 온라인으로 진행되며, 발표와 토론이 포함됩니다.", // processDesc (진행 방식 소개)
-				"2024.10.16", // mStartDate (모임 활동 시작 날짜)
-				"2024.12.30", // mEndDate (모임 활동 종료 날짜)
-				"5년차 백엔드 개발자입니다.", // leaderDesc (개설자 소개)
-				"준비물은 노트북과 열정입니다.", // note (유의할 사항)
-				false, // isMentorNeeded (멘토 필요 여부)
-				true, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
+				null, // files
+				null, // category
+				null, // startDate
+				null, // endDate
+				null, // capacity
+				null, // desc
+				null, // processDesc
+				null, // mStartDate
+				null, // mEndDate
+				null, // leaderDesc
+				null, // note
+				null, // isMentorNeeded
+				null, // canJoinOnlyActiveGeneration
 				joinInfo, // joinInfo (참여 정보)
-				joinableParts, // joinableParts (대상 파트 목록)
-				List.of(3, 4) // coLeaders (공동모임장 리스트)
+				null, // joinableParts
+				null, // coLeaderUserIds
+				null // welcomeMessageTypes
 			);
 
 			// when
@@ -2289,16 +2271,57 @@ public class MeetingV2ServiceTest {
 			// then
 			Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
 			Assertions.assertThat(meeting)
-				.extracting("title", "subTitle", "joinInfo", "category", "startDate", "endDate")
-				.containsExactly("수정1", "수정 부제목", joinInfo, MeetingCategory.EVENT,
-					LocalDateTime.of(2024, 12, 12, 0, 0, 0),
-					LocalDateTime.of(2024, 12, 25, 23, 59, 59));
+				.extracting("title", "subTitle", "joinInfo", "category")
+				.containsExactly("스터디 구합니다1", "수정 부제목", joinInfo, MeetingCategory.EVENT);
 
 			List<CoLeader> coLeaders = coLeaderRepository.findAllByMeetingId(meetingId);
-			Assertions.assertThat(coLeaders).hasSize(2);
+			Assertions.assertThat(coLeaders).hasSize(1);
 			Assertions.assertThat(coLeaders)
 				.extracting("user.name")
-				.containsExactly("승인신청자", "대기신청자");
+				.containsExactly("모임개설자2");
+		}
+
+		@Test
+		@DisplayName("기존 개설자 수정 페이지는 환영 태그만 수정할 수 있다.")
+		void patchMeeting_legacyPage_success() {
+			// given
+			Integer userId = 1;
+			Integer meetingId = 1;
+
+			MeetingV2UpdateMeetingBodyDto dto = new MeetingV2UpdateMeetingBodyDto(
+				null, // title
+				null, // subTitle
+				null, // files
+				null, // category
+				null, // startDate
+				null, // endDate
+				null, // capacity
+				null, // desc
+				null, // processDesc
+				null, // mStartDate
+				null, // mEndDate
+				null, // leaderDesc
+				null, // note
+				null, // isMentorNeeded
+				null, // canJoinOnlyActiveGeneration
+				null, // joinInfo
+				null, // joinableParts
+				null, // coLeaderUserIds
+				List.of("초면 환영") // welcomeMessageTypes
+			);
+
+			// when
+			meetingV2Service.updateMeeting(meetingId, dto, userId);
+
+			// then
+			Assertions.assertThat(tagV2Service.getWelcomeMessageTypesByMeetingId(meetingId))
+				.extracting("value")
+				.containsExactly("초면 환영");
+
+			Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
+			Assertions.assertThat(meeting.getSubTitle()).isEqualTo("스터디 부제목1");
+			Assertions.assertThat(meeting.getJoinInfo()).isEqualTo(
+				new MeetingJoinInfo(MeetingType.ONLINE, MeetingFrequency.STEADY));
 		}
 	}
 

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -1362,25 +1362,7 @@ public class MeetingV2ServiceTest {
 			Integer meetingId = 1;
 			Integer userId = 1;
 
-			User backendUser = User.builder()
-				.name("백엔드신청자")
-				.orgId(1000)
-				.activities(List.of(new UserActivityVO("백엔드", 38)))
-				.profileImage("backend-profile.jpg")
-				.phone("010-0000-0000")
-				.build();
-			User savedBackendUser = userRepository.save(backendUser);
-
-			Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
-			Apply apply = Apply.builder()
-				.type(EnApplyType.APPLY)
-				.meeting(meeting)
-				.meetingId(meetingId)
-				.user(savedBackendUser)
-				.userId(savedBackendUser.getId())
-				.content("백엔드 신청합니다.")
-				.build();
-			applyRepository.save(apply);
+			saveApplyUser(meetingId, 1000, "백엔드신청자", "백엔드");
 
 			// when
 			MeetingV2GetMeetingPartMembersResponseDto responseDto = meetingV2Service.getMeetingPartMembers(meetingId,
@@ -1390,6 +1372,71 @@ public class MeetingV2ServiceTest {
 			Assertions.assertThat(responseDto.part()).isEqualTo("서버");
 			Assertions.assertThat(responseDto.participantCount()).isEqualTo(1);
 			Assertions.assertThat(responseDto.memberNames()).containsExactly("백엔드신청자");
+		}
+
+		@Test
+		@DisplayName("기획 조회자는 PM 신청자를 같은 파트 멤버로 조회한다.")
+		void planUser_getMeetingPartMembers_pmApplicant_samePart() {
+			// given
+			Integer meetingId = 1;
+			Integer userId = 2;
+
+			saveApplyUser(meetingId, 1001, "PM신청자", "PM");
+
+			// when
+			MeetingV2GetMeetingPartMembersResponseDto responseDto = meetingV2Service.getMeetingPartMembers(meetingId,
+				userId);
+
+			// then
+			Assertions.assertThat(responseDto.part()).isEqualTo("기획");
+			Assertions.assertThat(responseDto.participantCount()).isEqualTo(2);
+			Assertions.assertThat(responseDto.memberNames()).containsExactly("승인신청자", "PM신청자");
+		}
+
+		@Test
+		@DisplayName("웹 조회자는 프론트엔드 신청자를 같은 파트 멤버로 조회한다.")
+		void webUser_getMeetingPartMembers_frontendApplicant_samePart() {
+			// given
+			Integer meetingId = 4;
+			User webUser = userRepository.save(User.builder()
+				.name("웹조회자")
+				.orgId(1002)
+				.activities(List.of(new UserActivityVO("웹", 35)))
+				.profileImage("web-profile.jpg")
+				.phone("010-0000-0000")
+				.build());
+
+			saveApplyUser(meetingId, 1003, "프론트엔드신청자", "프론트엔드");
+
+			// when
+			MeetingV2GetMeetingPartMembersResponseDto responseDto = meetingV2Service.getMeetingPartMembers(meetingId,
+				webUser.getId());
+
+			// then
+			Assertions.assertThat(responseDto.part()).isEqualTo("웹");
+			Assertions.assertThat(responseDto.participantCount()).isEqualTo(1);
+			Assertions.assertThat(responseDto.memberNames()).containsExactly("프론트엔드신청자");
+		}
+
+		private void saveApplyUser(Integer meetingId, Integer userId, String name, String part) {
+			User user = userRepository.save(User.builder()
+				.name(name)
+				.orgId(userId)
+				.activities(List.of(new UserActivityVO(part, 38)))
+				.profileImage("profile.jpg")
+				.phone("010-0000-0000")
+				.build());
+
+			Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
+			Apply apply = Apply.builder()
+				.type(EnApplyType.APPLY)
+				.meeting(meeting)
+				.meetingId(meetingId)
+				.user(user)
+				.userId(user.getId())
+				.content(part + " 신청합니다.")
+				.build();
+			applyRepository.save(apply);
 		}
 	}
 

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -119,6 +119,10 @@ public class MeetingV2ServiceTest {
 			.build();
 	}
 
+	private MeetingJoinInfo createMeetingJoinInfo() {
+		return new MeetingJoinInfo(MeetingType.ONLINE_OFFLINE, MeetingFrequency.STEADY);
+	}
+
 	@Nested
 	class 모임_생성 {
 		@ParameterizedTest
@@ -149,7 +153,7 @@ public class MeetingV2ServiceTest {
 			// 모임 키워드 목록
 			List<String> meetingKeywordTypes = List.of("자기계발", "네트워킹");
 
-			MeetingJoinInfo joinInfo = new MeetingJoinInfo(MeetingType.ONLINE, MeetingFrequency.STEADY);
+			MeetingJoinInfo joinInfo = createMeetingJoinInfo();
 
 			// DTO 생성
 			MeetingV2CreateMeetingBodyDto meetingDto = new MeetingV2CreateMeetingBodyDto(
@@ -269,9 +273,12 @@ public class MeetingV2ServiceTest {
 			// 모임 키워드 목록
 			List<String> meetingKeywordTypes = List.of("자기계발", "네트워킹");
 
+			MeetingJoinInfo joinInfo = createMeetingJoinInfo();
+
 			// DTO 생성
 			MeetingV2CreateMeetingBodyDto meetingDto = new MeetingV2CreateMeetingBodyDto(
 				"알고보면 쓸데있는 개발 프로세스", // title
+				"알고보면 쓸데있는 개발 프로세스", // subTitle
 				files, // files (모임 이미지 리스트)
 				"스터디", // category
 				"2024.10.01", // startDate (모집 시작 날짜)
@@ -285,9 +292,9 @@ public class MeetingV2ServiceTest {
 				"준비물은 노트북과 열정입니다.", // note (유의할 사항)
 				false, // isMentorNeeded (멘토 필요 여부)
 				true, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
+				joinInfo, // joinInfo (참여 정보)
 				joinableParts, // joinableParts (대상 파트 목록)
 				List.of(savedJointLeader1.getId(), savedJointLeader2.getId()), // coLeaders (공동모임장 리스트)
-				welcomeMessageTypes, // welcomeMessageTypes (환영 태그 리스트)
 				meetingKeywordTypes // meetingKeywordTypes (모임 키워드 태그 리스트)
 			);
 
@@ -341,9 +348,12 @@ public class MeetingV2ServiceTest {
 			// 모임 키워드 목록
 			List<String> meetingKeywordTypes = List.of("자기계발", "네트워킹");
 
+			MeetingJoinInfo joinInfo = createMeetingJoinInfo();
+
 			// DTO 생성
 			MeetingV2CreateMeetingBodyDto meetingDto = new MeetingV2CreateMeetingBodyDto(
 				"알고보면 쓸데있는 개발 프로세스", // title
+				"알고보면 쓸데있는 개발 프로세스", // subTitle
 				files, // files (모임 이미지 리스트)
 				"스터디", // category
 				"2024.10.01", // startDate (모집 시작 날짜)
@@ -357,9 +367,9 @@ public class MeetingV2ServiceTest {
 				"준비물은 노트북과 열정입니다.", // note (유의할 사항)
 				false, // isMentorNeeded (멘토 필요 여부)
 				true, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
+				joinInfo, // joinInfo (참여 정보)
 				joinableParts, // joinableParts (대상 파트 목록)
 				List.of(0, Integer.MAX_VALUE), // coLeaders (공동모임장 리스트)
-				welcomeMessageTypes, // welcomeMessageTypes (환영 태그 리스트)
 				meetingKeywordTypes // meetingKeywordTypes (모임 키워드 태그 리스트)
 			);
 
@@ -401,9 +411,12 @@ public class MeetingV2ServiceTest {
 			// 모임 키워드 목록
 			List<String> meetingKeywordTypes = List.of("자기계발", "네트워킹");
 
+			MeetingJoinInfo joinInfo = createMeetingJoinInfo();
+
 			// DTO 생성
 			MeetingV2CreateMeetingBodyDto meetingDto = new MeetingV2CreateMeetingBodyDto(
 				"알고보면 쓸데있는 개발 프로세스", // title
+				"알고보면 쓸데있는 개발 프로세스", // subTitle
 				files, // files (모임 이미지 리스트)
 				"스터디", // category
 				"2024.10.01", // startDate (모집 시작 날짜)
@@ -417,9 +430,9 @@ public class MeetingV2ServiceTest {
 				"준비물은 노트북과 열정입니다.", // note (유의할 사항)
 				false, // isMentorNeeded (멘토 필요 여부)
 				true, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
+				joinInfo, // joinInfo (참여 정보)
 				joinableParts, // joinableParts (대상 파트 목록)
 				List.of(savedUser.getId()), // coLeaders (공동모임장 리스트)
-				welcomeMessageTypes, // welcomeMessageTypes (환영 태그 리스트)
 				meetingKeywordTypes // meetingKeywordTypes (모임 키워드 태그 리스트)
 			);
 
@@ -461,9 +474,12 @@ public class MeetingV2ServiceTest {
 			// 모임 키워드 목록
 			List<String> meetingKeywordTypes = List.of("자기계발", "네트워킹");
 
+			MeetingJoinInfo joinInfo = createMeetingJoinInfo();
+
 			// DTO 생성
 			MeetingV2CreateMeetingBodyDto meetingDto = new MeetingV2CreateMeetingBodyDto(
 				"알고보면 쓸데있는 개발 프로세스", // title
+				"알고보면 쓸데있는 개발 프로세스", // subTitle
 				files, // files (모임 이미지 리스트)
 				"스터디", // category
 				"2022.10.08", // startDate (모집 시작 날짜)
@@ -477,9 +493,9 @@ public class MeetingV2ServiceTest {
 				"유의할 사항", // note (유의할 사항)
 				false, // isMentorNeeded (멘토 필요 여부)
 				false, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
+				joinInfo, // joinInfo (참여 정보)
 				joinableParts, // joinableParts (대상 파트 목록)
 				null, // coLeaders (공동모임장 리스트)
-				welcomeMessageTypes, // welcomeMessageTypes (환영 태그 리스트)
 				meetingKeywordTypes // meetingKeywordTypes (모임 키워드 태그 리스트)
 			);
 
@@ -515,9 +531,12 @@ public class MeetingV2ServiceTest {
 			// 모임 키워드 목록
 			List<String> meetingKeywordTypes = List.of("자기계발", "네트워킹");
 
+			MeetingJoinInfo joinInfo = createMeetingJoinInfo();
+
 			// DTO 생성
 			MeetingV2CreateMeetingBodyDto meetingDto = new MeetingV2CreateMeetingBodyDto(
 				"알고보면 쓸데있는 개발 프로세스", // title
+				"알고보면 쓸데있는 개발 프로세스", // subTitle
 				files, // files (모임 이미지 리스트)
 				"스터디", // category
 				"2022.10.08", // startDate (모집 시작 날짜)
@@ -531,9 +550,9 @@ public class MeetingV2ServiceTest {
 				"유의할 사항", // note (유의할 사항)
 				false, // isMentorNeeded (멘토 필요 여부)
 				false, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
+				joinInfo, // joinInfo (참여 정보)
 				joinableParts, // joinableParts (대상 파트 목록)
 				null, // coLeaders (공동모임장 리스트)
-				welcomeMessageTypes, // welcomeMessageTypes (환영 태그 리스트)
 				meetingKeywordTypes // meetingKeywordTypes (모임 키워드 태그 리스트)
 			);
 
@@ -570,9 +589,12 @@ public class MeetingV2ServiceTest {
 			// 모임 키워드 목록
 			List<String> meetingKeywordTypes = List.of("자기계발", "네트워킹");
 
+			MeetingJoinInfo joinInfo = createMeetingJoinInfo();
+
 			// DTO 생성
 			MeetingV2CreateMeetingBodyDto meetingDto = new MeetingV2CreateMeetingBodyDto(
 				"알고보면 쓸데있는 개발 프로세스", // title
+				"알고보면 쓸데있는 개발 프로세스", // subTitle
 				files, // files (모임 이미지 리스트)
 				"스터디", // category
 				"2022.10.08", // startDate (모집 시작 날짜)
@@ -586,9 +608,9 @@ public class MeetingV2ServiceTest {
 				"유의할 사항", // note (유의할 사항)
 				false, // isMentorNeeded (멘토 필요 여부)
 				false, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
+				joinInfo, // joinInfo (참여 정보)
 				joinableParts, // joinableParts (대상 파트 목록)
 				null, // coLeaders (공동모임장 리스트)
-				welcomeMessageTypes, // welcomeMessageTypes (환영 태그 리스트)
 				meetingKeywordTypes // meetingKeywordTypes (모임 키워드 태그 리스트)
 			);
 

--- a/main/src/test/resources/sql/meeting-service-test-data.sql
+++ b/main/src/test/resources/sql/meeting-service-test-data.sql
@@ -15,37 +15,37 @@ VALUES (1, '모임개설자',
         '[{"part": "iOS", "generation": 35}, {"part": "안드로이드", "generation": 34}]',
         'profile5.jpg', '010-6666-6666');
 
-INSERT INTO meeting ("id", "userId", title, category, "imageURL", "startDate", "endDate", capacity,
+INSERT INTO meeting ("id", "userId", title, "subTitle", category, "imageURL", "startDate", "endDate", capacity,
                      "desc", "processDesc", "mStartDate", "mEndDate", "leaderDesc",
-                     note, "isMentorNeeded", "canJoinOnlyActiveGeneration", "createdGeneration",
+                     note, "isMentorNeeded", "canJoinOnlyActiveGeneration", "joinInfo", "createdGeneration",
                      "targetActiveGeneration", "joinableParts")
-VALUES (1, 1, '스터디 구합니다1', '행사',
+VALUES (1, 1, '스터디 구합니다1', '스터디 부제목1', '행사',
         '[{"id": 0, "url": "https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/05/19/79ba8312-0ebf-48a2-9a5e-b372fb8a9e64.png"}]',
         '2024-04-24 00:00:00.000000', '2024-05-24 23:59:59.000000', 10,
         '스터디 설명입니다.', '스터디 진행방식입니다.',
         '2024-05-29 00:00:00.000000', '2024-05-31 23:59:59.000000', '스터디장 설명입니다.',
-        '시간지키세요.', true, true, 35, 35, '{PM,SERVER}'),
+        '시간지키세요.', true, true, '{"meetingType":"온라인","meetingFrequency":"꾸준히"}', 35, 35, '{PM,SERVER}'),
 
-       (2, 5, '스터디 구합니다 - 신청전', '스터디',
+       (2, 5, '스터디 구합니다 - 신청전', '스터디 부제목2', '스터디',
         '[{"id": 0, "url": "https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/05/19/79ba8312-0ebf-48a2-9a5e-b372fb8a9e64.png"}]',
         '2024-04-25 00:00:00.000000', '2024-05-24 23:59:59.000000', 10,
         '스터디 설명입니다.', '스터디 진행방식입니다.',
         '2024-05-29 00:00:00.000000', '2024-05-31 23:59:59.000000', null,
-        null, false, false, 34, null, '{PM,SERVER}'),
+        null, false, false, '{"meetingType":"오프라인","meetingFrequency":"가볍게"}', 34, null, '{PM,SERVER}'),
 
-       (3, 5, '스터디 구합니다 - 신청후', '스터디',
+       (3, 5, '스터디 구합니다 - 신청후', '스터디 부제목3', '스터디',
         '[{"id": 0, "url": "https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/05/19/79ba8312-0ebf-48a2-9a5e-b372fb8a9e64.png"}]',
         '2024-04-22 00:00:00.000000', '2024-04-22 23:59:59.000000', 10,
         '스터디 설명입니다.', '스터디 진행방식입니다.',
         '2024-05-29 00:00:00.000000', '2024-05-31 23:59:59.000000', null,
-        null, false, false, 34, null, '{PM,SERVER}'),
+        null, false, false, '{"meetingType":"온-오프","meetingFrequency":"몰입형"}', 34, null, '{PM,SERVER}'),
 
-       (4, 5, '세미나 구합니다 - 신청후', '세미나',
+       (4, 5, '세미나 구합니다 - 신청후', '세미나 부제목4', '세미나',
         '[{"id": 0, "url": "https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/05/19/79ba8312-0ebf-48a2-9a5e-b372fb8a9e64.png"}]',
         '2024-04-22 00:00:00.000000', '2024-04-22 23:59:59.000000', 13,
         '세미나 설명입니다.', '세미나 진행방식입니다.',
         '2024-05-29 00:00:00.000000', '2024-05-31 23:59:59.000000', null,
-        null, false, false, 34, null, '{WEB, IOS}');
+        null, false, false, '{"meetingType":"온라인","meetingFrequency":"가볍게"}', 34, null, '{WEB, IOS}');
 
 INSERT INTO apply (type, "meetingId", "userId", "appliedDate", status)
 VALUES (0, 1, 2, '2024-05-19 00:00:00.913489', 1),


### PR DESCRIPTION
## 👩‍💻 Contents


모임 테이블 수정
- [x] `subTitle` (부제목) 컬럼 추가
- [x] `joinInfo` (참여 정보) 컬럼 추가

모임 생성 API
- [x] `welcomeMessageTypes` 환영 메세지 태그 입력 삭제
- [x] `subTitle` 부제목, `joinInfo` 참여 정보 필드 추가 입력

모임 홈 API
- [x] `subTitle` 부제목 필드 추가 반환

모임 상세 조회 API
- [x] `subTitle` 부제목,  `joinInfo` 참여 정보 필드 추가 반환

모임 수정 API
- [x] 기존 모임 수정시 참여정보 추가, 수정 가능 (모임 태그는 X)
- [x] 신규 모임 수정시 참여정보 수정 가능

모임 같은 파트 참여자 리스트 API
- [x] 모임 같은 파트 참여자 리스트 반환 API 추가
- [x] 모임 상세조회에서 같은 파트, 참여 인원수 반환

## 📝 Review Note

1. 참여 정보는 엔티티라기보다는 값 객체에 가깝다고 판단하여 `MeetingJoinInfo` 라는 이름의 불변 `record`로 분리하고, 내부 값을 `String` 대신 `enum`으로 관리하도록 구현해두었습니다.
효준이형이 봤을때 더 적절한 구조나 관리 방식이 있다면 편하게 말씀주시면 감사하겠습니다!

2. 추가로, 존재하지 않는 `enum `값이 들어오는 경우에는 기존 코드 스타일을 참고해서 우선 간결하게 `IllegalArgumentException `을 던지도록 처리해두었어요. 추후에 다른 API들의 예외 처리 방향과 함께 맞추면서 조금 더 디테일한 방식으로 정리해도 좋을 것 같습니다.

3. 기존에는 모임 생성/수정이 한개의 DTO를 재활용하는 구조로 되어있던걸로 이해했습니다
이번 요구사항에서 모임 생성 시 `welcomeMessageTypes` 입력이 제거되고 `subTitle`, `joinInfo`가 새로 추가되었어요.
하지만 수정 API에서는 모임 수정이 불가능하고, 기존/신규 모임에 대해 `subTitle`과 `joinInfo`를 포함한 모임 정보만 변경할 수 있어야 해서 별도 DTO로 분리했습니다.

4. 또한 `user` 활동 정보 중 백엔드 / 서버 처럼 동일 의미의 파트가 혼재되어 있어, 같은 파트 조회가 정상적으로 되지 않는 이슈가 있었습니다. 우선 이번 작업 범위에서는 `MeetingV2ServiceImpl` 내부에서만 서버 / 백엔드 를 동일한 비교값으로 인식하도록 처리하여 해결해두었습니다.

혹시 위 작성한 부분 외에도 데이터 불일치로 인해 유사한 이슈가 발생할 수 있는 지점이 있는지 함께 크로스 체크해주시면 감사하겠습니다 🙇🏻‍♂️

## 📣 Related Issue

- closed #830 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?