### PR TITLE
fix: 모임 내 같은 파트/기수 멤버 리스트 조회 반환 필드 수정

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyMemberInfoDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyMemberInfoDto.java
@@ -3,7 +3,6 @@ package org.sopt.makers.crew.main.meeting.v2.dto.response;
 import java.time.LocalDateTime;
 
 import org.sopt.makers.crew.main.entity.apply.Apply;
-import org.sopt.makers.crew.main.entity.user.User;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -47,8 +46,8 @@ public class ApplyMemberInfoDto {
 	@NotNull
 	private final ApplicantByMeetingDto user;
 
-	public static ApplyMemberInfoDto of(Apply apply, User user, Integer applyNumber) {
-		ApplicantByMeetingDto applicantByMeetingDto = ApplicantByMeetingDto.of(user);
+	public static ApplyMemberInfoDto of(Apply apply, Integer applyNumber) {
+		ApplicantByMeetingDto applicantByMeetingDto = ApplicantByMeetingDto.of(apply.getUser());
 
 		return new ApplyMemberInfoDto(apply.getId(), applyNumber, apply.getType().getValue(), apply.getMeetingId(),
 			apply.getUserId(), apply.getAppliedDate(), apply.getStatus().getValue(), applicantByMeetingDto);

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyMemberInfoDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/ApplyMemberInfoDto.java
@@ -1,0 +1,56 @@
+package org.sopt.makers.crew.main.meeting.v2.dto.response;
+
+import java.time.LocalDateTime;
+
+import org.sopt.makers.crew.main.entity.apply.Apply;
+import org.sopt.makers.crew.main.entity.user.User;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Schema(description = "모임 같은 파트/기수 신청 정보 조회 dto")
+public class ApplyMemberInfoDto {
+
+	@Schema(description = "신청 id", example = "3")
+	@NotNull
+	private final Integer id;
+
+	@Schema(description = "신청 번호", example = "1")
+	@NotNull
+	private final Integer applyNumber;
+
+	@Schema(description = "신청 타입", example = "0")
+	@NotNull
+	private final Integer type;
+
+	@Schema(description = "모임 id", example = "13")
+	@NotNull
+	private final Integer meetingId;
+
+	@Schema(description = "신청자 id", example = "184")
+	@NotNull
+	private final Integer userId;
+
+	@Schema(description = "신청 날짜 및 시간", example = "2024-10-13T23:59:59")
+	@NotNull
+	private final LocalDateTime appliedDate;
+
+	@Schema(description = "신청 상태", example = "1")
+	@NotNull
+	private final Integer status;
+
+	@Schema(description = "신청자 객체", example = "")
+	@NotNull
+	private final ApplicantByMeetingDto user;
+
+	public static ApplyMemberInfoDto of(Apply apply, User user, Integer applyNumber) {
+		ApplicantByMeetingDto applicantByMeetingDto = ApplicantByMeetingDto.of(user);
+
+		return new ApplyMemberInfoDto(apply.getId(), applyNumber, apply.getType().getValue(), apply.getMeetingId(),
+			apply.getUserId(), apply.getAppliedDate(), apply.getStatus().getValue(), applicantByMeetingDto);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingPartMembersResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/response/MeetingV2GetMeetingPartMembersResponseDto.java
@@ -14,17 +14,12 @@ public record MeetingV2GetMeetingPartMembersResponseDto(
 	boolean isActiveGeneration,
 	@Schema(description = "참여 정보 기준 기수", example = "38")
 	Integer activeGeneration,
-	@Schema(description = "유저 리스트의 index id", example = "[1, 2]")
-	List<Integer> memberIds,
-	@Schema(description = "유저 이름 리스트", example = "[\"이지훈\", \"김효준\"]")
-	List<String> memberNames,
-	@Schema(description = "유저 프로필 이미지 리스트", example = "[\"https://example.com/profile.png\", null]")
-	List<String> memberProfileImages
+	@Schema(description = "조건에 맞는 신청 정보 목록", example = "")
+	List<ApplyMemberInfoDto> appliedInfo
 ) {
 	public static MeetingV2GetMeetingPartMembersResponseDto of(String part, int participantCount,
-		boolean isActiveGeneration, Integer activeGeneration, List<Integer> memberIds, List<String> memberNames,
-		List<String> memberProfileImages) {
+		boolean isActiveGeneration, Integer activeGeneration, List<ApplyMemberInfoDto> appliedInfo) {
 		return new MeetingV2GetMeetingPartMembersResponseDto(part, participantCount, isActiveGeneration,
-			activeGeneration, memberIds, memberNames, memberProfileImages);
+			activeGeneration, appliedInfo);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingParticipationFactory.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingParticipationFactory.java
@@ -4,13 +4,14 @@ import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.IntStream;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.sopt.makers.crew.main.entity.apply.Apply;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.entity.user.vo.UserActivityVO;
 import org.sopt.makers.crew.main.global.exception.BadRequestException;
 import org.sopt.makers.crew.main.global.util.ActiveGenerationProvider;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyMemberInfoDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingPartMembersResponseDto;
 import org.springframework.stereotype.Component;
 
@@ -31,18 +32,13 @@ public class MeetingParticipationFactory {
 		String requestUserPart = requestUserActivity.getPart();
 		List<Apply> participatingPartApplies = getParticipatingPartApplies(participatingApplies, requestUserActivity,
 			isActiveGeneration);
-		List<Integer> memberIds = IntStream.rangeClosed(1, participatingPartApplies.size())
-			.boxed()
-			.toList();
-		List<String> memberNames = participatingPartApplies.stream()
-			.map(apply -> apply.getUser().getName())
-			.toList();
-		List<String> memberProfileImages = participatingPartApplies.stream()
-			.map(apply -> apply.getUser().getProfileImage())
+		AtomicInteger applyNumber = new AtomicInteger(1);
+		List<ApplyMemberInfoDto> appliedInfo = participatingPartApplies.stream()
+			.map(apply -> ApplyMemberInfoDto.of(apply, apply.getUser(), applyNumber.getAndIncrement()))
 			.toList();
 
 		return MeetingV2GetMeetingPartMembersResponseDto.of(requestUserPart, participatingPartApplies.size(),
-			isActiveGeneration, requestUserActivity.getGeneration(), memberIds, memberNames, memberProfileImages);
+			isActiveGeneration, requestUserActivity.getGeneration(), appliedInfo);
 	}
 
 	private List<Apply> getParticipatingPartApplies(List<Apply> participatingApplies,

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingParticipationFactory.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingParticipationFactory.java
@@ -34,7 +34,7 @@ public class MeetingParticipationFactory {
 			isActiveGeneration);
 		AtomicInteger applyNumber = new AtomicInteger(1);
 		List<ApplyMemberInfoDto> appliedInfo = participatingPartApplies.stream()
-			.map(apply -> ApplyMemberInfoDto.of(apply, apply.getUser(), applyNumber.getAndIncrement()))
+			.map(apply -> ApplyMemberInfoDto.of(apply, applyNumber.getAndIncrement()))
 			.toList();
 
 		return MeetingV2GetMeetingPartMembersResponseDto.of(requestUserPart, participatingPartApplies.size(),

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ConcurrencyTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ConcurrencyTest.java
@@ -64,8 +64,8 @@ class MeetingV2ConcurrencyTest {
 	@DisplayName("모임 지원 락킹 테스트")
 	class 모임_지원_락킹_테스트 {
 		@Test
-		@DisplayName("동일 사용자가 동시에 여러 신청을 시도할 경우 오직 하나만 성공해야 한다")
-		void applyMeetingWithLock_WhenMultipleRequestsFromSameUser_ShouldProcessOnlyOne() throws InterruptedException {
+		@DisplayName("이미 신청한 동일 사용자가 동시에 여러 신청을 시도할 경우 모두 실패해야 한다")
+		void applyMeetingWithLock_WhenAppliedUserRequestsConcurrently_ShouldRejectAll() throws InterruptedException {
 			// given
 			User leader = User.builder()
 				.name("모임장")
@@ -113,14 +113,18 @@ class MeetingV2ConcurrencyTest {
 
 			MeetingV2ApplyMeetingDto applyDto = new MeetingV2ApplyMeetingDto(meeting.getId(), "지원 동기");
 
-			int concurrentRequests = 5;
+			MeetingV2ApplyMeetingResponseDto firstResponse = meetingV2Service.applyEventMeetingWithLock(applyDto,
+				applicant.getId());
+			assertThat(firstResponse.getApplyId()).isNotNull();
+
+			int concurrentRequests = 4;
 			ExecutorService executorService = Executors.newFixedThreadPool(concurrentRequests);
 			CountDownLatch startLatch = new CountDownLatch(1);
 			CountDownLatch readyLatch = new CountDownLatch(concurrentRequests);
 			CountDownLatch finishLatch = new CountDownLatch(concurrentRequests);
 
-			AtomicInteger successCount = new AtomicInteger(0);
-			AtomicInteger failCount = new AtomicInteger(0);
+			AtomicInteger duplicateSuccessCount = new AtomicInteger(0);
+			AtomicInteger duplicateFailCount = new AtomicInteger(0);
 
 			// when
 			for (int i = 0; i < concurrentRequests; i++) {
@@ -133,19 +137,18 @@ class MeetingV2ConcurrencyTest {
 							applicant.getId());
 
 						if (response != null && response.getApplyId() != null) {
-							successCount.incrementAndGet();
+							duplicateSuccessCount.incrementAndGet();
 						}
 					} catch (Exception e) {
-						failCount.incrementAndGet();
+						duplicateFailCount.incrementAndGet();
 					} finally {
 						finishLatch.countDown();
 					}
 				});
 			}
 
-			readyLatch.await();
-
-			Thread.sleep(5000);
+			boolean readyInTime = readyLatch.await(5, TimeUnit.SECONDS);
+			assertThat(readyInTime).isTrue();
 
 			startLatch.countDown();
 			boolean completedInTime = finishLatch.await(10, TimeUnit.SECONDS);
@@ -154,8 +157,8 @@ class MeetingV2ConcurrencyTest {
 
 			// then
 			assertThat(completedInTime).isTrue();
-			assertThat(successCount.get()).isEqualTo(1);
-			assertThat(failCount.get()).isEqualTo(concurrentRequests - 1);
+			assertThat(duplicateSuccessCount.get()).isZero();
+			assertThat(duplicateFailCount.get()).isEqualTo(concurrentRequests);
 
 			List<Apply> allApplies = applyRepository.findAllByMeetingId(meeting.getId());
 			List<Apply> userApplies = allApplies.stream()

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -51,6 +51,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2ApplyMeetingDto
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2CreateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.request.MeetingV2UpdateMeetingBodyDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyInfoDto;
+import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyMemberInfoDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.ApplyWholeInfoDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingGetApplyListResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2ApplyMeetingResponseDto;
@@ -150,6 +151,19 @@ public class MeetingV2ServiceTest {
 			.content(part + " 신청합니다.")
 			.build();
 		applyRepository.save(apply);
+	}
+
+	private void assertAppliedInfoMembers(MeetingV2GetMeetingPartMembersResponseDto responseDto,
+		List<Integer> applyNumbers, List<String> memberNames, List<String> memberProfileImages) {
+		Assertions.assertThat(responseDto.appliedInfo())
+			.extracting(ApplyMemberInfoDto::getApplyNumber)
+			.containsExactlyElementsOf(applyNumbers);
+		Assertions.assertThat(responseDto.appliedInfo())
+			.extracting(applyInfo -> applyInfo.getUser().getName())
+			.containsExactlyElementsOf(memberNames);
+		Assertions.assertThat(responseDto.appliedInfo())
+			.extracting(applyInfo -> applyInfo.getUser().getProfileImage())
+			.containsExactlyElementsOf(memberProfileImages);
 	}
 
 	@Nested
@@ -1237,9 +1251,7 @@ public class MeetingV2ServiceTest {
 			Assertions.assertThat(responseDto.participantCount()).isEqualTo(1);
 			Assertions.assertThat(responseDto.isActiveGeneration()).isFalse();
 			Assertions.assertThat(responseDto.activeGeneration()).isEqualTo(33);
-			Assertions.assertThat(responseDto.memberIds()).containsExactly(1);
-			Assertions.assertThat(responseDto.memberNames()).containsExactly("승인신청자");
-			Assertions.assertThat(responseDto.memberProfileImages()).containsExactly("profile2.jpg");
+			assertAppliedInfoMembers(responseDto, List.of(1), List.of("승인신청자"), List.of("profile2.jpg"));
 		}
 
 		@Test
@@ -1284,9 +1296,7 @@ public class MeetingV2ServiceTest {
 			Assertions.assertThat(responseDto.participantCount()).isEqualTo(1);
 			Assertions.assertThat(responseDto.isActiveGeneration()).isTrue();
 			Assertions.assertThat(responseDto.activeGeneration()).isEqualTo(35);
-			Assertions.assertThat(responseDto.memberIds()).containsExactly(1);
-			Assertions.assertThat(responseDto.memberNames()).containsExactly("백엔드신청자");
-			Assertions.assertThat(responseDto.memberProfileImages()).containsExactly("backend-profile.jpg");
+			assertAppliedInfoMembers(responseDto, List.of(1), List.of("백엔드신청자"), List.of("backend-profile.jpg"));
 		}
 
 		@Test
@@ -1317,9 +1327,7 @@ public class MeetingV2ServiceTest {
 			Assertions.assertThat(responseDto.isActiveGeneration()).isFalse();
 			Assertions.assertThat(responseDto.activeGeneration()).isEqualTo(37);
 			Assertions.assertThat(responseDto.participantCount()).isEqualTo(1);
-			Assertions.assertThat(responseDto.memberIds()).containsExactly(1);
-			Assertions.assertThat(responseDto.memberNames()).containsExactly("37기신청자");
-			Assertions.assertThat(responseDto.memberProfileImages()).containsExactly("profile.jpg");
+			assertAppliedInfoMembers(responseDto, List.of(1), List.of("37기신청자"), List.of("profile.jpg"));
 		}
 
 		@Test
@@ -1451,9 +1459,7 @@ public class MeetingV2ServiceTest {
 			Assertions.assertThat(responseDto.isActiveGeneration()).isTrue();
 			Assertions.assertThat(responseDto.activeGeneration()).isEqualTo(35);
 			Assertions.assertThat(responseDto.participantCount()).isEqualTo(1);
-			Assertions.assertThat(responseDto.memberIds()).containsExactly(1);
-			Assertions.assertThat(responseDto.memberNames()).containsExactly("35기iOS신청자");
-			Assertions.assertThat(responseDto.memberProfileImages()).containsExactly("profile.jpg");
+			assertAppliedInfoMembers(responseDto, List.of(1), List.of("35기iOS신청자"), List.of("profile.jpg"));
 		}
 
 		@Test
@@ -1474,9 +1480,8 @@ public class MeetingV2ServiceTest {
 			Assertions.assertThat(responseDto.isActiveGeneration()).isFalse();
 			Assertions.assertThat(responseDto.activeGeneration()).isEqualTo(33);
 			Assertions.assertThat(responseDto.participantCount()).isEqualTo(2);
-			Assertions.assertThat(responseDto.memberIds()).containsExactly(1, 2);
-			Assertions.assertThat(responseDto.memberNames()).containsExactly("승인신청자", "33기백엔드신청자");
-			Assertions.assertThat(responseDto.memberProfileImages()).containsExactly("profile2.jpg", "profile.jpg");
+			assertAppliedInfoMembers(responseDto, List.of(1, 2), List.of("승인신청자", "33기백엔드신청자"),
+				List.of("profile2.jpg", "profile.jpg"));
 		}
 
 		@Test
@@ -1497,9 +1502,8 @@ public class MeetingV2ServiceTest {
 			Assertions.assertThat(responseDto.isActiveGeneration()).isFalse();
 			Assertions.assertThat(responseDto.activeGeneration()).isEqualTo(33);
 			Assertions.assertThat(responseDto.participantCount()).isEqualTo(2);
-			Assertions.assertThat(responseDto.memberIds()).containsExactly(1, 2);
-			Assertions.assertThat(responseDto.memberNames()).containsExactly("승인신청자", "PM신청자");
-			Assertions.assertThat(responseDto.memberProfileImages()).containsExactly("profile2.jpg", "profile.jpg");
+			assertAppliedInfoMembers(responseDto, List.of(1, 2), List.of("승인신청자", "PM신청자"),
+				List.of("profile2.jpg", "profile.jpg"));
 		}
 
 		@Test
@@ -1526,9 +1530,7 @@ public class MeetingV2ServiceTest {
 			Assertions.assertThat(responseDto.isActiveGeneration()).isTrue();
 			Assertions.assertThat(responseDto.activeGeneration()).isEqualTo(35);
 			Assertions.assertThat(responseDto.participantCount()).isEqualTo(1);
-			Assertions.assertThat(responseDto.memberIds()).containsExactly(1);
-			Assertions.assertThat(responseDto.memberNames()).containsExactly("프론트엔드신청자");
-			Assertions.assertThat(responseDto.memberProfileImages()).containsExactly("profile.jpg");
+			assertAppliedInfoMembers(responseDto, List.of(1), List.of("프론트엔드신청자"), List.of("profile.jpg"));
 		}
 
 		@Test


### PR DESCRIPTION
## 👩‍💻 Contents
기존 반환 필드에서 조회자 기준 필드들인 `part`, `participantCount`, `isActiveGeneration`, `activeGeneration`은 그대로 반환해주고
신청자 관련한 필드들은 삭제하고, `appliedInfo`로 반환해주도록 수정

## 📣 Related Issue

- closed #870 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?