### PR TITLE
fix: Prometheus actuator scrape 요청 401이 발생하는 문제

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/global/config/SecurityConfig.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.sopt.makers.crew.main.global.security.filter.JwtAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -48,7 +49,6 @@ public class SecurityConfig {
 			"/meeting/v2/org-user/**",
 			"/admin/v2/**",
 			actuatorEndPoint + "/health",
-			actuatorEndPoint + "/prometheus",
 			actuatorEndPoint + "/caches/**",
 			actuatorEndPoint + "/cachecontents/**",
 			actuatorEndPoint + "/metrics/**",
@@ -70,6 +70,8 @@ public class SecurityConfig {
 					.requestMatchers(Stream.of(SWAGGER_URL)
 						.map(AntPathRequestMatcher::antMatcher)
 						.toArray(AntPathRequestMatcher[]::new)).permitAll()
+					.requestMatchers(new AntPathRequestMatcher(
+						actuatorEndPoint + "/prometheus", HttpMethod.GET.name())).permitAll()
 					.requestMatchers(Stream.of(getAuthWhitelist())
 						.map(AntPathRequestMatcher::antMatcher)
 						.toArray(AntPathRequestMatcher[]::new)).permitAll()


### PR DESCRIPTION
## 👩‍💻 Contents
현재 Nginx 설정상 ${ACTUATOR_PATH}/ 하위 전체가 actuator upstream으로 proxy되고 있어, /prometheus 외의 actuator endpoint도 외부에서 접근 가능한 상태입니다. 실제 Nginx access log에서 ${ACTUATOR_PATH}/cachecontents에 대한 외부 DELETE 요청이 204로 성공한 기록이 확인되었습니다

따라서 Prometheus scrape endpoint는 인증 토큰 없이 접근 가능하도록 하고, 외부 접근 제어는 Nginx에서 Prometheus 서버 고정 EIP만 허용하는 방식으로 개선할 예정이에요

## 📣 Related Issue

- closed #887 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?