### PR TITLE
fix: 상세조회 createdAt 필드 추가 반환

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/MeetingCacheDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/redis/MeetingCacheDto.java
@@ -35,6 +35,10 @@ public class MeetingCacheDto {
 	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	private final LocalDateTime endDate;
 
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
+	private final LocalDateTime createdTimestamp;
+
 	private final Integer capacity;
 	private final String desc;
 	private final String processDesc;
@@ -66,6 +70,7 @@ public class MeetingCacheDto {
 		@JsonProperty("imageURL") List<ImageUrlVO> imageURL,
 		@JsonProperty("startDate") LocalDateTime startDate,
 		@JsonProperty("endDate") LocalDateTime endDate,
+		@JsonProperty("createdTimestamp") LocalDateTime createdTimestamp,
 		@JsonProperty("capacity") Integer capacity,
 		@JsonProperty("desc") String desc,
 		@JsonProperty("processDesc") String processDesc,
@@ -87,6 +92,7 @@ public class MeetingCacheDto {
 		this.imageURL = imageURL;
 		this.startDate = startDate;
 		this.endDate = endDate;
+		this.createdTimestamp = createdTimestamp;
 		this.capacity = capacity;
 		this.desc = desc;
 		this.processDesc = processDesc;
@@ -105,15 +111,15 @@ public class MeetingCacheDto {
 	public static MeetingCacheDto from(Meeting meeting) {
 		return new MeetingCacheDto(meeting.getId(), meeting.getUserId(), meeting.getTitle(), meeting.getSubTitle(),
 			meeting.getCategory(),
-			meeting.getImageURL(), meeting.getStartDate(), meeting.getEndDate(), meeting.getCapacity(),
-			meeting.getDesc(), meeting.getProcessDesc(), meeting.getmStartDate(), meeting.getmEndDate(),
-			meeting.getLeaderDesc(), meeting.getNote(), meeting.getIsMentorNeeded(),
+			meeting.getImageURL(), meeting.getStartDate(), meeting.getEndDate(), meeting.createdTimestamp,
+			meeting.getCapacity(), meeting.getDesc(), meeting.getProcessDesc(), meeting.getmStartDate(),
+			meeting.getmEndDate(), meeting.getLeaderDesc(), meeting.getNote(), meeting.getIsMentorNeeded(),
 			meeting.getCanJoinOnlyActiveGeneration(), meeting.getJoinInfo(), meeting.getCreatedGeneration(),
 			meeting.getTargetActiveGeneration(), meeting.getJoinableParts());
 	}
 
 	public Meeting toEntity() {
-		return Meeting.builder()
+		Meeting meeting = Meeting.builder()
 			.userId(userId)
 			.title(title)
 			.subTitle(subTitle)
@@ -135,6 +141,9 @@ public class MeetingCacheDto {
 			.targetActiveGeneration(targetActiveGeneration)
 			.joinableParts(joinableParts)
 			.build();
+
+		meeting.createdTimestamp = createdTimestamp;
+		return meeting;
 	}
 
 	public LocalDateTime getmStartDate() {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingByIdResponseDto.java
@@ -60,6 +60,10 @@ public class MeetingV2GetMeetingByIdResponseDto {
 	@NotNull
 	private final int capacity;
 
+	@Schema(description = "모임 생성 시간", example = "2024-07-10T15:30:00")
+	@NotNull
+	private final LocalDateTime createdTimestamp;
+
 	@Schema(description = "모임 소개", example = "모임 소개 입니다.")
 	@NotNull
 	private final String desc;
@@ -197,6 +201,7 @@ public class MeetingV2GetMeetingByIdResponseDto {
 			.startDate(meeting.getStartDate())
 			.endDate(meeting.getEndDate())
 			.capacity(meeting.getCapacity())
+			.createdTimestamp(meeting.createdTimestamp)
 			.desc(meeting.getDesc())
 			.processDesc(meeting.getProcessDesc())
 			.mStartDate(meeting.getmStartDate())

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -1073,6 +1073,8 @@ public class MeetingV2ServiceTest {
 					"010-1234-5678"
 				);
 
+			Assertions.assertThat(responseDto.getCreatedTimestamp()).isNotNull();
+
 			Assertions.assertThat(responseDto.getAppliedInfo())
 				.extracting(
 					"id", "meetingId", "userId", "appliedDate", "status",


### PR DESCRIPTION
## 👩‍💻 Contents

프론트 분들이 요청주신 상세조회 API에서 createdAt 필드를 추가 반환하려고 합니다.
(모임 수정 API에서 필드가 변경되어 유연한 처리를 하기 위함)


## 📣 Related Issue

- closed #846 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?