### PR TITLE
chore: Assign 자동 설정 스크립트 추가

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,26 @@
+name: Auto Assign
+
+on:
+  pull_request_target:
+    branches:
+      - develop
+      - main
+    types:
+      - opened
+      - ready_for_review
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign:
+    if: github.event.pull_request.draft == false # draft PR은 자동 Assign 대상에서 제외
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign pull request author
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: gh pr edit "$PR_URL" --add-assignee "$PR_AUTHOR"


### PR DESCRIPTION
## 👩‍💻 Contents

PR 생성시, author를 Assign로 자동으로 지정해주는 스크립트를 추가합니다

## 📝 Review Note

- `pull_request_target` 이벤트를 사용해 fork PR에서도 `GITHUB_TOKEN` 권한으로 assignee 지정이 가능하도록 했습니다
- draft PR은 제외하고, `ready_for_review` 상태가 되었을 때 author가 assignee로 지정되도록 조건을 추가해주었어요

## 📣 Related Issue

- closed #889 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?