### PR TITLE
fix: 솝커톤 로직과 별도로 네트워킹 로직 최신 단건으로 변경

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/advertisement/service/AdvertisementFactory.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/advertisement/service/AdvertisementFactory.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.sopt.makers.crew.main.advertisement.dto.AdvertisementMeetingTopGetResponseDto;
 import org.sopt.makers.crew.main.advertisement.dto.AdvertisementsGetResponseDto;
 import org.sopt.makers.crew.main.advertisement.dto.AdvertisementsGetResponseDto.AdvertisementGetDto;
 import org.sopt.makers.crew.main.entity.advertisement.Advertisement;
@@ -24,7 +23,7 @@ public class AdvertisementFactory {
 
 	private static final String SOPKATHON_APPLY_TITLE_FORMAT = "[%d기 솝커톤] %s 파트 신청";
 	private static final String SOPKATHON_BROWSE_QUERY_FORMAT = "%d기 솝커톤";
-	private static final String NETWORKING_APPLY_TITLE_FORMAT = "[%d기 네트워킹 데이] 신청";
+	private static final String NETWORKING_TITLE_QUERY_FORMAT = "[%d기 네트워킹 데이]";
 
 	private final MeetingPartNormalizer meetingPartNormalizer;
 
@@ -43,8 +42,8 @@ public class AdvertisementFactory {
 		return String.format(SOPKATHON_BROWSE_QUERY_FORMAT, generation);
 	}
 
-	public String createNetworkingApplyTitle(Integer generation) {
-		return String.format(NETWORKING_APPLY_TITLE_FORMAT, generation);
+	public String createNetworkingTitleQuery(Integer generation) {
+		return String.format(NETWORKING_TITLE_QUERY_FORMAT, generation);
 	}
 
 	public MeetingV2ParticipatingPartInfoDto createParticipatingPartInfo(UserActivityVO requestUserActivity,

--- a/main/src/main/java/org/sopt/makers/crew/main/advertisement/service/AdvertisementService.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/advertisement/service/AdvertisementService.java
@@ -188,8 +188,8 @@ public class AdvertisementService {
 	}
 
 	private Optional<Integer> findNetworkingApplicationMeetingId(Integer activeGeneration) {
-		String title = advertisementFactory.createNetworkingApplyTitle(activeGeneration);
-		return meetingRepository.findFirstByTitleOrderByIdDesc(title)
+		String titleQuery = advertisementFactory.createNetworkingTitleQuery(activeGeneration);
+		return meetingRepository.findFirstByTitleContainingOrderByIdDesc(titleQuery)
 			.map(Meeting::getId);
 	}
 

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingRepository.java
@@ -35,4 +35,6 @@ public interface MeetingRepository extends JpaRepository<Meeting, Integer>, Meet
 	Integer countAllByCreatedGeneration(Integer generation);
 
 	Optional<Meeting> findFirstByTitleOrderByIdDesc(String title);
+
+	Optional<Meeting> findFirstByTitleContainingOrderByIdDesc(String title);
 }

--- a/main/src/test/java/org/sopt/makers/crew/main/advertisement/service/AdvertisementServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/advertisement/service/AdvertisementServiceTest.java
@@ -121,7 +121,7 @@ class AdvertisementServiceTest {
 	}
 
 	@Test
-	@DisplayName("네트워킹 광고 조회 시 활동 기수 네트워킹 데이 신청 모임 링크를 반환한다.")
+	@DisplayName("네트워킹 광고 조회 시 활동 기수 네트워킹 데이를 포함하는 최신 모임 링크를 반환한다.")
 	void getMeetingTopAdvertisement_returnsNetworkingMeetingLinkByActiveGeneration() {
 		User requestUser = UserFixture.createUser(1, "서버", 38);
 		Advertisement sopkathonAdvertisement = createAdvertisement(TargetGeneration.ALL, MEETING_TOP, true,
@@ -136,7 +136,7 @@ class AdvertisementServiceTest {
 		when(activeGenerationProvider.getActiveGeneration()).thenReturn(38);
 		when(advertisementRepository.findMeetingTopAdvertisements(MEETING_TOP, NOW)).thenReturn(
 			List.of(sopkathonAdvertisement, networkingAdvertisement));
-		when(meetingRepository.findFirstByTitleOrderByIdDesc("[38기 네트워킹 데이] 신청"))
+		when(meetingRepository.findFirstByTitleContainingOrderByIdDesc("[38기 네트워킹 데이]"))
 			.thenReturn(Optional.of(applicationMeeting));
 
 		AdvertisementMeetingTopGetResponseDto response = advertisementService.getMeetingTopAdvertisement(
@@ -150,7 +150,7 @@ class AdvertisementServiceTest {
 	}
 
 	@Test
-	@DisplayName("네트워킹 신청 모임이 없으면 배너를 노출하되 배너 링크 2는 반환하지 않는다.")
+	@DisplayName("네트워킹 데이를 포함하는 모임이 없으면 배너를 노출하되 배너 링크 2는 반환하지 않는다.")
 	void getMeetingTopAdvertisement_returnsNullNetworkingBannerLink2WhenApplicationMeetingMissing() {
 		User requestUser = UserFixture.createUser(1, "서버", 38);
 		Advertisement advertisement = createAdvertisement(TargetGeneration.ALL, MEETING_TOP, true,
@@ -161,7 +161,7 @@ class AdvertisementServiceTest {
 		when(time.now()).thenReturn(NOW);
 		when(activeGenerationProvider.getActiveGeneration()).thenReturn(38);
 		when(advertisementRepository.findMeetingTopAdvertisements(MEETING_TOP, NOW)).thenReturn(List.of(advertisement));
-		when(meetingRepository.findFirstByTitleOrderByIdDesc("[38기 네트워킹 데이] 신청"))
+		when(meetingRepository.findFirstByTitleContainingOrderByIdDesc("[38기 네트워킹 데이]"))
 			.thenReturn(Optional.empty());
 
 		AdvertisementMeetingTopGetResponseDto response = advertisementService.getMeetingTopAdvertisement(


### PR DESCRIPTION
## 👩‍💻 Contents


## 📝 Review Note


## 📣 Related Issue

- closed #882 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?