### PR TITLE
feat: 모임 수요 관련 기능 구현

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyRepository.java
@@ -23,7 +23,6 @@ public interface ApplyRepository extends JpaRepository<Apply, Integer>, ApplySea
 	@Query("select a "
 		+ "from Apply a "
 		+ "join fetch a.meeting m "
-		+ "join fetch m.user u "
 		+ "where a.userId = :userId "
 		+ "ORDER BY a.id DESC ")
 	List<Apply> findAllByUserIdOrderByIdDesc(@Param("userId") Integer userId);

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyTestRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/apply/ApplyTestRepository.java
@@ -22,7 +22,6 @@ public interface ApplyTestRepository extends JpaRepository<ApplyTest, Integer> {
 	@Query("select a "
 		+ "from ApplyTest a "
 		+ "join fetch a.meeting m "
-		+ "join fetch m.user u "
 		+ "where a.userId = :userId "
 		+ "ORDER BY a.id DESC ")
 	List<ApplyTest> findAllByUserIdOrderByIdDesc(@Param("userId") Integer userId);

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -48,17 +48,15 @@ public class Meeting extends BaseTimeEntity {
 	private Integer id;
 
 	/**
-	 * 개설한 유저
-	 */
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "userId", nullable = false)
-	private User user;
-
-	/**
 	 * 유저 id
 	 */
 	@Column(insertable = false, updatable = false)
 	private Integer userId;
+
+	/**
+	 * 개설 기반 모임 수요 id
+	 */
+	private Integer meetingDemandId;
 
 	/**
 	 * 모임 제목
@@ -184,15 +182,23 @@ public class Meeting extends BaseTimeEntity {
 	@Column(name = "joinableParts", columnDefinition = "meeting_joinableparts_enum[]")
 	private MeetingJoinablePart[] joinableParts;
 
+	/**
+	 * 개설한 유저
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "userId", nullable = false)
+	private User user;
+
 	@Builder
-	public Meeting(User user, Integer userId, String title, String subTitle, MeetingCategory category,
-		List<ImageUrlVO> imageURL, LocalDateTime startDate, LocalDateTime endDate, Integer capacity,
-		String desc, String processDesc, LocalDateTime mStartDate, LocalDateTime mEndDate,
+	public Meeting(User user, Integer userId, Integer meetingDemandId, String title, String subTitle,
+		MeetingCategory category, List<ImageUrlVO> imageURL, LocalDateTime startDate, LocalDateTime endDate,
+		Integer capacity, String desc, String processDesc, LocalDateTime mStartDate, LocalDateTime mEndDate,
 		String leaderDesc, String note, Boolean isMentorNeeded,
 		Boolean canJoinOnlyActiveGeneration, MeetingJoinInfo joinInfo, Integer createdGeneration,
 		Integer targetActiveGeneration, MeetingJoinablePart[] joinableParts) {
 		this.user = user;
 		this.userId = userId;
+		this.meetingDemandId = meetingDemandId;
 		this.title = title;
 		this.subTitle = subTitle;
 		this.category = category;

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -14,7 +14,6 @@ import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
-import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemand;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.global.exception.BadRequestException;
 import org.sopt.makers.crew.main.global.exception.ForbiddenException;
@@ -25,12 +24,9 @@ import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -51,13 +47,12 @@ public class Meeting extends BaseTimeEntity {
 	/**
 	 * 유저 id
 	 */
-	@Column(insertable = false, updatable = false)
+	@Column(nullable = false)
 	private Integer userId;
 
 	/**
 	 * 개설 기반 모임 수요 id
 	 */
-	@Column(insertable = false, updatable = false)
 	private Integer meetingDemandId;
 
 	/**
@@ -184,31 +179,15 @@ public class Meeting extends BaseTimeEntity {
 	@Column(name = "joinableParts", columnDefinition = "meeting_joinableparts_enum[]")
 	private MeetingJoinablePart[] joinableParts;
 
-	/**
-	 * 개설한 유저
-	 */
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "userId", nullable = false)
-	private User user;
-
-	/**
-	 * 개설 기반 모임 수요
-	 */
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "meetingDemandId")
-	private MeetingDemand meetingDemand;
-
 	@Builder
