### PR TITLE
hotfix: 배너 링크2 nullable 하게 수정

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/advertisement/dto/AdvertisementsGetResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/advertisement/dto/AdvertisementsGetResponseDto.java
@@ -30,7 +30,6 @@ public record AdvertisementsGetResponseDto(
 		String mobileImageUrl,
 
 		@Schema(description = "광고 구좌 링크", example = "https://www.naver.com")
-		@NotNull
 		String advertisementLink,
 
 		@Schema(description = "광고 게시 시작일", example = "2024-07-31T00:00:00")

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/advertisement/Advertisement.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/advertisement/Advertisement.java
@@ -39,7 +39,6 @@ public class Advertisement extends BaseTimeEntity {
 	@NotNull
 	private String advertisementMobileImageUrl;
 
-	@NotNull
 	private String advertisementLink;
 
 	private String calendarImageUrl;

--- a/main/src/test/java/org/sopt/makers/crew/main/entity/advertisement/AdvertisementTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/entity/advertisement/AdvertisementTest.java
@@ -30,4 +30,23 @@ class AdvertisementTest {
 
 		assertThat(advertisement.isDisplay()).isTrue();
 	}
+
+	@Test
+	@DisplayName("광고 링크는 null일 수 있다.")
+	void advertisementBuilder_allowsNullAdvertisementLink() {
+		Advertisement advertisement = Advertisement.builder()
+			.advertisementDesktopImageUrl("https://example.com/desktop.png")
+			.advertisementMobileImageUrl("https://example.com/mobile.png")
+			.advertisementLink(null)
+			.advertisementCategory(MEETING_TOP)
+			.priority(1L)
+			.advertisementStartDate(LocalDateTime.of(2026, 5, 1, 0, 0))
+			.advertisementEndDate(LocalDateTime.of(2026, 5, 10, 0, 0))
+			.isSponsoredContent(false)
+			.eventType(EventType.SOPKATHON)
+			.targetGeneration(TargetGeneration.ALL)
+			.build();
+
+		assertThat(advertisement.getAdvertisementLink()).isNull();
+	}
 }


### PR DESCRIPTION
## 👩‍💻 Contents

프론트 요청에 따라서 배너 링크 2를 nullable하게 수정합니다

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?