-	public Meeting(User user, Integer userId, MeetingDemand meetingDemand, Integer meetingDemandId, String title,
-		String subTitle, MeetingCategory category, List<ImageUrlVO> imageURL, LocalDateTime startDate,
-		LocalDateTime endDate, Integer capacity, String desc, String processDesc, LocalDateTime mStartDate,
-		LocalDateTime mEndDate, String leaderDesc, String note, Boolean isMentorNeeded,
+	public Meeting(User user, Integer userId, Integer meetingDemandId, String title, String subTitle,
+		MeetingCategory category, List<ImageUrlVO> imageURL, LocalDateTime startDate, LocalDateTime endDate,
+		Integer capacity, String desc, String processDesc, LocalDateTime mStartDate, LocalDateTime mEndDate,
+		String leaderDesc, String note, Boolean isMentorNeeded,
 		Boolean canJoinOnlyActiveGeneration, MeetingJoinInfo joinInfo, Integer createdGeneration,
 		Integer targetActiveGeneration, MeetingJoinablePart[] joinableParts) {
-		this.user = user;
 		this.userId = user != null ? user.getId() : userId;
-		this.meetingDemand = meetingDemand;
-		this.meetingDemandId = meetingDemand != null ? meetingDemand.getId() : meetingDemandId;
+		this.meetingDemandId = meetingDemandId;
 		this.title = title;
 		this.subTitle = subTitle;
 		this.category = category;
@@ -228,11 +207,6 @@ public class Meeting extends BaseTimeEntity {
 		this.createdGeneration = createdGeneration;
 		this.targetActiveGeneration = targetActiveGeneration;
 		this.joinableParts = joinableParts;
-	}
-
-	public void connectMeetingDemand(MeetingDemand meetingDemand) {
-		this.meetingDemand = meetingDemand;
-		this.meetingDemandId = meetingDemand.getId();
 	}
 
 	/**

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/Meeting.java
@@ -14,6 +14,7 @@ import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemand;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.global.exception.BadRequestException;
 import org.sopt.makers.crew.main.global.exception.ForbiddenException;
@@ -56,6 +57,7 @@ public class Meeting extends BaseTimeEntity {
 	/**
 	 * 개설 기반 모임 수요 id
 	 */
+	@Column(insertable = false, updatable = false)
 	private Integer meetingDemandId;
 
 	/**
@@ -189,16 +191,24 @@ public class Meeting extends BaseTimeEntity {
 	@JoinColumn(name = "userId", nullable = false)
 	private User user;
 
+	/**
+	 * 개설 기반 모임 수요
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "meetingDemandId")
+	private MeetingDemand meetingDemand;
+
 	@Builder
-	public Meeting(User user, Integer userId, Integer meetingDemandId, String title, String subTitle,
-		MeetingCategory category, List<ImageUrlVO> imageURL, LocalDateTime startDate, LocalDateTime endDate,
-		Integer capacity, String desc, String processDesc, LocalDateTime mStartDate, LocalDateTime mEndDate,
-		String leaderDesc, String note, Boolean isMentorNeeded,
+	public Meeting(User user, Integer userId, MeetingDemand meetingDemand, Integer meetingDemandId, String title,
+		String subTitle, MeetingCategory category, List<ImageUrlVO> imageURL, LocalDateTime startDate,
+		LocalDateTime endDate, Integer capacity, String desc, String processDesc, LocalDateTime mStartDate,
+		LocalDateTime mEndDate, String leaderDesc, String note, Boolean isMentorNeeded,
 		Boolean canJoinOnlyActiveGeneration, MeetingJoinInfo joinInfo, Integer createdGeneration,
 		Integer targetActiveGeneration, MeetingJoinablePart[] joinableParts) {
 		this.user = user;
-		this.userId = userId;
-		this.meetingDemandId = meetingDemandId;
+		this.userId = user != null ? user.getId() : userId;
+		this.meetingDemand = meetingDemand;
+		this.meetingDemandId = meetingDemand != null ? meetingDemand.getId() : meetingDemandId;
 		this.title = title;
 		this.subTitle = subTitle;
 		this.category = category;
@@ -218,6 +228,11 @@ public class Meeting extends BaseTimeEntity {
 		this.createdGeneration = createdGeneration;
 		this.targetActiveGeneration = targetActiveGeneration;
 		this.joinableParts = joinableParts;
+	}
+
+	public void connectMeetingDemand(MeetingDemand meetingDemand) {
+		this.meetingDemand = meetingDemand;
+		this.meetingDemandId = meetingDemand.getId();
 	}
 
 	/**

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingRepository.java
@@ -18,8 +18,7 @@ public interface MeetingRepository extends JpaRepository<Meeting, Integer>, Meet
 	 * **/
 	@Query("SELECT m "
 		+ "FROM Meeting m "
-		+ "JOIN fetch m.user "
-		+ "WHERE m.user.id =:userId "
+		+ "WHERE m.userId =:userId "
 		+ "OR m.id IN (:coLeaderMeetingIds)"
 		+ "ORDER BY m.id DESC ")
 	List<Meeting> findAllByUserIdOrIdInWithUser(Integer userId, List<Integer> coLeaderMeetingIds);
@@ -29,7 +28,6 @@ public interface MeetingRepository extends JpaRepository<Meeting, Integer>, Meet
 			.orElseThrow(() -> new NotFoundException(NOT_FOUND_MEETING.getErrorCode()));
 	}
 
-	@Query("SELECT m FROM Meeting m JOIN FETCH m.user ORDER BY m.id DESC LIMIT 20")
 	List<Meeting> findTop20ByOrderByIdDesc();
 
 	Integer countAllByCreatedGeneration(Integer generation);

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingRepository.java
@@ -34,6 +34,8 @@ public interface MeetingRepository extends JpaRepository<Meeting, Integer>, Meet
 
 	Integer countAllByCreatedGeneration(Integer generation);
 
+	int countByMeetingDemandId(Integer meetingDemandId);
+
 	Optional<Meeting> findFirstByTitleOrderByIdDesc(String title);
 
 	Optional<Meeting> findFirstByTitleContainingOrderByIdDesc(String title);

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepositoryImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meeting/MeetingSearchRepositoryImpl.java
@@ -2,7 +2,6 @@ package org.sopt.makers.crew.main.entity.meeting;
 
 import static org.sopt.makers.crew.main.entity.meeting.QMeeting.*;
 import static org.sopt.makers.crew.main.entity.tag.QTag.*;
-import static org.sopt.makers.crew.main.entity.user.QUser.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -122,9 +121,7 @@ public class MeetingSearchRepositoryImpl implements MeetingSearchRepository {
 	@Override
 	public List<Meeting> findRecommendMeetings(List<Integer> meetingIds, Time time) {
 		LocalDateTime now = time.now();
-		JPAQuery<Meeting> query = queryFactory.selectFrom(meeting)
-			.innerJoin(meeting.user, user)
-			.fetchJoin();
+		JPAQuery<Meeting> query = queryFactory.selectFrom(meeting);
 
 		if (meetingIds == null) {
 			query.where(eqStatus(List.of(String.valueOf(EnMeetingStatus.APPLY_ABLE.getValue())), now));
@@ -190,8 +187,6 @@ public class MeetingSearchRepositoryImpl implements MeetingSearchRepository {
 				eqJoinableParts(queryCommand.getJoinableParts()),
 				eqQuery(queryCommand.getQuery())
 			)
-			.innerJoin(meeting.user, user)
-			.fetchJoin()
 			.orderBy(
 				statusOrder.asc(),
 				meeting.id.desc()
@@ -218,8 +213,6 @@ public class MeetingSearchRepositoryImpl implements MeetingSearchRepository {
 				eqJoinableParts(queryCommand.getJoinableParts()),
 				eqQuery(queryCommand.getQuery())
 			)
-			.innerJoin(meeting.user, user)
-			.fetchJoin()
 			.orderBy(
 				statusOrder.asc(),  //  모집 마감은 가장 마지막, 모집 중 & 모집 전은 동일 우선순위
 				meeting.mStartDate.asc(), //  모집 중 & 모집 전 내부에서는 mStartDate(번쩍 진행일)이 가장 가까운 날짜부터 오름차순 정렬

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemand.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemand.java
@@ -1,0 +1,113 @@
+package org.sopt.makers.crew.main.entity.meetingdemand;
+
+import java.util.List;
+
+import org.hibernate.annotations.Type;
+import org.sopt.makers.crew.main.entity.common.BaseTimeEntity;
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
+import org.sopt.makers.crew.main.entity.meetingdemand.enums.MeetingDemandStatus;
+import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
+import org.sopt.makers.crew.main.entity.user.User;
+
+import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "meeting_demand")
+public class MeetingDemand extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
+	@Column(insertable = false, updatable = false)
+	private Integer userId;
+
+	@Column(nullable = false, length = 30)
+	private String shortIntro;
+
+	@Column(nullable = false, length = 1000)
+	private String expectation;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private MeetingDemandStatus status;
+
+	@Column(insertable = false, updatable = false)
+	private Integer meetingId;
+
+	@Column(nullable = false, columnDefinition = "jsonb")
+	@Type(JsonBinaryType.class)
+	private List<MeetingKeywordType> meetingKeywordTypes;
+
+	@Column(nullable = false, columnDefinition = "jsonb")
+	@Type(JsonBinaryType.class)
+	private MeetingJoinInfo joinInfo;
+
+	@Column(nullable = false, columnDefinition = "int default 0")
+	private int waitCount;
+
+	@Column(nullable = false, columnDefinition = "int default 0")
+	private int commentCount;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "userId", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "meetingId")
+	private Meeting meeting;
+
+	@Builder
+	public MeetingDemand(User user, String shortIntro, String expectation,
+		List<MeetingKeywordType> meetingKeywordTypes, MeetingJoinInfo joinInfo) {
+		this.user = user;
+		this.userId = user.getId();
+		this.shortIntro = shortIntro;
+		this.expectation = expectation;
+		this.status = MeetingDemandStatus.BEFORE_OPEN;
+		this.meetingKeywordTypes = meetingKeywordTypes;
+		this.joinInfo = joinInfo;
+		this.waitCount = 0;
+		this.commentCount = 0;
+	}
+
+	public void open(Meeting openedMeeting) {
+		this.meeting = openedMeeting;
+		this.meetingId = openedMeeting.getId();
+		this.status = MeetingDemandStatus.OPENED;
+	}
+
+	public void increaseWaitCount() {
+		this.waitCount++;
+	}
+
+	public void decreaseWaitCount() {
+		this.waitCount--;
+	}
+
+	public void increaseCommentCount() {
+		this.commentCount++;
+	}
+
+	public void decreaseCommentCount() {
+		this.commentCount--;
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemand.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemand.java
@@ -4,11 +4,12 @@ import java.util.List;
 
 import org.hibernate.annotations.Type;
 import org.sopt.makers.crew.main.entity.common.BaseTimeEntity;
-import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
 import org.sopt.makers.crew.main.entity.meetingdemand.enums.MeetingDemandStatus;
 import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
 import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.global.exception.BadRequestException;
+import org.sopt.makers.crew.main.global.exception.ForbiddenException;
 
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;
@@ -26,6 +27,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import static org.sopt.makers.crew.main.global.exception.ErrorStatus.FORBIDDEN_EXCEPTION;
+import static org.sopt.makers.crew.main.global.exception.ErrorStatus.OPENED_MEETING_DEMAND;
 
 @Entity
 @Getter
@@ -50,9 +54,6 @@ public class MeetingDemand extends BaseTimeEntity {
 	@Column(nullable = false)
 	private MeetingDemandStatus status;
 
-	@Column(insertable = false, updatable = false)
-	private Integer meetingId;
-
 	@Column(nullable = false, columnDefinition = "jsonb")
 	@Type(JsonBinaryType.class)
 	private List<MeetingKeywordType> meetingKeywordTypes;
@@ -71,10 +72,6 @@ public class MeetingDemand extends BaseTimeEntity {
 	@JoinColumn(name = "userId", nullable = false)
 	private User user;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "meetingId")
-	private Meeting meeting;
-
 	@Builder
 	public MeetingDemand(User user, String shortIntro, String expectation,
 		List<MeetingKeywordType> meetingKeywordTypes, MeetingJoinInfo joinInfo) {
@@ -89,10 +86,20 @@ public class MeetingDemand extends BaseTimeEntity {
 		this.commentCount = 0;
 	}
 
-	public void open(Meeting openedMeeting) {
-		this.meeting = openedMeeting;
-		this.meetingId = openedMeeting.getId();
+	public void open() {
 		this.status = MeetingDemandStatus.OPENED;
+	}
+
+	public void validateWriter(Integer userId) {
+		if (!this.userId.equals(userId)) {
+			throw new ForbiddenException(FORBIDDEN_EXCEPTION.getErrorCode());
+		}
+	}
+
+	public void validateBeforeOpen() {
+		if (MeetingDemandStatus.OPENED.equals(this.status)) {
+			throw new BadRequestException(OPENED_MEETING_DEMAND.getErrorCode());
+		}
 	}
 
 	public void increaseWaitCount() {

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemand.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemand.java
@@ -119,11 +119,17 @@ public class MeetingDemand extends BaseTimeEntity {
 		}
 	}
 
+	public void syncWaitCount(int waitCount) {
+		this.waitCount = waitCount;
+	}
+
 	public void increaseCommentCount() {
 		this.commentCount++;
 	}
 
 	public void decreaseCommentCount() {
-		this.commentCount--;
+		if (this.commentCount > 0) {
+			this.commentCount--;
+		}
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemand.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemand.java
@@ -30,6 +30,7 @@ import lombok.NoArgsConstructor;
 
 import static org.sopt.makers.crew.main.global.exception.ErrorStatus.FORBIDDEN_EXCEPTION;
 import static org.sopt.makers.crew.main.global.exception.ErrorStatus.OPENED_MEETING_DEMAND;
+import static org.sopt.makers.crew.main.global.exception.ErrorStatus.WRITER_CANNOT_WAIT_MEETING_DEMAND;
 
 @Entity
 @Getter
@@ -96,6 +97,12 @@ public class MeetingDemand extends BaseTimeEntity {
 		}
 	}
 
+	public void validateNotWriter(Integer userId) {
+		if (this.userId.equals(userId)) {
+			throw new BadRequestException(WRITER_CANNOT_WAIT_MEETING_DEMAND.getErrorCode());
+		}
+	}
+
 	public void validateBeforeOpen() {
 		if (MeetingDemandStatus.OPENED.equals(this.status)) {
 			throw new BadRequestException(OPENED_MEETING_DEMAND.getErrorCode());
@@ -107,7 +114,9 @@ public class MeetingDemand extends BaseTimeEntity {
 	}
 
 	public void decreaseWaitCount() {
-		this.waitCount--;
+		if (this.waitCount > 0) {
+			this.waitCount--;
+		}
 	}
 
 	public void increaseCommentCount() {

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemand.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemand.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.Type;
 import org.sopt.makers.crew.main.entity.common.BaseTimeEntity;
 import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
 import org.sopt.makers.crew.main.entity.meetingdemand.enums.MeetingDemandStatus;
+import org.sopt.makers.crew.main.entity.meetingdemand.vo.MeetingDemandAnonymousProfile;
 import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
 import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.global.exception.BadRequestException;
@@ -55,6 +56,12 @@ public class MeetingDemand extends BaseTimeEntity {
 	@Column(nullable = false)
 	private MeetingDemandStatus status;
 
+	@Column(nullable = false, length = 30)
+	private String anonymousNickname;
+
+	@Column(nullable = false)
+	private Integer anonymousImageNumber;
+
 	@Column(nullable = false, columnDefinition = "jsonb")
 	@Type(JsonBinaryType.class)
 	private List<MeetingKeywordType> meetingKeywordTypes;
@@ -81,6 +88,8 @@ public class MeetingDemand extends BaseTimeEntity {
 		this.shortIntro = shortIntro;
 		this.expectation = expectation;
 		this.status = MeetingDemandStatus.BEFORE_OPEN;
+		this.anonymousNickname = MeetingDemandAnonymousProfile.generateNickname();
+		this.anonymousImageNumber = MeetingDemandAnonymousProfile.generateImageNumber();
 		this.meetingKeywordTypes = meetingKeywordTypes;
 		this.joinInfo = joinInfo;
 		this.waitCount = 0;
@@ -92,13 +101,17 @@ public class MeetingDemand extends BaseTimeEntity {
 	}
 
 	public void validateWriter(Integer userId) {
-		if (!this.userId.equals(userId)) {
+		if (!isWriter(userId)) {
 			throw new ForbiddenException(FORBIDDEN_EXCEPTION.getErrorCode());
 		}
 	}
 
+	public boolean isWriter(Integer userId) {
+		return this.userId.equals(userId);
+	}
+
 	public void validateNotWriter(Integer userId) {
-		if (this.userId.equals(userId)) {
+		if (isWriter(userId)) {
 			throw new BadRequestException(WRITER_CANNOT_WAIT_MEETING_DEMAND.getErrorCode());
 		}
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandRepository.java
@@ -1,6 +1,21 @@
 package org.sopt.makers.crew.main.entity.meetingdemand;
 
+import static org.sopt.makers.crew.main.global.exception.ErrorStatus.NOT_FOUND_MEETING_DEMAND;
+
+import org.sopt.makers.crew.main.entity.meetingdemand.enums.MeetingDemandStatus;
+import org.sopt.makers.crew.main.global.exception.NotFoundException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MeetingDemandRepository extends JpaRepository<MeetingDemand, Integer> {
+
+	Page<MeetingDemand> findAllByStatus(MeetingDemandStatus status, Pageable pageable);
+
+	int countByStatus(MeetingDemandStatus status);
+
+	default MeetingDemand findByIdOrThrow(Integer meetingDemandId) {
+		return findById(meetingDemandId)
+			.orElseThrow(() -> new NotFoundException(NOT_FOUND_MEETING_DEMAND.getErrorCode()));
+	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandRepository.java
@@ -1,0 +1,6 @@
+package org.sopt.makers.crew.main.entity.meetingdemand;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MeetingDemandRepository extends JpaRepository<MeetingDemand, Integer> {
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandRepository.java
@@ -2,11 +2,18 @@ package org.sopt.makers.crew.main.entity.meetingdemand;
 
 import static org.sopt.makers.crew.main.global.exception.ErrorStatus.NOT_FOUND_MEETING_DEMAND;
 
+import java.util.Optional;
+
 import org.sopt.makers.crew.main.entity.meetingdemand.enums.MeetingDemandStatus;
 import org.sopt.makers.crew.main.global.exception.NotFoundException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.LockModeType;
 
 public interface MeetingDemandRepository extends JpaRepository<MeetingDemand, Integer> {
 
@@ -14,8 +21,17 @@ public interface MeetingDemandRepository extends JpaRepository<MeetingDemand, In
 
 	int countByStatus(MeetingDemandStatus status);
 
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("select md from MeetingDemand md where md.id = :meetingDemandId")
+	Optional<MeetingDemand> findByIdWithPessimisticWriteLock(@Param("meetingDemandId") Integer meetingDemandId);
+
 	default MeetingDemand findByIdOrThrow(Integer meetingDemandId) {
 		return findById(meetingDemandId)
+			.orElseThrow(() -> new NotFoundException(NOT_FOUND_MEETING_DEMAND.getErrorCode()));
+	}
+
+	default MeetingDemand findByIdWithPessimisticWriteLockOrThrow(Integer meetingDemandId) {
+		return findByIdWithPessimisticWriteLock(meetingDemandId)
 			.orElseThrow(() -> new NotFoundException(NOT_FOUND_MEETING_DEMAND.getErrorCode()));
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandWait.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandWait.java
@@ -1,0 +1,42 @@
+package org.sopt.makers.crew.main.entity.meetingdemand;
+
+import org.sopt.makers.crew.main.entity.common.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "meeting_demand_wait",
+	uniqueConstraints = @UniqueConstraint(
+		name = "UQ_meeting_demand_wait_demand_user",
+		columnNames = {"meetingDemandId", "userId"}
+	))
+public class MeetingDemandWait extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
+	@Column(nullable = false)
+	private Integer meetingDemandId;
+
+	@Column(nullable = false)
+	private Integer userId;
+
+	@Builder
+	public MeetingDemandWait(Integer meetingDemandId, Integer userId) {
+		this.meetingDemandId = meetingDemandId;
+		this.userId = userId;
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandWaitRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandWaitRepository.java
@@ -10,5 +10,9 @@ public interface MeetingDemandWaitRepository extends JpaRepository<MeetingDemand
 
 	int deleteByMeetingDemandIdAndUserId(Integer meetingDemandId, Integer userId);
 
+	void deleteAllByMeetingDemandId(Integer meetingDemandId);
+
+	long countByMeetingDemandId(Integer meetingDemandId);
+
 	List<MeetingDemandWait> findAllByMeetingDemandIdInAndUserId(List<Integer> meetingDemandIds, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandWaitRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandWaitRepository.java
@@ -1,6 +1,12 @@
 package org.sopt.makers.crew.main.entity.meetingdemand;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MeetingDemandWaitRepository extends JpaRepository<MeetingDemandWait, Integer> {
+
+	boolean existsByMeetingDemandIdAndUserId(Integer meetingDemandId, Integer userId);
+
+	List<MeetingDemandWait> findAllByMeetingDemandIdInAndUserId(List<Integer> meetingDemandIds, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandWaitRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandWaitRepository.java
@@ -8,5 +8,7 @@ public interface MeetingDemandWaitRepository extends JpaRepository<MeetingDemand
 
 	boolean existsByMeetingDemandIdAndUserId(Integer meetingDemandId, Integer userId);
 
+	int deleteByMeetingDemandIdAndUserId(Integer meetingDemandId, Integer userId);
+
 	List<MeetingDemandWait> findAllByMeetingDemandIdInAndUserId(List<Integer> meetingDemandIds, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandWaitRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandWaitRepository.java
@@ -1,0 +1,6 @@
+package org.sopt.makers.crew.main.entity.meetingdemand;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MeetingDemandWaitRepository extends JpaRepository<MeetingDemandWait, Integer> {
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/enums/MeetingDemandStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/enums/MeetingDemandStatus.java
@@ -1,0 +1,13 @@
+package org.sopt.makers.crew.main.entity.meetingdemand.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MeetingDemandStatus {
+	BEFORE_OPEN("개설전"),
+	OPENED("개설완료");
+
+	private final String value;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/vo/MeetingDemandAnonymousProfile.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/vo/MeetingDemandAnonymousProfile.java
@@ -1,6 +1,7 @@
 package org.sopt.makers.crew.main.entity.meetingdemand.vo;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 import lombok.AccessLevel;
@@ -8,6 +9,10 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MeetingDemandAnonymousProfile {
+
+	private static final int MIN_IMAGE_NUMBER = 1;
+	private static final int MAX_IMAGE_NUMBER = 5;
+	private static final int DEFAULT_IMAGE_NUMBER = 1;
 
 	private static final List<String> ADJECTIVES = List.of(
 		"열정적인",
@@ -79,12 +84,12 @@ public class MeetingDemandAnonymousProfile {
 		"쿠키"
 	);
 
-	private static final List<String> IMAGE_URLS = List.of(
-		"https://sopt-makers-mds.s3.ap-northeast-2.amazonaws.com/anonymousImage/avatar_m.png",
-		"https://sopt-makers-mds.s3.ap-northeast-2.amazonaws.com/anonymousImage/avatar_o.png",
-		"https://sopt-makers-mds.s3.ap-northeast-2.amazonaws.com/anonymousImage/avatar_p.png",
-		"https://sopt-makers-mds.s3.ap-northeast-2.amazonaws.com/anonymousImage/avatar_s.png",
-		"https://sopt-makers-mds.s3.ap-northeast-2.amazonaws.com/anonymousImage/avatar_t.png"
+	private static final Map<Integer, String> IMAGE_URLS = Map.of(
+		1, "https://sopt-makers-mds.s3.ap-northeast-2.amazonaws.com/anonymousImage/avatar_m.png",
+		2, "https://sopt-makers-mds.s3.ap-northeast-2.amazonaws.com/anonymousImage/avatar_o.png",
+		3, "https://sopt-makers-mds.s3.ap-northeast-2.amazonaws.com/anonymousImage/avatar_p.png",
+		4, "https://sopt-makers-mds.s3.ap-northeast-2.amazonaws.com/anonymousImage/avatar_s.png",
+		5, "https://sopt-makers-mds.s3.ap-northeast-2.amazonaws.com/anonymousImage/avatar_t.png"
 	);
 
 	public static String generateNickname() {
@@ -92,14 +97,11 @@ public class MeetingDemandAnonymousProfile {
 	}
 
 	public static int generateImageNumber() {
-		return ThreadLocalRandom.current().nextInt(1, IMAGE_URLS.size() + 1);
+		return ThreadLocalRandom.current().nextInt(MIN_IMAGE_NUMBER, MAX_IMAGE_NUMBER + 1);
 	}
 
 	public static String getImageUrl(int imageNumber) {
-		if (imageNumber < 1 || imageNumber > IMAGE_URLS.size()) {
-			return IMAGE_URLS.get(0);
-		}
-		return IMAGE_URLS.get(imageNumber - 1);
+		return IMAGE_URLS.getOrDefault(imageNumber, IMAGE_URLS.get(DEFAULT_IMAGE_NUMBER));
 	}
 
 	private static String getRandomValue(List<String> values) {

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/vo/MeetingDemandAnonymousProfile.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/vo/MeetingDemandAnonymousProfile.java
@@ -1,0 +1,108 @@
+package org.sopt.makers.crew.main.entity.meetingdemand.vo;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MeetingDemandAnonymousProfile {
+
+	private static final List<String> ADJECTIVES = List.of(
+		"열정적인",
+		"믿음직한",
+		"용기 있는",
+		"성장하는",
+		"도전하는",
+		"끈기 있는",
+		"재치 있는",
+		"친화력 좋은",
+		"솔직한",
+		"창의적인",
+		"영감을 주는",
+		"적극적인",
+		"유연한",
+		"모험적인",
+		"의욕적인",
+		"통찰력 있는",
+		"센스 있는",
+		"책임감 있는",
+		"배려 깊은",
+		"호기심 많은",
+		"실행력 있는",
+		"집중력 좋은",
+		"섬세한",
+		"든든한",
+		"긍정적인",
+		"활기찬",
+		"따뜻한",
+		"성실한",
+		"차분한",
+		"민첩한",
+		"대담한",
+		"반짝이는"
+	);
+
+	private static final List<String> NOUNS = List.of(
+		"토마토",
+		"참외",
+		"브로콜리",
+		"고구마",
+		"딸기",
+		"복숭아",
+		"자두",
+		"포도",
+		"수박",
+		"체리",
+		"레몬",
+		"망고",
+		"당근",
+		"감자",
+		"호박",
+		"완두콩",
+		"오리",
+		"너구리",
+		"개구리",
+		"병아리",
+		"사슴",
+		"참새",
+		"수달",
+		"토끼",
+		"다람쥐",
+		"펭귄",
+		"해달",
+		"판다",
+		"마카롱",
+		"케이크",
+		"푸딩",
+		"쿠키"
+	);
+
+	private static final List<String> IMAGE_URLS = List.of(
+		"https://sopt-makers-mds.s3.ap-northeast-2.amazonaws.com/anonymousImage/avatar_m.png",
+		"https://sopt-makers-mds.s3.ap-northeast-2.amazonaws.com/anonymousImage/avatar_o.png",
+		"https://sopt-makers-mds.s3.ap-northeast-2.amazonaws.com/anonymousImage/avatar_p.png",
+		"https://sopt-makers-mds.s3.ap-northeast-2.amazonaws.com/anonymousImage/avatar_s.png",
+		"https://sopt-makers-mds.s3.ap-northeast-2.amazonaws.com/anonymousImage/avatar_t.png"
+	);
+
+	public static String generateNickname() {
+		return getRandomValue(ADJECTIVES) + " " + getRandomValue(NOUNS);
+	}
+
+	public static int generateImageNumber() {
+		return ThreadLocalRandom.current().nextInt(1, IMAGE_URLS.size() + 1);
+	}
+
+	public static String getImageUrl(int imageNumber) {
+		if (imageNumber < 1 || imageNumber > IMAGE_URLS.size()) {
+			return IMAGE_URLS.get(0);
+		}
+		return IMAGE_URLS.get(imageNumber - 1);
+	}
+
+	private static String getRandomValue(List<String> values) {
+		return values.get(ThreadLocalRandom.current().nextInt(values.size()));
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
@@ -35,6 +35,7 @@ public enum ErrorStatus {
 	LEADER_CANNOT_BE_CO_LEADER_APPLY("모임장은 공동 모임장이 될 수 없습니다."),
 	NOT_ALLOW_MEETING_APPLY("허용되지 않는 모임 신청입니다."),
 	OPENED_MEETING_DEMAND("이미 개설 완료된 모임 수요입니다."),
+	WRITER_CANNOT_WAIT_MEETING_DEMAND("본인이 작성한 모임 수요에는 기다려요를 누를 수 없습니다."),
 	IO_EXCEPTION("파일 입출력 오류가 발생했습니다."),
 	INVALID_WELCOME_MESSAGE_TYPE("유효하지 않은 환영 메시지 타입입니다."),
 	INVALID_MEETING_KEYWORD_TYPE("유효하지 않은 모임 키워드 타입입니다."),

--- a/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/global/exception/ErrorStatus.java
@@ -34,6 +34,7 @@ public enum ErrorStatus {
 	CO_LEADER_CANNOT_APPLY("공동 모임장은 신청할 수 없습니다."),
 	LEADER_CANNOT_BE_CO_LEADER_APPLY("모임장은 공동 모임장이 될 수 없습니다."),
 	NOT_ALLOW_MEETING_APPLY("허용되지 않는 모임 신청입니다."),
+	OPENED_MEETING_DEMAND("이미 개설 완료된 모임 수요입니다."),
 	IO_EXCEPTION("파일 입출력 오류가 발생했습니다."),
 	INVALID_WELCOME_MESSAGE_TYPE("유효하지 않은 환영 메시지 타입입니다."),
 	INVALID_MEETING_KEYWORD_TYPE("유효하지 않은 모임 키워드 타입입니다."),
@@ -80,6 +81,7 @@ public enum ErrorStatus {
 	NOT_FOUND_POST("존재하지 않는 게시글입니다."), // 예외 처리 NotFound로 수정 필요
 	NOT_FOUND_USER("존재하지 않는 유저입니다."), // 예외 처리 NotFound로 수정 필요
 	NOT_FOUND_COMMENT("존재하지 않는 댓글입니다."), // 예외 처리 NotFound로 수정 필요
+	NOT_FOUND_MEETING_DEMAND("존재하지 않는 모임 수요입니다."),
 	NOT_FOUND_FLASH("번쩍 모임이 없습니다."), // 예외 처리 NotFound로 수정 필요
 	NOT_FOUND_TAG("존재하지 않는 태그입니다."),
 	NOT_FOUND_PROPERTY_KEY("프로퍼티 키가 존재하지 않습니다 해당 키 :  "),

--- a/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingService.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/internal/service/InternalMeetingService.java
@@ -16,7 +16,6 @@ import org.sopt.makers.crew.main.entity.apply.enums.EnApplyStatus;
 import org.sopt.makers.crew.main.entity.meeting.CoLeaderRepository;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
-import org.sopt.makers.crew.main.entity.user.UserRepository;
 import org.sopt.makers.crew.main.external.playground.service.MemberBlockService;
 import org.sopt.makers.crew.main.global.pagination.dto.PageMetaDto;
 import org.sopt.makers.crew.main.global.pagination.dto.PageOptionsDto;
@@ -49,7 +48,6 @@ public class InternalMeetingService {
 	private final Time time;
 	private final CoLeaderRepository coLeaderRepository;
 	private final ApplyRepository applyRepository;
-	private final UserRepository userRepository;
 
 	/**
 	 * [for. APP BE] 모일 리스트 페이지네이션 조회 (10개)
@@ -69,7 +67,7 @@ public class InternalMeetingService {
 
 		List<Long> userOrgIds = meetings.getContent()
 			.stream()
-			.map(meeting -> meeting.getUser().getId().longValue())
+			.map(meeting -> meeting.getUserId().longValue())
 			.toList();
 
 		Map<Long, Boolean> blockedUsers = memberBlockService.getBlockedUsers(orgId.longValue(), userOrgIds);

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/FlashMeetingMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/FlashMeetingMapper.java
@@ -37,7 +37,6 @@ public interface FlashMeetingMapper {
 	@Mapping(target = "subTitle", ignore = true)
 	@Mapping(target = "joinInfo", ignore = true)
 	@Mapping(target = "meetingDemandId", ignore = true)
-	@Mapping(target = "meetingDemand", ignore = true)
 	@Mapping(target = "targetActiveGeneration", expression = "java(null)") // 번쩍 정책에 맞게 null
 	@Mapping(target = "joinableParts", expression = "java(org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart.values())")
 		// 번쩍 정책에 맞게 모든 파트 허용

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/FlashMeetingMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/FlashMeetingMapper.java
@@ -36,6 +36,7 @@ public interface FlashMeetingMapper {
 	@Mapping(target = "canJoinOnlyActiveGeneration", constant = "false") // 번쩍 정책에 맞게 false
 	@Mapping(target = "subTitle", ignore = true)
 	@Mapping(target = "joinInfo", ignore = true)
+	@Mapping(target = "meetingDemandId", ignore = true)
 	@Mapping(target = "targetActiveGeneration", expression = "java(null)") // 번쩍 정책에 맞게 null
 	@Mapping(target = "joinableParts", expression = "java(org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart.values())")
 		// 번쩍 정책에 맞게 모든 파트 허용

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/FlashMeetingMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/FlashMeetingMapper.java
@@ -37,6 +37,7 @@ public interface FlashMeetingMapper {
 	@Mapping(target = "subTitle", ignore = true)
 	@Mapping(target = "joinInfo", ignore = true)
 	@Mapping(target = "meetingDemandId", ignore = true)
+	@Mapping(target = "meetingDemand", ignore = true)
 	@Mapping(target = "targetActiveGeneration", expression = "java(null)") // 번쩍 정책에 맞게 null
 	@Mapping(target = "joinableParts", expression = "java(org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart.values())")
 		// 번쩍 정책에 맞게 모든 파트 허용

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/MeetingMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/MeetingMapper.java
@@ -56,8 +56,7 @@ public interface MeetingMapper {
 	@Mapping(source = "requestBody.mStartDate", target = "mStartDate", qualifiedByName = "getStartDate")
 	@Mapping(source = "requestBody.mEndDate", target = "mEndDate", qualifiedByName = "getEndDate")
 	@Mapping(source = "requestBody.joinInfo", target = "joinInfo")
-	@Mapping(target = "meetingDemandId", ignore = true)
-	@Mapping(target = "meetingDemand", ignore = true)
+	@Mapping(source = "requestBody.meetingDemandId", target = "meetingDemandId")
 	Meeting toMeetingEntity(MeetingV2CreateMeetingBodyDto requestBody, Integer targetActiveGeneration,
 		Integer createdGeneration, User user, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/MeetingMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/MeetingMapper.java
@@ -56,7 +56,8 @@ public interface MeetingMapper {
 	@Mapping(source = "requestBody.mStartDate", target = "mStartDate", qualifiedByName = "getStartDate")
 	@Mapping(source = "requestBody.mEndDate", target = "mEndDate", qualifiedByName = "getEndDate")
 	@Mapping(source = "requestBody.joinInfo", target = "joinInfo")
-	@Mapping(source = "requestBody.meetingDemandId", target = "meetingDemandId")
+	@Mapping(target = "meetingDemandId", ignore = true)
+	@Mapping(target = "meetingDemand", ignore = true)
 	Meeting toMeetingEntity(MeetingV2CreateMeetingBodyDto requestBody, Integer targetActiveGeneration,
 		Integer createdGeneration, User user, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/MeetingMapper.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/MeetingMapper.java
@@ -56,6 +56,7 @@ public interface MeetingMapper {
 	@Mapping(source = "requestBody.mStartDate", target = "mStartDate", qualifiedByName = "getStartDate")
 	@Mapping(source = "requestBody.mEndDate", target = "mEndDate", qualifiedByName = "getEndDate")
 	@Mapping(source = "requestBody.joinInfo", target = "joinInfo")
+	@Mapping(source = "requestBody.meetingDemandId", target = "meetingDemandId")
 	Meeting toMeetingEntity(MeetingV2CreateMeetingBodyDto requestBody, Integer targetActiveGeneration,
 		Integer createdGeneration, User user, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/MeetingV2CreateMeetingBodyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/dto/request/MeetingV2CreateMeetingBodyDto.java
@@ -12,9 +12,11 @@ import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "모임 생성 request body dto")
 public class MeetingV2CreateMeetingBodyDto {
 
@@ -94,6 +96,9 @@ public class MeetingV2CreateMeetingBodyDto {
 	@NotNull
 	@Size(min = 1, max = 6)
 	private MeetingJoinablePart[] joinableParts;
+
+	@Schema(example = "1", description = "개설 기반 모임 수요 id")
+	private Integer meetingDemandId;
 
 	@Schema(example = """
 		[1304, 1305]

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -268,7 +268,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 			return null;
 		}
 
-		return meetingDemandRepository.findByIdOrThrow(meetingDemandId);
+		return meetingDemandRepository.findByIdWithPessimisticWriteLockOrThrow(meetingDemandId);
 	}
 
 	private void publishMeetingEvent(MeetingV2CreateMeetingBodyDto requestBody, Meeting meeting) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -43,6 +43,8 @@ import org.sopt.makers.crew.main.entity.meeting.MeetingReader;
 import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemand;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandRepository;
 import org.sopt.makers.crew.main.entity.post.Post;
 import org.sopt.makers.crew.main.entity.post.PostRepository;
 import org.sopt.makers.crew.main.entity.tag.TagRepository;
@@ -126,6 +128,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 	private final ApplyRepository applyRepository;
 	private final ApplyTestRepository applyTestRepository;
 	private final MeetingRepository meetingRepository;
+	private final MeetingDemandRepository meetingDemandRepository;
 	private final PostRepository postRepository;
 	private final CommentRepository commentRepository;
 	private final LikeRepository likeRepository;
@@ -228,12 +231,16 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 			throw new BadRequestException(VALIDATION_EXCEPTION.getErrorCode());
 		}
 
+		MeetingDemand meetingDemand = findMeetingDemandIfRequested(requestBody.getMeetingDemandId());
 		Meeting meeting = meetingMapper.toMeetingEntity(requestBody,
 			createTargetActiveGeneration(requestBody.getCanJoinOnlyActiveGeneration()),
 			activeGenerationProvider.getActiveGeneration(), user,
 			user.getId());
 
 		Meeting savedMeeting = meetingRepository.save(meeting);
+		if (meetingDemand != null) {
+			meetingDemand.open();
+		}
 
 		List<Integer> coLeaderUserIds = requestBody.getCoLeaderUserIds();
 		if (coLeaderUserIds != null && !coLeaderUserIds.isEmpty()) {
@@ -250,6 +257,14 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		}
 
 		return MeetingV2CreateMeetingResponseDto.of(savedMeeting.getId(), tagResponseDto.tagId());
+	}
+
+	private MeetingDemand findMeetingDemandIfRequested(Integer meetingDemandId) {
+		if (meetingDemandId == null) {
+			return null;
+		}
+
+		return meetingDemandRepository.findByIdOrThrow(meetingDemandId);
 	}
 
 	private void publishMeetingEvent(MeetingV2CreateMeetingBodyDto requestBody, Meeting meeting) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -268,7 +268,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 			return null;
 		}
 
-		return meetingDemandRepository.findByIdWithPessimisticWriteLockOrThrow(meetingDemandId);
+		return meetingDemandRepository.findByIdOrThrow(meetingDemandId);
 	}
 
 	private void publishMeetingEvent(MeetingV2CreateMeetingBodyDto requestBody, Meeting meeting) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -213,8 +213,11 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 			.collect(Collectors.toMap(post -> post.getMeeting().getId(), post -> post));
 
 		Applies applies = new Applies(applyRepository.findAllByMeetingIdIn(meetingIds));
+		Map<Integer, User> userMap = getUsersById(meetings.stream()
+			.map(Meeting::getUserId)
+			.toList());
 
-		return getResponseDto(meetings, postMap, applies);
+		return getResponseDto(meetings, postMap, applies, userMap);
 	}
 
 	@Override
@@ -238,7 +241,6 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 			user.getId());
 
 		if (meetingDemand != null) {
-			meeting.connectMeetingDemand(meetingDemand);
 			meetingDemand.open();
 		}
 
@@ -425,11 +427,14 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
 		Map<Integer, TagV2MeetingTagsResponseDto> allTagsResponseDto = tagV2Service.getMeetingTagsByMeetingIds(
 			meetingIds);
+		Map<Integer, User> userMap = getUsersById(meetings.stream()
+			.map(Meeting::getUserId)
+			.toList());
 
 		List<MeetingResponseDto> meetingResponseDtos = meetings.stream()
 			.map(meeting -> MeetingResponseDto.of(
 				meeting,
-				meeting.getUser(),
+				userMap.get(meeting.getUserId()),
 				allApplies.getApprovedCount(meeting.getId()),
 				time.now(),
 				activeGenerationProvider.getActiveGeneration(),
@@ -666,11 +671,14 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 
 		Map<Integer, TagV2MeetingTagsResponseDto> allTagsResponseDto = tagV2Service.getMeetingTagsByMeetingIds(
 			meetingIds);
+		Map<Integer, User> userMap = getUsersById(meetings.stream()
+			.map(Meeting::getUserId)
+			.toList());
 
 		List<MeetingResponseDto> meetingResponseDtos = meetings.stream()
 			.map(meeting -> MeetingResponseDto.of(
 				meeting,
-				meeting.getUser(),
+				userMap.get(meeting.getUserId()),
 				allApplies.getApprovedCount(meeting.getId()),
 				time.now(),
 				activeGenerationProvider.getActiveGeneration(),
@@ -809,11 +817,11 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 	}
 
 	private List<MeetingV2GetMeetingBannerResponseDto> getResponseDto(List<Meeting> meetings,
-		Map<Integer, Post> postMap, Applies applies) {
+		Map<Integer, Post> postMap, Applies applies, Map<Integer, User> userMap) {
 		return meetings.stream()
 			.map(meeting -> {
 				MeetingV2GetMeetingBannerResponseUserDto meetingCreatorDto = MeetingV2GetMeetingBannerResponseUserDto.of(
-					meeting.getUser());
+					userMap.get(meeting.getUserId()));
 
 				LocalDateTime recentActivityDate = null;
 				if (postMap.containsKey(meeting.getId())) {
@@ -824,6 +832,14 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 					applies.getAppliedCount(meeting.getId()), applies.getApprovedCount(meeting.getId()),
 					meetingCreatorDto, time.now());
 			}).toList();
+	}
+
+	private Map<Integer, User> getUsersById(List<Integer> userIds) {
+		return userRepository.findAllById(userIds.stream()
+				.distinct()
+				.toList())
+			.stream()
+			.collect(Collectors.toMap(User::getId, user -> user));
 	}
 
 	private void deleteCsvFile(String filePath) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -237,10 +237,12 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 			activeGenerationProvider.getActiveGeneration(), user,
 			user.getId());
 
-		Meeting savedMeeting = meetingRepository.save(meeting);
 		if (meetingDemand != null) {
+			meeting.connectMeetingDemand(meetingDemand);
 			meetingDemand.open();
 		}
+
+		Meeting savedMeeting = meetingRepository.save(meeting);
 
 		List<Integer> coLeaderUserIds = requestBody.getCoLeaderUserIds();
 		if (coLeaderUserIds != null && !coLeaderUserIds.isEmpty()) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/MeetingDemandV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/MeetingDemandV2Api.java
@@ -1,0 +1,49 @@
+package org.sopt.makers.crew.main.meetingdemand.v2;
+
+import java.security.Principal;
+
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.query.MeetingDemandV2GetMeetingDemandsQueryDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.request.MeetingDemandV2CreateMeetingDemandBodyDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2CreateMeetingDemandResponseDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandResponseDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandsResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "모임 수요")
+public interface MeetingDemandV2Api {
+
+	@Operation(summary = "모임 수요 리스트 조회")
+	@ApiResponse(responseCode = "200", description = "성공")
+	@Parameters({
+		@Parameter(name = "page", description = "페이지, default = 1", example = "1", schema = @Schema(type = "integer", format = "int32")),
+		@Parameter(name = "take", description = "가져올 데이터 개수, default = 3", example = "3", schema = @Schema(type = "integer", format = "int32"))
+	})
+	ResponseEntity<MeetingDemandV2GetMeetingDemandsResponseDto> getMeetingDemands(
+		@Valid @ModelAttribute @Parameter(hidden = true) MeetingDemandV2GetMeetingDemandsQueryDto queryDto,
+		Principal principal);
+
+	@Operation(summary = "모임 수요 상세 조회")
+	@ApiResponse(responseCode = "200", description = "성공")
+	ResponseEntity<MeetingDemandV2GetMeetingDemandResponseDto> getMeetingDemand(
+		@PathVariable Integer meetingDemandId, Principal principal);
+
+	@Operation(summary = "모임 수요 제안하기")
+	@ApiResponse(responseCode = "201", description = "성공")
+	ResponseEntity<MeetingDemandV2CreateMeetingDemandResponseDto> createMeetingDemand(
+		@Valid @RequestBody MeetingDemandV2CreateMeetingDemandBodyDto requestBody, Principal principal);
+
+	@Operation(summary = "모임 수요 삭제")
+	@ApiResponse(responseCode = "204", description = "성공")
+	ResponseEntity<Void> deleteMeetingDemand(@PathVariable Integer meetingDemandId, Principal principal);
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/MeetingDemandV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/MeetingDemandV2Api.java
@@ -23,7 +23,7 @@ import jakarta.validation.Valid;
 @Tag(name = "모임 수요")
 public interface MeetingDemandV2Api {
 
-	@Operation(summary = "모임 수요 리스트 조회")
+	@Operation(summary = "모임 수요 리스트 조회", description = "개설 전 상태의 모임 수요 목록을 최신순으로 조회")
 	@ApiResponse(responseCode = "200", description = "성공")
 	@Parameters({
 		@Parameter(name = "page", description = "페이지, default = 1", example = "1", schema = @Schema(type = "integer", format = "int32")),
@@ -33,17 +33,17 @@ public interface MeetingDemandV2Api {
 		@Valid @ModelAttribute @Parameter(hidden = true) MeetingDemandV2GetMeetingDemandsQueryDto queryDto,
 		Principal principal);
 
-	@Operation(summary = "모임 수요 상세 조회")
+	@Operation(summary = "모임 수요 상세 조회", description = "모임 수요의 상세 정보 조회")
 	@ApiResponse(responseCode = "200", description = "성공")
 	ResponseEntity<MeetingDemandV2GetMeetingDemandResponseDto> getMeetingDemand(
 		@PathVariable Integer meetingDemandId, Principal principal);
 
-	@Operation(summary = "모임 수요 제안하기")
-	@ApiResponse(responseCode = "201", description = "성공")
+	@Operation(summary = "모임 수요 제안하기", description = "모임 수요 생성 API")
+	@ApiResponse(responseCode = "200", description = "성공")
 	ResponseEntity<MeetingDemandV2CreateMeetingDemandResponseDto> createMeetingDemand(
 		@Valid @RequestBody MeetingDemandV2CreateMeetingDemandBodyDto requestBody, Principal principal);
 
-	@Operation(summary = "모임 수요 삭제")
-	@ApiResponse(responseCode = "204", description = "성공")
+	@Operation(summary = "모임 수요 삭제", description = "모임 수요 삭제 API")
+	@ApiResponse(responseCode = "200", description = "성공")
 	ResponseEntity<Void> deleteMeetingDemand(@PathVariable Integer meetingDemandId, Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/MeetingDemandV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/MeetingDemandV2Api.java
@@ -7,6 +7,7 @@ import org.sopt.makers.crew.main.meetingdemand.v2.dto.request.MeetingDemandV2Cre
 import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2CreateMeetingDemandResponseDto;
 import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandResponseDto;
 import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandsResponseDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2SwitchMeetingDemandWaitResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -46,4 +47,9 @@ public interface MeetingDemandV2Api {
 	@Operation(summary = "모임 수요 삭제", description = "모임 수요 삭제 API")
 	@ApiResponse(responseCode = "200", description = "성공")
 	ResponseEntity<Void> deleteMeetingDemand(@PathVariable Integer meetingDemandId, Principal principal);
+
+	@Operation(summary = "모임 수요 기다려요 토글", description = "모임 수요의 기다려요 상태를 토글합니다.")
+	@ApiResponse(responseCode = "200", description = "성공")
+	ResponseEntity<MeetingDemandV2SwitchMeetingDemandWaitResponseDto> switchMeetingDemandWait(
+		@PathVariable Integer meetingDemandId, Principal principal);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/MeetingDemandV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/MeetingDemandV2Controller.java
@@ -8,6 +8,7 @@ import org.sopt.makers.crew.main.meetingdemand.v2.dto.request.MeetingDemandV2Cre
 import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2CreateMeetingDemandResponseDto;
 import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandResponseDto;
 import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandsResponseDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2SwitchMeetingDemandWaitResponseDto;
 import org.sopt.makers.crew.main.meetingdemand.v2.service.MeetingDemandV2Service;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -61,5 +62,13 @@ public class MeetingDemandV2Controller implements MeetingDemandV2Api {
 		Integer userId = UserUtil.getUserId(principal);
 		meetingDemandV2Service.deleteMeetingDemand(meetingDemandId, userId);
 		return ResponseEntity.ok().build();
+	}
+
+	@Override
+	@PostMapping("/{meetingDemandId}/wait")
+	public ResponseEntity<MeetingDemandV2SwitchMeetingDemandWaitResponseDto> switchMeetingDemandWait(
+		@PathVariable Integer meetingDemandId, Principal principal) {
+		Integer userId = UserUtil.getUserId(principal);
+		return ResponseEntity.ok(meetingDemandV2Service.switchMeetingDemandWait(meetingDemandId, userId));
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/MeetingDemandV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/MeetingDemandV2Controller.java
@@ -9,7 +9,6 @@ import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2Cr
 import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandResponseDto;
 import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandsResponseDto;
 import org.sopt.makers.crew.main.meetingdemand.v2.service.MeetingDemandV2Service;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -53,8 +52,7 @@ public class MeetingDemandV2Controller implements MeetingDemandV2Api {
 	public ResponseEntity<MeetingDemandV2CreateMeetingDemandResponseDto> createMeetingDemand(
 		@Valid @RequestBody MeetingDemandV2CreateMeetingDemandBodyDto requestBody, Principal principal) {
 		Integer userId = UserUtil.getUserId(principal);
-		return ResponseEntity.status(HttpStatus.CREATED)
-			.body(meetingDemandV2Service.createMeetingDemand(requestBody, userId));
+		return ResponseEntity.ok(meetingDemandV2Service.createMeetingDemand(requestBody, userId));
 	}
 
 	@Override
@@ -62,6 +60,6 @@ public class MeetingDemandV2Controller implements MeetingDemandV2Api {
 	public ResponseEntity<Void> deleteMeetingDemand(@PathVariable Integer meetingDemandId, Principal principal) {
 		Integer userId = UserUtil.getUserId(principal);
 		meetingDemandV2Service.deleteMeetingDemand(meetingDemandId, userId);
-		return ResponseEntity.noContent().build();
+		return ResponseEntity.ok().build();
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/MeetingDemandV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/MeetingDemandV2Controller.java
@@ -1,0 +1,67 @@
+package org.sopt.makers.crew.main.meetingdemand.v2;
+
+import java.security.Principal;
+
+import org.sopt.makers.crew.main.global.util.UserUtil;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.query.MeetingDemandV2GetMeetingDemandsQueryDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.request.MeetingDemandV2CreateMeetingDemandBodyDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2CreateMeetingDemandResponseDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandResponseDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandsResponseDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.service.MeetingDemandV2Service;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/meeting-demand/v2")
+@RequiredArgsConstructor
+public class MeetingDemandV2Controller implements MeetingDemandV2Api {
+
+	private final MeetingDemandV2Service meetingDemandV2Service;
+
+	@Override
+	@GetMapping
+	public ResponseEntity<MeetingDemandV2GetMeetingDemandsResponseDto> getMeetingDemands(
+		@Valid @ModelAttribute @Parameter(hidden = true) MeetingDemandV2GetMeetingDemandsQueryDto queryDto,
+		Principal principal) {
+		Integer userId = UserUtil.getUserId(principal);
+		return ResponseEntity.ok(meetingDemandV2Service.getMeetingDemands(queryDto, userId));
+	}
+
+	@Override
+	@GetMapping("/{meetingDemandId}")
+	public ResponseEntity<MeetingDemandV2GetMeetingDemandResponseDto> getMeetingDemand(
+		@PathVariable Integer meetingDemandId, Principal principal) {
+		Integer userId = UserUtil.getUserId(principal);
+		return ResponseEntity.ok(meetingDemandV2Service.getMeetingDemand(meetingDemandId, userId));
+	}
+
+	@Override
+	@PostMapping
+	public ResponseEntity<MeetingDemandV2CreateMeetingDemandResponseDto> createMeetingDemand(
+		@Valid @RequestBody MeetingDemandV2CreateMeetingDemandBodyDto requestBody, Principal principal) {
+		Integer userId = UserUtil.getUserId(principal);
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(meetingDemandV2Service.createMeetingDemand(requestBody, userId));
+	}
+
+	@Override
+	@DeleteMapping("/{meetingDemandId}")
+	public ResponseEntity<Void> deleteMeetingDemand(@PathVariable Integer meetingDemandId, Principal principal) {
+		Integer userId = UserUtil.getUserId(principal);
+		meetingDemandV2Service.deleteMeetingDemand(meetingDemandId, userId);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/dto/query/MeetingDemandV2GetMeetingDemandsQueryDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/dto/query/MeetingDemandV2GetMeetingDemandsQueryDto.java
@@ -1,0 +1,17 @@
+package org.sopt.makers.crew.main.meetingdemand.v2.dto.query;
+
+import org.sopt.makers.crew.main.global.pagination.dto.PageOptionsDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(name = "MeetingDemandV2GetMeetingDemandsQueryDto", description = "모임 수요 목록 요청 Dto")
+public class MeetingDemandV2GetMeetingDemandsQueryDto extends PageOptionsDto {
+
+	private static final int DEFAULT_TAKE = 3;
+
+	public MeetingDemandV2GetMeetingDemandsQueryDto(Integer page, Integer take) {
+		super(page, take == null ? DEFAULT_TAKE : take);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/dto/request/MeetingDemandV2CreateMeetingDemandBodyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/dto/request/MeetingDemandV2CreateMeetingDemandBodyDto.java
@@ -1,0 +1,44 @@
+package org.sopt.makers.crew.main.meetingdemand.v2.dto.request;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "모임 수요 생성 request body dto")
+public class MeetingDemandV2CreateMeetingDemandBodyDto {
+
+	@Schema(example = "퇴근 후 같이 러닝할 사람", description = "모임 한줄소개")
+	@NotBlank
+	@Size(min = 1, max = 30)
+	private String shortIntro;
+
+	@Schema(example = "혼자 뛰기는 아쉬워서 함께 꾸준히 달릴 수 있는 모임이 있으면 좋겠어요.", description = "기대하는 내용")
+	@NotBlank
+	@Size(min = 1, max = 1000)
+	private String expectation;
+
+	@Schema(example = """
+		["운동", "네트워킹"]
+		""", description = "모임 키워드 타입 리스트")
+	@NotNull
+	@Size(min = 1, max = 2)
+	private List<String> meetingKeywordTypes;
+
+	@Schema(example = """
+		{
+		  "meetingType": "오프라인",
+		  "meetingFrequency": "가볍게"
+		}
+		""", description = "참여 정보")
+	@NotNull
+	private MeetingJoinInfo joinInfo;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/dto/response/MeetingDemandV2CreateMeetingDemandResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/dto/response/MeetingDemandV2CreateMeetingDemandResponseDto.java
@@ -1,0 +1,16 @@
+package org.sopt.makers.crew.main.meetingdemand.v2.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+@Schema(name = "MeetingDemandV2CreateMeetingDemandResponseDto", description = "모임 수요 생성 응답 Dto")
+public class MeetingDemandV2CreateMeetingDemandResponseDto {
+
+	@Schema(description = "모임 수요 id", example = "1")
+	@NotNull
+	private Integer meetingDemandId;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/dto/response/MeetingDemandV2GetMeetingDemandResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/dto/response/MeetingDemandV2GetMeetingDemandResponseDto.java
@@ -1,0 +1,82 @@
+package org.sopt.makers.crew.main.meetingdemand.v2.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemand;
+import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+@Schema(name = "MeetingDemandV2GetMeetingDemandResponseDto", description = "모임 수요 조회 응답 Dto")
+public class MeetingDemandV2GetMeetingDemandResponseDto {
+
+	@Schema(description = "모임 수요 id", example = "1")
+	@NotNull
+	private Integer id;
+
+	@Schema(description = "모임 한줄소개", example = "러닝 모임 열어주세요")
+	@NotNull
+	private String shortIntro;
+
+	@Schema(description = "기대하는 내용", example = "함께 꾸준히 달릴 수 있는 모임이 있으면 좋겠어요.")
+	@NotNull
+	private String expectation;
+
+	@Schema(description = "모임 수요 상태", example = "BEFORE_OPEN")
+	@NotNull
+	private String status;
+
+	@Schema(description = "개설된 모임 수", example = "1")
+	@NotNull
+	private int openedMeetingCount;
+
+	@Schema(description = "모임 키워드 타입 리스트", example = "[\"운동\", \"네트워킹\"]")
+	@NotNull
+	private List<String> meetingKeywordTypes;
+
+	@Schema(description = "참여 정보")
+	@NotNull
+	private MeetingJoinInfo joinInfo;
+
+	@Schema(description = "기다려요 수", example = "10")
+	@NotNull
+	private int waitCount;
+
+	@Schema(description = "본인이 기다려요를 눌렀는지 여부", example = "true")
+	@NotNull
+	private Boolean isWaiting;
+
+	@Schema(description = "댓글 수", example = "3")
+	@NotNull
+	private int commentCount;
+
+	@Schema(description = "모임 수요 생성일자", example = "2026-06-30T15:30:00")
+	@NotNull
+	private LocalDateTime createdDate;
+
+	public static MeetingDemandV2GetMeetingDemandResponseDto of(MeetingDemand meetingDemand, boolean isWaiting,
+		int openedMeetingCount) {
+		return MeetingDemandV2GetMeetingDemandResponseDto.of(
+			meetingDemand.getId(),
+			meetingDemand.getShortIntro(),
+			meetingDemand.getExpectation(),
+			meetingDemand.getStatus().name(),
+			openedMeetingCount,
+			meetingDemand.getMeetingKeywordTypes().stream()
+				.map(MeetingKeywordType::getValue)
+				.toList(),
+			meetingDemand.getJoinInfo(),
+			meetingDemand.getWaitCount(),
+			isWaiting,
+			meetingDemand.getCommentCount(),
+			meetingDemand.createdTimestamp
+		);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/dto/response/MeetingDemandV2GetMeetingDemandResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/dto/response/MeetingDemandV2GetMeetingDemandResponseDto.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
 import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemand;
+import org.sopt.makers.crew.main.entity.meetingdemand.vo.MeetingDemandAnonymousProfile;
 import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -32,6 +33,18 @@ public class MeetingDemandV2GetMeetingDemandResponseDto {
 	@Schema(description = "모임 수요 상태", example = "BEFORE_OPEN")
 	@NotNull
 	private String status;
+
+	@Schema(description = "본인이 작성한 모임 수요인지 여부", example = "true")
+	@NotNull
+	private Boolean isMine;
+
+	@Schema(description = "익명 닉네임", example = "성실한 판다")
+	@NotNull
+	private String anonymousNickname;
+
+	@Schema(description = "익명 이미지 URL", example = "https://sopt-makers-mds.s3.ap-northeast-2.amazonaws.com/anonymousImage/avatar_m.png")
+	@NotNull
+	private String anonymousImageUrl;
 
 	@Schema(description = "개설된 모임 수", example = "1")
 	@NotNull
@@ -62,12 +75,15 @@ public class MeetingDemandV2GetMeetingDemandResponseDto {
 	private LocalDateTime createdDate;
 
 	public static MeetingDemandV2GetMeetingDemandResponseDto of(MeetingDemand meetingDemand, boolean isWaiting,
-		int openedMeetingCount) {
+		boolean isMine, int openedMeetingCount) {
 		return MeetingDemandV2GetMeetingDemandResponseDto.of(
 			meetingDemand.getId(),
 			meetingDemand.getShortIntro(),
 			meetingDemand.getExpectation(),
 			meetingDemand.getStatus().name(),
+			isMine,
+			meetingDemand.getAnonymousNickname(),
+			MeetingDemandAnonymousProfile.getImageUrl(meetingDemand.getAnonymousImageNumber()),
 			openedMeetingCount,
 			meetingDemand.getMeetingKeywordTypes().stream()
 				.map(MeetingKeywordType::getValue)

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/dto/response/MeetingDemandV2GetMeetingDemandsResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/dto/response/MeetingDemandV2GetMeetingDemandsResponseDto.java
@@ -1,0 +1,24 @@
+package org.sopt.makers.crew.main.meetingdemand.v2.dto.response;
+
+import java.util.List;
+
+import org.sopt.makers.crew.main.global.pagination.dto.PageMetaDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(name = "MeetingDemandV2GetMeetingDemandsResponseDto", description = "모임 수요 목록 조회 응답 Dto")
+public record MeetingDemandV2GetMeetingDemandsResponseDto(
+	@Schema(description = "모임 수요 목록")
+	@NotNull
+	List<MeetingDemandV2GetMeetingDemandResponseDto> meetingDemands,
+
+	@Schema(description = "페이지네이션 객체")
+	@NotNull
+	PageMetaDto meta
+) {
+	public static MeetingDemandV2GetMeetingDemandsResponseDto of(
+		List<MeetingDemandV2GetMeetingDemandResponseDto> meetingDemands, PageMetaDto meta) {
+		return new MeetingDemandV2GetMeetingDemandsResponseDto(meetingDemands, meta);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/dto/response/MeetingDemandV2SwitchMeetingDemandWaitResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/dto/response/MeetingDemandV2SwitchMeetingDemandWaitResponseDto.java
@@ -1,0 +1,20 @@
+package org.sopt.makers.crew.main.meetingdemand.v2.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+@Schema(name = "MeetingDemandV2SwitchMeetingDemandWaitResponseDto", description = "모임 수요 기다려요 토글 응답 Dto")
+public class MeetingDemandV2SwitchMeetingDemandWaitResponseDto {
+
+	@Schema(description = "기다려요 수", example = "10")
+	@NotNull
+	private int waitCount;
+
+	@Schema(description = "요청 후 본인이 기다려요를 누른 상태", example = "true")
+	@NotNull
+	private Boolean isWaiting;
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandV2Service.java
@@ -1,0 +1,20 @@
+package org.sopt.makers.crew.main.meetingdemand.v2.service;
+
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.query.MeetingDemandV2GetMeetingDemandsQueryDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.request.MeetingDemandV2CreateMeetingDemandBodyDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2CreateMeetingDemandResponseDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandResponseDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandsResponseDto;
+
+public interface MeetingDemandV2Service {
+
+	MeetingDemandV2GetMeetingDemandsResponseDto getMeetingDemands(
+		MeetingDemandV2GetMeetingDemandsQueryDto queryDto, Integer userId);
+
+	MeetingDemandV2GetMeetingDemandResponseDto getMeetingDemand(Integer meetingDemandId, Integer userId);
+
+	MeetingDemandV2CreateMeetingDemandResponseDto createMeetingDemand(
+		MeetingDemandV2CreateMeetingDemandBodyDto requestBody, Integer userId);
+
+	void deleteMeetingDemand(Integer meetingDemandId, Integer userId);
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandV2Service.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandV2Service.java
@@ -5,6 +5,7 @@ import org.sopt.makers.crew.main.meetingdemand.v2.dto.request.MeetingDemandV2Cre
 import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2CreateMeetingDemandResponseDto;
 import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandResponseDto;
 import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandsResponseDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2SwitchMeetingDemandWaitResponseDto;
 
 public interface MeetingDemandV2Service {
 
@@ -17,4 +18,6 @@ public interface MeetingDemandV2Service {
 		MeetingDemandV2CreateMeetingDemandBodyDto requestBody, Integer userId);
 
 	void deleteMeetingDemand(Integer meetingDemandId, Integer userId);
+
+	MeetingDemandV2SwitchMeetingDemandWaitResponseDto switchMeetingDemandWait(Integer meetingDemandId, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandV2ServiceImpl.java
@@ -1,0 +1,147 @@
+package org.sopt.makers.crew.main.meetingdemand.v2.service;
+
+import static org.sopt.makers.crew.main.entity.meetingdemand.enums.MeetingDemandStatus.BEFORE_OPEN;
+import static org.sopt.makers.crew.main.global.exception.ErrorStatus.INVALID_MEETING_KEYWORD_SIZE;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemand;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandRepository;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandWait;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandWaitRepository;
+import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
+import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.UserRepository;
+import org.sopt.makers.crew.main.global.exception.BadRequestException;
+import org.sopt.makers.crew.main.global.pagination.dto.PageMetaDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.query.MeetingDemandV2GetMeetingDemandsQueryDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.request.MeetingDemandV2CreateMeetingDemandBodyDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2CreateMeetingDemandResponseDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandResponseDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandsResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MeetingDemandV2ServiceImpl implements MeetingDemandV2Service {
+
+	private static final int MAX_MEETING_KEYWORD_SIZE = 2;
+
+	private final UserRepository userRepository;
+	private final MeetingDemandRepository meetingDemandRepository;
+	private final MeetingDemandWaitRepository meetingDemandWaitRepository;
+	private final MeetingRepository meetingRepository;
+
+	@Override
+	public MeetingDemandV2GetMeetingDemandsResponseDto getMeetingDemands(
+		MeetingDemandV2GetMeetingDemandsQueryDto queryDto, Integer userId) {
+
+		int totalCount = meetingDemandRepository.countByStatus(BEFORE_OPEN);
+		MeetingDemandV2GetMeetingDemandsQueryDto effectiveQueryDto = adjustPageWhenOutOfRange(queryDto, totalCount);
+		Page<MeetingDemand> meetingDemands = meetingDemandRepository.findAllByStatus(BEFORE_OPEN,
+			PageRequest.of(
+				effectiveQueryDto.getPage() - 1,
+				effectiveQueryDto.getTake(),
+				Sort.by(Sort.Order.desc("createdTimestamp"), Sort.Order.desc("id"))
+			));
+
+		Set<Integer> waitingMeetingDemandIds = getWaitingMeetingDemandIds(meetingDemands.getContent(), userId);
+		List<MeetingDemandV2GetMeetingDemandResponseDto> responseDtos = meetingDemands.getContent().stream()
+			.map(meetingDemand -> MeetingDemandV2GetMeetingDemandResponseDto.of(
+				meetingDemand,
+				waitingMeetingDemandIds.contains(meetingDemand.getId()),
+				meetingRepository.countByMeetingDemandId(meetingDemand.getId())
+			))
+			.toList();
+
+		PageMetaDto pageMetaDto = new PageMetaDto(effectiveQueryDto, totalCount);
+
+		return MeetingDemandV2GetMeetingDemandsResponseDto.of(responseDtos, pageMetaDto);
+	}
+
+	@Override
+	public MeetingDemandV2GetMeetingDemandResponseDto getMeetingDemand(Integer meetingDemandId, Integer userId) {
+		MeetingDemand meetingDemand = meetingDemandRepository.findByIdOrThrow(meetingDemandId);
+		boolean isWaiting = meetingDemandWaitRepository.existsByMeetingDemandIdAndUserId(meetingDemandId, userId);
+		int openedMeetingCount = meetingRepository.countByMeetingDemandId(meetingDemandId);
+
+		return MeetingDemandV2GetMeetingDemandResponseDto.of(meetingDemand, isWaiting, openedMeetingCount);
+	}
+
+	@Override
+	@Transactional
+	public MeetingDemandV2CreateMeetingDemandResponseDto createMeetingDemand(
+		MeetingDemandV2CreateMeetingDemandBodyDto requestBody, Integer userId) {
+		User user = userRepository.findByIdOrThrow(userId);
+		List<MeetingKeywordType> meetingKeywordTypes = toMeetingKeywordTypes(requestBody.getMeetingKeywordTypes());
+
+		MeetingDemand meetingDemand = MeetingDemand.builder()
+			.user(user)
+			.shortIntro(requestBody.getShortIntro())
+			.expectation(requestBody.getExpectation())
+			.meetingKeywordTypes(meetingKeywordTypes)
+			.joinInfo(requestBody.getJoinInfo())
+			.build();
+
+		MeetingDemand savedMeetingDemand = meetingDemandRepository.save(meetingDemand);
+
+		return MeetingDemandV2CreateMeetingDemandResponseDto.of(savedMeetingDemand.getId());
+	}
+
+	@Override
+	@Transactional
+	public void deleteMeetingDemand(Integer meetingDemandId, Integer userId) {
+		MeetingDemand meetingDemand = meetingDemandRepository.findByIdOrThrow(meetingDemandId);
+
+		meetingDemand.validateWriter(userId);
+		meetingDemand.validateBeforeOpen();
+
+		meetingDemandRepository.delete(meetingDemand);
+	}
+
+	private Set<Integer> getWaitingMeetingDemandIds(List<MeetingDemand> meetingDemands, Integer userId) {
+		if (meetingDemands.isEmpty()) {
+			return Set.of();
+		}
+
+		List<Integer> meetingDemandIds = meetingDemands.stream()
+			.map(MeetingDemand::getId)
+			.toList();
+
+		return meetingDemandWaitRepository.findAllByMeetingDemandIdInAndUserId(meetingDemandIds, userId).stream()
+			.map(MeetingDemandWait::getMeetingDemandId)
+			.collect(Collectors.toSet());
+	}
+
+	private MeetingDemandV2GetMeetingDemandsQueryDto adjustPageWhenOutOfRange(
+		MeetingDemandV2GetMeetingDemandsQueryDto queryDto, int totalCount) {
+		if (totalCount == 0) {
+			return new MeetingDemandV2GetMeetingDemandsQueryDto(1, queryDto.getTake());
+		}
+
+		int pageCount = (int)Math.ceil((double)totalCount / queryDto.getTake());
+		int normalizedPage = Math.min(queryDto.getPage(), pageCount);
+
+		return new MeetingDemandV2GetMeetingDemandsQueryDto(normalizedPage, queryDto.getTake());
+	}
+
+	private List<MeetingKeywordType> toMeetingKeywordTypes(List<String> values) {
+		if (values == null || values.isEmpty() || values.size() > MAX_MEETING_KEYWORD_SIZE) {
+			throw new BadRequestException(INVALID_MEETING_KEYWORD_SIZE.getErrorCode());
+		}
+
+		return values.stream()
+			.map(MeetingKeywordType::ofValue)
+			.toList();
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandV2ServiceImpl.java
@@ -22,6 +22,7 @@ import org.sopt.makers.crew.main.meetingdemand.v2.dto.request.MeetingDemandV2Cre
 import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2CreateMeetingDemandResponseDto;
 import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandResponseDto;
 import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2GetMeetingDemandsResponseDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.response.MeetingDemandV2SwitchMeetingDemandWaitResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -107,6 +108,32 @@ public class MeetingDemandV2ServiceImpl implements MeetingDemandV2Service {
 		meetingDemand.validateBeforeOpen();
 
 		meetingDemandRepository.delete(meetingDemand);
+	}
+
+	@Override
+	@Transactional
+	public MeetingDemandV2SwitchMeetingDemandWaitResponseDto switchMeetingDemandWait(
+		Integer meetingDemandId, Integer userId) {
+		MeetingDemand meetingDemand = meetingDemandRepository.findByIdOrThrow(meetingDemandId);
+
+		meetingDemand.validateNotWriter(userId);
+
+		int deletedWaits = meetingDemandWaitRepository.deleteByMeetingDemandIdAndUserId(meetingDemandId, userId);
+		if (deletedWaits == 0) {
+			MeetingDemandWait meetingDemandWait = MeetingDemandWait.builder()
+				.meetingDemandId(meetingDemandId)
+				.userId(userId)
+				.build();
+
+			meetingDemandWaitRepository.save(meetingDemandWait);
+			meetingDemand.increaseWaitCount();
+
+			return MeetingDemandV2SwitchMeetingDemandWaitResponseDto.of(meetingDemand.getWaitCount(), true);
+		}
+
+		meetingDemand.decreaseWaitCount();
+
+		return MeetingDemandV2SwitchMeetingDemandWaitResponseDto.of(meetingDemand.getWaitCount(), false);
 	}
 
 	private Set<Integer> getWaitingMeetingDemandIds(List<MeetingDemand> meetingDemands, Integer userId) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandV2ServiceImpl.java
@@ -61,6 +61,7 @@ public class MeetingDemandV2ServiceImpl implements MeetingDemandV2Service {
 			.map(meetingDemand -> MeetingDemandV2GetMeetingDemandResponseDto.of(
 				meetingDemand,
 				waitingMeetingDemandIds.contains(meetingDemand.getId()),
+				meetingDemand.isWriter(userId),
 				meetingRepository.countByMeetingDemandId(meetingDemand.getId())
 			))
 			.toList();
@@ -76,7 +77,8 @@ public class MeetingDemandV2ServiceImpl implements MeetingDemandV2Service {
 		boolean isWaiting = meetingDemandWaitRepository.existsByMeetingDemandIdAndUserId(meetingDemandId, userId);
 		int openedMeetingCount = meetingRepository.countByMeetingDemandId(meetingDemandId);
 
-		return MeetingDemandV2GetMeetingDemandResponseDto.of(meetingDemand, isWaiting, openedMeetingCount);
+		return MeetingDemandV2GetMeetingDemandResponseDto.of(meetingDemand, isWaiting, meetingDemand.isWriter(userId),
+			openedMeetingCount);
 	}
 
 	@Override

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandV2ServiceImpl.java
@@ -102,11 +102,12 @@ public class MeetingDemandV2ServiceImpl implements MeetingDemandV2Service {
 	@Override
 	@Transactional
 	public void deleteMeetingDemand(Integer meetingDemandId, Integer userId) {
-		MeetingDemand meetingDemand = meetingDemandRepository.findByIdOrThrow(meetingDemandId);
+		MeetingDemand meetingDemand = meetingDemandRepository.findByIdWithPessimisticWriteLockOrThrow(meetingDemandId);
 
 		meetingDemand.validateWriter(userId);
 		meetingDemand.validateBeforeOpen();
 
+		meetingDemandWaitRepository.deleteAllByMeetingDemandId(meetingDemandId);
 		meetingDemandRepository.delete(meetingDemand);
 	}
 
@@ -114,26 +115,27 @@ public class MeetingDemandV2ServiceImpl implements MeetingDemandV2Service {
 	@Transactional
 	public MeetingDemandV2SwitchMeetingDemandWaitResponseDto switchMeetingDemandWait(
 		Integer meetingDemandId, Integer userId) {
-		MeetingDemand meetingDemand = meetingDemandRepository.findByIdOrThrow(meetingDemandId);
+		MeetingDemand meetingDemand = meetingDemandRepository.findByIdWithPessimisticWriteLockOrThrow(meetingDemandId);
 
 		meetingDemand.validateNotWriter(userId);
 
-		int deletedWaits = meetingDemandWaitRepository.deleteByMeetingDemandIdAndUserId(meetingDemandId, userId);
-		if (deletedWaits == 0) {
+		boolean isWaiting = meetingDemandWaitRepository.existsByMeetingDemandIdAndUserId(meetingDemandId, userId);
+		if (isWaiting) {
+			meetingDemandWaitRepository.deleteByMeetingDemandIdAndUserId(meetingDemandId, userId);
+		} else {
 			MeetingDemandWait meetingDemandWait = MeetingDemandWait.builder()
 				.meetingDemandId(meetingDemandId)
 				.userId(userId)
 				.build();
 
 			meetingDemandWaitRepository.save(meetingDemandWait);
-			meetingDemand.increaseWaitCount();
-
-			return MeetingDemandV2SwitchMeetingDemandWaitResponseDto.of(meetingDemand.getWaitCount(), true);
 		}
 
-		meetingDemand.decreaseWaitCount();
+		meetingDemandWaitRepository.flush();
+		long waitCount = meetingDemandWaitRepository.countByMeetingDemandId(meetingDemandId);
+		meetingDemand.syncWaitCount((int)waitCount);
 
-		return MeetingDemandV2SwitchMeetingDemandWaitResponseDto.of(meetingDemand.getWaitCount(), false);
+		return MeetingDemandV2SwitchMeetingDemandWaitResponseDto.of(meetingDemand.getWaitCount(), !isWaiting);
 	}
 
 	private Set<Integer> getWaitingMeetingDemandIds(List<MeetingDemand> meetingDemands, Integer userId) {

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/dto/response/MeetingV2GetCreatedMeetingByUserResponseDto.java
@@ -12,6 +12,7 @@ import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
 import org.sopt.makers.crew.main.entity.meeting.vo.ImageUrlVO;
 import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
 import org.sopt.makers.crew.main.entity.tag.enums.WelcomeMessageType;
+import org.sopt.makers.crew.main.entity.user.User;
 import org.sopt.makers.crew.main.global.dto.MeetingCreatorDto;
 import org.sopt.makers.crew.main.tag.v2.dto.response.TagV2MeetingTagsResponseDto;
 
@@ -109,10 +110,11 @@ public record MeetingV2GetCreatedMeetingByUserResponseDto(
 	@NotNull
 	List<String> meetingKeywordTypes
 ) {
-	public static MeetingV2GetCreatedMeetingByUserResponseDto of(Meeting meeting, boolean isCoLeader, int approvedCount,
-		LocalDateTime now, Integer activeGeneration, Map<Integer, TagV2MeetingTagsResponseDto> allTagsResponseDto) {
+	public static MeetingV2GetCreatedMeetingByUserResponseDto of(Meeting meeting, User meetingCreator,
+		boolean isCoLeader, int approvedCount, LocalDateTime now, Integer activeGeneration,
+		Map<Integer, TagV2MeetingTagsResponseDto> allTagsResponseDto) {
 
-		MeetingCreatorDto creatorDto = MeetingCreatorDto.from(meeting.getUser());
+		MeetingCreatorDto creatorDto = MeetingCreatorDto.from(meetingCreator);
 		boolean canJoinOnlyActiveGeneration = Objects.equals(meeting.getTargetActiveGeneration(), activeGeneration)
 			&& meeting.getCanJoinOnlyActiveGeneration();
 

--- a/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/user/v2/service/UserV2ServiceImpl.java
@@ -125,10 +125,14 @@ public class UserV2ServiceImpl implements UserV2Service {
 
 		Map<Integer, TagV2MeetingTagsResponseDto> allTagsResponseDto = tagV2Service.getMeetingTagsByMeetingIds(
 			myMeetingIds);
+		Map<Integer, User> userMap = getUsersById(myMeetings.stream()
+			.map(Meeting::getUserId)
+			.toList());
 
 		List<MeetingV2GetCreatedMeetingByUserResponseDto> meetingByUserDtos = myMeetings.stream()
 			.map(meeting -> MeetingV2GetCreatedMeetingByUserResponseDto.of(
 				meeting,
+				userMap.get(meeting.getUserId()),
 				coLeaders.isCoLeader(meeting.getId(), userId),
 				applies.getApprovedCount(meeting.getId()),
 				time.now(),
@@ -151,6 +155,12 @@ public class UserV2ServiceImpl implements UserV2Service {
 
 		Map<Integer, TagV2MeetingTagsResponseDto> allTagsResponseDto = tagV2Service.getMeetingTagsByMeetingIds(
 			meetingIds);
+		List<Meeting> appliedMeetings = myApplies.stream()
+			.map(Apply::getMeeting)
+			.toList();
+		Map<Integer, User> userMap = getUsersById(appliedMeetings.stream()
+			.map(Meeting::getUserId)
+			.toList());
 
 		List<ApplyV2GetAppliedMeetingByUserResponseDto> appliedMeetingByUserDtos = myApplies.stream()
 			.map(apply -> ApplyV2GetAppliedMeetingByUserResponseDto.of(
@@ -158,6 +168,7 @@ public class UserV2ServiceImpl implements UserV2Service {
 				apply.getStatus().getValue(),
 				MeetingV2GetCreatedMeetingByUserResponseDto.of(
 					apply.getMeeting(),
+					userMap.get(apply.getMeeting().getUserId()),
 					false,
 					allApplies.getApprovedCount(apply.getMeetingId()),
 					time.now(),
@@ -167,6 +178,14 @@ public class UserV2ServiceImpl implements UserV2Service {
 			.toList();
 
 		return UserV2GetAppliedMeetingByUserResponseDto.from(appliedMeetingByUserDtos);
+	}
+
+	private Map<Integer, User> getUsersById(List<Integer> userIds) {
+		return userRepository.findAllById(userIds.stream()
+				.distinct()
+				.toList())
+			.stream()
+			.collect(Collectors.toMap(User::getId, user -> user));
 	}
 
 	@Override

--- a/main/src/main/resources/schema.sql
+++ b/main/src/main/resources/schema.sql
@@ -48,6 +48,8 @@ create table if not exists meeting_demand
     "shortIntro"          varchar(30)          not null,
     expectation           varchar(1000)        not null,
     status                varchar              not null default 'BEFORE_OPEN',
+    "anonymousNickname"   varchar(30)          not null,
+    "anonymousImageNumber" integer             not null,
     "meetingKeywordTypes" jsonb                not null,
     "joinInfo"            jsonb                not null,
     "waitCount"           integer              not null default 0,

--- a/main/src/main/resources/schema.sql
+++ b/main/src/main/resources/schema.sql
@@ -5,6 +5,8 @@ drop table if exists "like" cascade;
 drop table if exists "tag" cascade;
 drop table if exists "flash" cascade;
 drop table if exists "post" cascade;
+drop table if exists "meeting_demand_wait" cascade;
+drop table if exists "meeting_demand" cascade;
 drop table if exists "meeting" cascade;
 drop table if exists "notice" cascade;
 drop table if exists "report" cascade;
@@ -35,6 +37,49 @@ create table if not exists "user"
     "modifiedTimestamp"    timestamp default CURRENT_TIMESTAMP
 );
 
+create table if not exists meeting_demand
+(
+    id                    serial
+    primary key,
+    "userId"              integer              not null
+    constraint fk_meeting_demand_user
+    references "user"
+    on delete cascade,
+    "shortIntro"          varchar(30)          not null,
+    expectation           varchar(1000)        not null,
+    status                varchar              not null default 'BEFORE_OPEN',
+    "meetingKeywordTypes" jsonb                not null,
+    "joinInfo"            jsonb                not null,
+    "waitCount"           integer              not null default 0,
+    "commentCount"        integer              not null default 0,
+    "createdTimestamp"    timestamp default CURRENT_TIMESTAMP,
+    "modifiedTimestamp"   timestamp default CURRENT_TIMESTAMP
+);
+
+create table if not exists meeting_demand_wait
+(
+    id                 serial
+    primary key,
+    "meetingDemandId"  integer              not null
+    constraint fk_meeting_demand_wait_demand
+    references meeting_demand
+    on delete cascade,
+    "userId"           integer              not null
+    constraint fk_meeting_demand_wait_user
+    references "user"
+    on delete cascade,
+    "createdTimestamp" timestamp default CURRENT_TIMESTAMP,
+    "modifiedTimestamp" timestamp default CURRENT_TIMESTAMP,
+    constraint "UQ_meeting_demand_wait_demand_user"
+    unique ("meetingDemandId", "userId")
+);
+
+create index if not exists "meeting_demand_status_created_index"
+    on meeting_demand (status, "createdTimestamp" desc, id desc);
+
+create index if not exists "meeting_demand_wait_user_index"
+    on meeting_demand_wait ("userId");
+
 create table if not exists meeting
 (
     id                            serial
@@ -46,6 +91,9 @@ create table if not exists meeting
     constraint "FK_854982a74818bb6307419e0e6b8"
     references "user"
     on delete cascade,
+    "meetingDemandId"             integer
+    constraint fk_meeting_meeting_demand
+    references meeting_demand,
     title                         varchar   not null,
     "subTitle"                    varchar,
     category                      varchar   not null,
@@ -68,6 +116,9 @@ create table if not exists meeting
     "createdTimestamp"    timestamp default CURRENT_TIMESTAMP,
     "modifiedTimestamp"    timestamp default CURRENT_TIMESTAMP
 );
+
+create index if not exists "meeting_meeting_demand_index"
+    on meeting ("meetingDemandId");
 
 create table if not exists co_leader
 (

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/repository/MeetingRepositoryTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/repository/MeetingRepositoryTest.java
@@ -75,12 +75,11 @@ public class MeetingRepositoryTest {
 		Assertions.assertThat(savedMeeting)
 			.isNotNull()
 			.extracting(
-				"user", "userId", "title", "category", "imageURL", "startDate", "endDate", "capacity", "desc",
+				"userId", "title", "category", "imageURL", "startDate", "endDate", "capacity", "desc",
 				"processDesc", "mStartDate", "mEndDate", "leaderDesc", "note", "isMentorNeeded",
 				"canJoinOnlyActiveGeneration", "createdGeneration", "targetActiveGeneration", "joinableParts"
 			)
 			.containsExactly(
-				savedUser,  // user 필드
 				savedUser.getId(),  // userId 필드
 				"Backend 개발 스터디",  // title 필드
 				MeetingCategory.STUDY,  // category 필드

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -233,12 +233,11 @@ public class MeetingV2ServiceTest {
 			Assertions.assertThat(foundMeeting)
 				.isNotNull()
 				.extracting(
-					"user", "userId", "title", "subTitle", "category", "startDate", "endDate", "capacity", "desc",
+					"userId", "title", "subTitle", "category", "startDate", "endDate", "capacity", "desc",
 					"processDesc", "mStartDate", "mEndDate", "leaderDesc", "note", "isMentorNeeded",
 					"canJoinOnlyActiveGeneration", "joinInfo", "createdGeneration", "targetActiveGeneration", "joinableParts"
 				)
 				.containsExactly(
-					savedUser,  // user 필드
 					savedUser.getId(),  // userId 필드
 					"알고보면 쓸데있는 개발 프로세스",  // title 필드
 					"백엔드 실전 설계부터 배포까지", // subTitle 필드

--- a/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceTest.java
@@ -217,6 +217,7 @@ public class MeetingV2ServiceTest {
 				canJoinOnlyActiveGeneration, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
 				joinInfo, // joinInfo (참여 정보)
 				joinableParts, // joinableParts (대상 파트 목록)
+				null, // meetingDemandId (개설 기반 모임 수요 id)
 				null, // coLeaders (공동모임장 리스트)
 				meetingKeywordTypes // meetingKeywordTypes (모임 키워드 태그 리스트)
 			);
@@ -337,6 +338,7 @@ public class MeetingV2ServiceTest {
 				true, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
 				joinInfo, // joinInfo (참여 정보)
 				joinableParts, // joinableParts (대상 파트 목록)
+				null, // meetingDemandId (개설 기반 모임 수요 id)
 				List.of(savedJointLeader1.getId(), savedJointLeader2.getId()), // coLeaders (공동모임장 리스트)
 				meetingKeywordTypes // meetingKeywordTypes (모임 키워드 태그 리스트)
 			);
@@ -412,6 +414,7 @@ public class MeetingV2ServiceTest {
 				true, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
 				joinInfo, // joinInfo (참여 정보)
 				joinableParts, // joinableParts (대상 파트 목록)
+				null, // meetingDemandId (개설 기반 모임 수요 id)
 				List.of(0, Integer.MAX_VALUE), // coLeaders (공동모임장 리스트)
 				meetingKeywordTypes // meetingKeywordTypes (모임 키워드 태그 리스트)
 			);
@@ -475,6 +478,7 @@ public class MeetingV2ServiceTest {
 				true, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
 				joinInfo, // joinInfo (참여 정보)
 				joinableParts, // joinableParts (대상 파트 목록)
+				null, // meetingDemandId (개설 기반 모임 수요 id)
 				List.of(savedUser.getId()), // coLeaders (공동모임장 리스트)
 				meetingKeywordTypes // meetingKeywordTypes (모임 키워드 태그 리스트)
 			);
@@ -538,6 +542,7 @@ public class MeetingV2ServiceTest {
 				false, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
 				joinInfo, // joinInfo (참여 정보)
 				joinableParts, // joinableParts (대상 파트 목록)
+				null, // meetingDemandId (개설 기반 모임 수요 id)
 				null, // coLeaders (공동모임장 리스트)
 				meetingKeywordTypes // meetingKeywordTypes (모임 키워드 태그 리스트)
 			);
@@ -595,6 +600,7 @@ public class MeetingV2ServiceTest {
 				false, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
 				joinInfo, // joinInfo (참여 정보)
 				joinableParts, // joinableParts (대상 파트 목록)
+				null, // meetingDemandId (개설 기반 모임 수요 id)
 				null, // coLeaders (공동모임장 리스트)
 				meetingKeywordTypes // meetingKeywordTypes (모임 키워드 태그 리스트)
 			);
@@ -653,6 +659,7 @@ public class MeetingV2ServiceTest {
 				false, // canJoinOnlyActiveGeneration (활동기수만 지원 가능 여부)
 				joinInfo, // joinInfo (참여 정보)
 				joinableParts, // joinableParts (대상 파트 목록)
+				null, // meetingDemandId (개설 기반 모임 수요 id)
 				null, // coLeaders (공동모임장 리스트)
 				meetingKeywordTypes // meetingKeywordTypes (모임 키워드 태그 리스트)
 			);


### PR DESCRIPTION
## 👩‍💻 Contents

- 모임 수요 도메인 및 스키마 추가
- 모임 수요 조회/상세/생성/삭제 API 구현
- 모임 수요 기다려요 토글 API 구현
- 기존 모임 개설 API에 `meetingDemandId` 연동

## 📝 Review Note

모임 수요 리스트는 개설 전 상태의 수요만 노출하도록 구현했어요

- 정렬 기준: `createdTimestamp DESC`, `id DESC`
- 기본 조회 개수: `take = 3`

`isMine`은 현재 로그인 유저가 해당 모임 수요 작성자인지 판단하기 위한 필드이고, 프론트에서는 이 값을 기준으로 본인이 작성한 모임 수요에는 삭제/수정 등의 기능을 노출하고, 다른 사람이 작성한 모임 수요에는 신고하기 노출 여부를 판단할 수 있어요

`openedMeetingCount`는 해당 수요를 기반으로 개설된 모임 수인데요, 프론트에서는 이 값을 기준으로 CTA 문구를 판단할 수 있습니다
- `openedMeetingCount = 0`: 열어볼래요
- `openedMeetingCount >= 1`: 나도 열어볼래요

하나의 모임 수요에서 여러 모임이 개설될 수 있도록, `meeting_demand`가 특정 `meetingId`를 직접 들고 있지 않게 설계한 대신에 실제 개설된 `meeting`이 nullable `meetingDemandId`를 가지고, `openedMeetingCount`는 `meeting.meetingDemandId` 기준으로 계산해주었어요

---

익명 프로필 정책은 아래와 같아요

모임 수요 생성 시 익명 프로필을 함께 생성
- `anonymousNickname`: 형용사 32개 중 랜덤 1개 + 명사 32개 중 랜덤 1개 조합
- 예: `성실한 판다`
- `anonymousImageNumber`: 1~5 중 랜덤 저장
- 응답에서는 `anonymousImageNumber`를 기반으로 서버에서 `anonymousImageUrl`을 조립해서 내려줍니다 (기획단에서 전달해준 이미지)

---

기다려요는 좋아요처럼 한 엔드포인트에서 현재 상태를 반전하는 토글 방식으로 구현했어요


## 📣 Related Issue

- closed #897 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?