### PR TITLE
feat: 모임 수요 게시글 관련 푸시 알림 추가

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/MainApplication.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/MainApplication.java
@@ -5,11 +5,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAspectJAutoProxy
 @EnableFeignClients
 @ConfigurationPropertiesScan
+@EnableScheduling
 public class MainApplication {
 
 	public static void main(String[] args) {

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandOpenedNotification.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandOpenedNotification.java
@@ -1,0 +1,50 @@
+package org.sopt.makers.crew.main.entity.meetingdemand;
+
+import java.time.LocalDateTime;
+
+import org.sopt.makers.crew.main.entity.common.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "meeting_demand_opened_notification",
+	uniqueConstraints = @UniqueConstraint(
+		name = "UQ_meeting_demand_opened_notification_meeting",
+		columnNames = {"meetingId"}
+	))
+public class MeetingDemandOpenedNotification extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
+	@Column(nullable = false)
+	private Integer meetingId;
+
+	private LocalDateTime sentAt;
+
+	@Builder
+	public MeetingDemandOpenedNotification(Integer meetingId) {
+		this.meetingId = meetingId;
+	}
+
+	public boolean isSent() {
+		return sentAt != null;
+	}
+
+	public void markSent(LocalDateTime sentAt) {
+		this.sentAt = sentAt;
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandOpenedNotificationRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandOpenedNotificationRepository.java
@@ -1,0 +1,24 @@
+package org.sopt.makers.crew.main.entity.meetingdemand;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MeetingDemandOpenedNotificationRepository
+	extends JpaRepository<MeetingDemandOpenedNotification, Integer> {
+
+	Optional<MeetingDemandOpenedNotification> findByMeetingId(Integer meetingId);
+
+	@Query("SELECT n "
+		+ "FROM MeetingDemandOpenedNotification n "
+		+ "JOIN Meeting m ON m.id = n.meetingId "
+		+ "WHERE n.sentAt IS NULL "
+		+ "AND m.meetingDemandId IS NOT NULL "
+		+ "AND m.startDate <= :now "
+		+ "AND m.endDate > :now")
+	List<MeetingDemandOpenedNotification> findAllUnsentApplyAble(@Param("now") LocalDateTime now);
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandWaitHistory.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandWaitHistory.java
@@ -1,0 +1,42 @@
+package org.sopt.makers.crew.main.entity.meetingdemand;
+
+import org.sopt.makers.crew.main.entity.common.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "meeting_demand_wait_history",
+	uniqueConstraints = @UniqueConstraint(
+		name = "UQ_meeting_demand_wait_history_demand_user",
+		columnNames = {"meetingDemandId", "userId"}
+	))
+public class MeetingDemandWaitHistory extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
+	@Column(nullable = false)
+	private Integer meetingDemandId;
+
+	@Column(nullable = false)
+	private Integer userId;
+
+	@Builder
+	public MeetingDemandWaitHistory(Integer meetingDemandId, Integer userId) {
+		this.meetingDemandId = meetingDemandId;
+		this.userId = userId;
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandWaitHistoryRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandWaitHistoryRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.makers.crew.main.entity.meetingdemand;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MeetingDemandWaitHistoryRepository extends JpaRepository<MeetingDemandWaitHistory, Integer> {
+
+	boolean existsByMeetingDemandIdAndUserId(Integer meetingDemandId, Integer userId);
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandWaitRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemand/MeetingDemandWaitRepository.java
@@ -3,6 +3,8 @@ package org.sopt.makers.crew.main.entity.meetingdemand;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MeetingDemandWaitRepository extends JpaRepository<MeetingDemandWait, Integer> {
 
@@ -13,6 +15,9 @@ public interface MeetingDemandWaitRepository extends JpaRepository<MeetingDemand
 	void deleteAllByMeetingDemandId(Integer meetingDemandId);
 
 	long countByMeetingDemandId(Integer meetingDemandId);
+
+	@Query("SELECT w.userId FROM MeetingDemandWait w WHERE w.meetingDemandId = :meetingDemandId")
+	List<Integer> findUserIdsByMeetingDemandId(@Param("meetingDemandId") Integer meetingDemandId);
 
 	List<MeetingDemandWait> findAllByMeetingDemandIdInAndUserId(List<Integer> meetingDemandIds, Integer userId);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemandcomment/MeetingDemandCommentRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemandcomment/MeetingDemandCommentRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface MeetingDemandCommentRepository extends JpaRepository<MeetingDemandComment, Integer> {
@@ -34,6 +35,12 @@ public interface MeetingDemandCommentRepository extends JpaRepository<MeetingDem
 	}
 
 	List<MeetingDemandComment> findAllByMeetingDemandIdOrderByCreatedTimestampAsc(Integer meetingDemandId);
+
+	@Query("SELECT DISTINCT c.userId "
+		+ "FROM MeetingDemandComment c "
+		+ "WHERE c.meetingDemandId = :meetingDemandId "
+		+ "AND c.userId IS NOT NULL")
+	List<Integer> findDistinctUserIdsByMeetingDemandId(@Param("meetingDemandId") Integer meetingDemandId);
 
 	Page<MeetingDemandComment> findAllByMeetingDemandIdAndDepth(Integer meetingDemandId, int depth, Pageable pageable);
 

--- a/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meeting/v2/service/MeetingV2ServiceImpl.java
@@ -100,6 +100,7 @@ import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingBann
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingByIdResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetMeetingPartMembersResponseDto;
 import org.sopt.makers.crew.main.meeting.v2.dto.response.MeetingV2GetRecommendDto;
+import org.sopt.makers.crew.main.meetingdemand.v2.service.MeetingDemandOpenedNotificationService;
 import org.sopt.makers.crew.main.tag.v2.dto.response.TagV2CreateGeneralMeetingTagResponseDto;
 import org.sopt.makers.crew.main.tag.v2.dto.response.TagV2MeetingTagsResponseDto;
 import org.sopt.makers.crew.main.tag.v2.service.TagV2Service;
@@ -151,6 +152,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 	private final MeetingApplyValidator meetingApplyValidator;
 	private final MeetingParticipationFactory meetingParticipationFactory;
 	private final MeetingCoLeaderFactory meetingCoLeaderFactory;
+	private final MeetingDemandOpenedNotificationService meetingDemandOpenedNotificationService;
 
 	private final ImageSettingProperties imageSettingProperties;
 	private final ActiveGenerationProvider activeGenerationProvider;
@@ -245,6 +247,7 @@ public class MeetingV2ServiceImpl implements MeetingV2Service {
 		}
 
 		Meeting savedMeeting = meetingRepository.save(meeting);
+		meetingDemandOpenedNotificationService.register(savedMeeting);
 
 		List<Integer> coLeaderUserIds = requestBody.getCoLeaderUserIds();
 		if (coLeaderUserIds != null && !coLeaderUserIds.isEmpty()) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/dto/event/MeetingDemandOpenedNotificationEvent.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/dto/event/MeetingDemandOpenedNotificationEvent.java
@@ -1,0 +1,4 @@
+package org.sopt.makers.crew.main.meetingdemand.v2.dto.event;
+
+public record MeetingDemandOpenedNotificationEvent(Integer meetingId) {
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandNotificationSender.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandNotificationSender.java
@@ -1,0 +1,90 @@
+package org.sopt.makers.crew.main.meetingdemand.v2.service;
+
+import static org.sopt.makers.crew.main.external.notification.PushNotificationEnums.PUSH_NOTIFICATION_CATEGORY;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemand;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandRepository;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandWaitRepository;
+import org.sopt.makers.crew.main.entity.meetingdemandcomment.MeetingDemandCommentRepository;
+import org.sopt.makers.crew.main.external.notification.PushNotificationService;
+import org.sopt.makers.crew.main.external.notification.dto.request.PushNotificationRequestDto;
+import org.sopt.makers.crew.main.global.config.PushNotificationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MeetingDemandNotificationSender {
+
+	private static final String MEETING_DEMAND_OPENED_TITLE = "기다리던 모임이 열렸어요";
+	private static final String MEETING_DEMAND_OPENED_CONTENT = "관심을 보였던 수요가 모임으로 개설됐어요.";
+	private static final String MEETING_DEMAND_WAIT_TITLE = "내가 만든 모임 수요를 기다리는 사람이 생겼어요";
+	private static final String MEETING_DEMAND_WAIT_CONTENT = "수요에 관심을 보인 멤버가 있어요.";
+	private static final String MEETING_DETAIL_WEB_LINK_FORMAT = "%s/detail?id=%d";
+	private static final String MEETING_DEMAND_WEB_LINK_FORMAT = "%s/meeting-demand?id=%d";
+
+	private final MeetingDemandRepository meetingDemandRepository;
+	private final MeetingDemandCommentRepository meetingDemandCommentRepository;
+	private final MeetingDemandWaitRepository meetingDemandWaitRepository;
+	private final PushNotificationService pushNotificationService;
+	private final PushNotificationProperties pushNotificationProperties;
+
+	public void sendOpenedMeetingNotification(Meeting meeting) {
+		MeetingDemand meetingDemand = meetingDemandRepository.findByIdOrThrow(meeting.getMeetingDemandId());
+		String[] receiverUserIds = getOpenedMeetingReceiverUserIds(meetingDemand, meeting.getUserId());
+		if (receiverUserIds.length == 0) {
+			return;
+		}
+
+		pushNotificationService.sendPushNotification(PushNotificationRequestDto.of(
+			receiverUserIds,
+			MEETING_DEMAND_OPENED_TITLE,
+			MEETING_DEMAND_OPENED_CONTENT,
+			PUSH_NOTIFICATION_CATEGORY.getValue(),
+			createMeetingDetailWebLink(meeting.getId())
+		));
+	}
+
+	public void sendWaitNotification(MeetingDemand meetingDemand) {
+		pushNotificationService.sendPushNotification(PushNotificationRequestDto.of(
+			new String[] {String.valueOf(meetingDemand.getUserId())},
+			MEETING_DEMAND_WAIT_TITLE,
+			MEETING_DEMAND_WAIT_CONTENT,
+			PUSH_NOTIFICATION_CATEGORY.getValue(),
+			createMeetingDemandWebLink(meetingDemand.getId())
+		));
+	}
+
+	private String[] getOpenedMeetingReceiverUserIds(MeetingDemand meetingDemand, Integer meetingLeaderUserId) {
+		Set<Integer> receiverUserIds = new LinkedHashSet<>();
+		receiverUserIds.add(meetingDemand.getUserId());
+		receiverUserIds.addAll(getCommentWriterUserIds(meetingDemand.getId()));
+		receiverUserIds.addAll(meetingDemandWaitRepository.findUserIdsByMeetingDemandId(meetingDemand.getId()));
+		receiverUserIds.removeIf(Objects::isNull);
+		receiverUserIds.remove(meetingLeaderUserId);
+
+		return receiverUserIds.stream()
+			.map(String::valueOf)
+			.toArray(String[]::new);
+	}
+
+	private List<Integer> getCommentWriterUserIds(Integer meetingDemandId) {
+		return meetingDemandCommentRepository.findDistinctUserIdsByMeetingDemandId(meetingDemandId);
+	}
+
+	private String createMeetingDetailWebLink(Integer meetingId) {
+		return String.format(MEETING_DETAIL_WEB_LINK_FORMAT, pushNotificationProperties.getPushWebUrl(), meetingId);
+	}
+
+	private String createMeetingDemandWebLink(Integer meetingDemandId) {
+		return String.format(MEETING_DEMAND_WEB_LINK_FORMAT, pushNotificationProperties.getPushWebUrl(),
+			meetingDemandId);
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandOpenedNotificationEventListener.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandOpenedNotificationEventListener.java
@@ -1,0 +1,22 @@
+package org.sopt.makers.crew.main.meetingdemand.v2.service;
+
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.event.MeetingDemandOpenedNotificationEvent;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MeetingDemandOpenedNotificationEventListener {
+
+	private final MeetingDemandOpenedNotificationService meetingDemandOpenedNotificationService;
+
+	@Async("taskExecutor")
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleMeetingDemandOpenedNotificationEvent(MeetingDemandOpenedNotificationEvent event) {
+		meetingDemandOpenedNotificationService.sendNotification(event.meetingId());
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandOpenedNotificationScheduler.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandOpenedNotificationScheduler.java
@@ -1,0 +1,20 @@
+package org.sopt.makers.crew.main.meetingdemand.v2.service;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@Profile({"local", "dev", "prod", "traffic", "lambda-dev"})
+@RequiredArgsConstructor
+public class MeetingDemandOpenedNotificationScheduler {
+
+	private final MeetingDemandOpenedNotificationService meetingDemandOpenedNotificationService;
+
+	@Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
+	public void sendPendingNotifications() {
+		meetingDemandOpenedNotificationService.sendPendingNotifications();
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandOpenedNotificationService.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandOpenedNotificationService.java
@@ -1,0 +1,91 @@
+package org.sopt.makers.crew.main.meetingdemand.v2.service;
+
+import java.time.LocalDateTime;
+
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
+import org.sopt.makers.crew.main.entity.meeting.enums.EnMeetingStatus;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandOpenedNotification;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandOpenedNotificationRepository;
+import org.sopt.makers.crew.main.external.notification.event.NotificationTimeValidator;
+import org.sopt.makers.crew.main.global.util.Time;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.event.MeetingDemandOpenedNotificationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingDemandOpenedNotificationService {
+
+	private final MeetingDemandOpenedNotificationRepository meetingDemandOpenedNotificationRepository;
+	private final MeetingRepository meetingRepository;
+	private final MeetingDemandNotificationSender meetingDemandNotificationSender;
+	private final ApplicationEventPublisher eventPublisher;
+	private final Time time;
+
+	@Transactional
+	public void register(Meeting meeting) {
+		if (meeting.getMeetingDemandId() == null) {
+			return;
+		}
+
+		LocalDateTime now = time.now();
+		EnMeetingStatus meetingStatus = meeting.getMeetingStatus(now);
+		if (EnMeetingStatus.RECRUITMENT_COMPLETE.equals(meetingStatus)) {
+			return;
+		}
+
+		MeetingDemandOpenedNotification notification = findOrCreate(meeting.getId());
+		if (!notification.isSent()
+			&& EnMeetingStatus.APPLY_ABLE.equals(meetingStatus)
+			&& NotificationTimeValidator.isPublishedTime(now)) {
+			eventPublisher.publishEvent(new MeetingDemandOpenedNotificationEvent(meeting.getId()));
+		}
+	}
+
+	@Transactional
+	public void sendNotification(Integer meetingId) {
+		LocalDateTime now = time.now();
+		if (!NotificationTimeValidator.isPublishedTime(now)) {
+			return;
+		}
+
+		MeetingDemandOpenedNotification notification = meetingDemandOpenedNotificationRepository
+			.findByMeetingId(meetingId)
+			.orElse(null);
+		if (notification == null || notification.isSent()) {
+			return;
+		}
+
+		Meeting meeting = meetingRepository.findByIdOrThrow(meetingId);
+		if (!EnMeetingStatus.APPLY_ABLE.equals(meeting.getMeetingStatus(now))) {
+			return;
+		}
+
+		meetingDemandNotificationSender.sendOpenedMeetingNotification(meeting);
+		notification.markSent(now);
+	}
+
+	@Transactional
+	public void sendPendingNotifications() {
+		LocalDateTime now = time.now();
+		if (!NotificationTimeValidator.isPublishedTime(now)) {
+			return;
+		}
+
+		meetingDemandOpenedNotificationRepository.findAllUnsentApplyAble(now)
+			.forEach(notification -> sendNotification(notification.getMeetingId()));
+	}
+
+	private MeetingDemandOpenedNotification findOrCreate(Integer meetingId) {
+		return meetingDemandOpenedNotificationRepository.findByMeetingId(meetingId)
+			.orElseGet(() -> meetingDemandOpenedNotificationRepository.save(
+				MeetingDemandOpenedNotification.builder()
+					.meetingId(meetingId)
+					.build()
+			));
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandV2ServiceImpl.java
@@ -13,6 +13,8 @@ import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
 import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemand;
 import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandRepository;
 import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandWait;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandWaitHistory;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandWaitHistoryRepository;
 import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandWaitRepository;
 import org.sopt.makers.crew.main.entity.report.Report;
 import org.sopt.makers.crew.main.entity.report.ReportRepository;
@@ -49,10 +51,12 @@ public class MeetingDemandV2ServiceImpl implements MeetingDemandV2Service {
 	private final UserRepository userRepository;
 	private final MeetingDemandRepository meetingDemandRepository;
 	private final MeetingDemandWaitRepository meetingDemandWaitRepository;
+	private final MeetingDemandWaitHistoryRepository meetingDemandWaitHistoryRepository;
 	private final MeetingRepository meetingRepository;
 	private final ReportRepository reportRepository;
 	private final MeetingDemandFactory meetingDemandFactory;
 	private final MeetingDemandPageNormalizer meetingDemandPageNormalizer;
+	private final MeetingDemandNotificationSender meetingDemandNotificationSender;
 
 	@Override
 	public MeetingDemandV2GetMeetingDemandsResponseDto getMeetingDemands(
@@ -155,6 +159,7 @@ public class MeetingDemandV2ServiceImpl implements MeetingDemandV2Service {
 				.build();
 
 			meetingDemandWaitRepository.save(meetingDemandWait);
+			sendFirstWaitNotificationIfNeeded(meetingDemand, meetingDemandId, userId);
 		}
 
 		meetingDemandWaitRepository.flush();
@@ -213,5 +218,21 @@ public class MeetingDemandV2ServiceImpl implements MeetingDemandV2Service {
 
 		return userRepository.findAllById(userIds).stream()
 			.collect(Collectors.toMap(User::getId, user -> user));
+	}
+
+	private void sendFirstWaitNotificationIfNeeded(MeetingDemand meetingDemand, Integer meetingDemandId,
+		Integer userId) {
+		boolean hasWaitHistory = meetingDemandWaitHistoryRepository.existsByMeetingDemandIdAndUserId(meetingDemandId,
+			userId);
+		if (hasWaitHistory) {
+			return;
+		}
+
+		MeetingDemandWaitHistory waitHistory = MeetingDemandWaitHistory.builder()
+			.meetingDemandId(meetingDemandId)
+			.userId(userId)
+			.build();
+		meetingDemandWaitHistoryRepository.save(waitHistory);
+		meetingDemandNotificationSender.sendWaitNotification(meetingDemand);
 	}
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentNotificationSender.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentNotificationSender.java
@@ -3,13 +3,11 @@ package org.sopt.makers.crew.main.meetingdemandcomment.v2.service;
 import static org.sopt.makers.crew.main.external.notification.PushNotificationEnums.PUSH_NOTIFICATION_CATEGORY;
 
 import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemand;
-import org.sopt.makers.crew.main.entity.meetingdemandcomment.MeetingDemandComment;
 import org.sopt.makers.crew.main.entity.meetingdemandcomment.MeetingDemandCommentProfile;
 import org.sopt.makers.crew.main.external.notification.PushNotificationService;
 import org.sopt.makers.crew.main.external.notification.dto.request.PushNotificationRequestDto;
 import org.sopt.makers.crew.main.global.config.PushNotificationProperties;
 import org.sopt.makers.crew.main.global.util.MentionSecretStringRemover;
-import org.sopt.makers.crew.main.meetingdemandcomment.v2.dto.request.MeetingDemandCommentV2CreateCommentBodyDto;
 import org.sopt.makers.crew.main.meetingdemandcomment.v2.dto.request.MeetingDemandCommentV2MentionUserInCommentRequestDto;
 import org.springframework.stereotype.Component;
 
@@ -19,33 +17,25 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MeetingDemandCommentNotificationSender {
 
-	private static final String MEETING_DEMAND_COMMENT_TITLE = "나의 모임 수요에 새로운 댓글이 달렸어요";
-	private static final String MEETING_DEMAND_REPLY_TITLE = "나의 모임 수요 댓글에 새로운 답글이 달렸어요";
+	private static final String MEETING_DEMAND_COMMENT_TITLE = "내가 만든 모임 수요에 댓글이 달렸어요";
+	private static final String MEETING_DEMAND_COMMENT_CONTENT = "새로운 댓글이 달렸어요.";
 	private static final String MEETING_DEMAND_MENTION_TITLE_FORMAT = "%s님이 회원님을 언급했어요";
 	private static final String MEETING_DEMAND_WEB_LINK_FORMAT = "%s/meeting-demand?id=%d";
 
 	private final PushNotificationService pushNotificationService;
 	private final PushNotificationProperties pushNotificationProperties;
 
-	public void sendCommentNotification(MeetingDemandCommentV2CreateCommentBodyDto requestBody,
-		MeetingDemand meetingDemand, MeetingDemandComment parentComment, MeetingDemandCommentProfile writerProfile) {
-		boolean isReplyComment = !requestBody.getIsParent();
-		Integer receiverUserId = isReplyComment ? getReplyReceiverUserId(parentComment) : meetingDemand.getUserId();
-		if (receiverUserId == null) {
+	public void sendCommentNotification(MeetingDemand meetingDemand, Integer writerUserId) {
+		if (writerUserId == null || meetingDemand.isWriter(writerUserId)) {
 			return;
 		}
 
-		String title = isReplyComment ? MEETING_DEMAND_REPLY_TITLE : MEETING_DEMAND_COMMENT_TITLE;
-		String commentType = isReplyComment ? "답글" : "댓글";
-		String secretStringRemovedContent = MentionSecretStringRemover.removeSecretString(requestBody.getContents());
-		String pushNotificationContent = String.format("[%s의 %s] : \"%s\"",
-			writerProfile.getAnonymousNickname(), commentType, secretStringRemovedContent);
 		String webLink = createMeetingDemandWebLink(meetingDemand.getId());
 
 		PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(
-			new String[] {String.valueOf(receiverUserId)},
-			title,
-			pushNotificationContent,
+			new String[] {String.valueOf(meetingDemand.getUserId())},
+			MEETING_DEMAND_COMMENT_TITLE,
+			MEETING_DEMAND_COMMENT_CONTENT,
 			PUSH_NOTIFICATION_CATEGORY.getValue(),
 			webLink
 		);
@@ -72,14 +62,6 @@ public class MeetingDemandCommentNotificationSender {
 		);
 
 		pushNotificationService.sendPushNotification(pushRequestDto);
-	}
-
-	private Integer getReplyReceiverUserId(MeetingDemandComment parentComment) {
-		if (parentComment == null) {
-			return null;
-		}
-
-		return parentComment.getUserId();
 	}
 
 	private String createMeetingDemandWebLink(Integer meetingDemandId) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentNotificationSender.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentNotificationSender.java
@@ -3,13 +3,9 @@ package org.sopt.makers.crew.main.meetingdemandcomment.v2.service;
 import static org.sopt.makers.crew.main.external.notification.PushNotificationEnums.PUSH_NOTIFICATION_CATEGORY;
 
 import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemand;
-import org.sopt.makers.crew.main.entity.meetingdemandcomment.MeetingDemandComment;
-import org.sopt.makers.crew.main.entity.meetingdemandcomment.MeetingDemandCommentProfile;
 import org.sopt.makers.crew.main.external.notification.PushNotificationService;
 import org.sopt.makers.crew.main.external.notification.dto.request.PushNotificationRequestDto;
 import org.sopt.makers.crew.main.global.config.PushNotificationProperties;
-import org.sopt.makers.crew.main.global.util.MentionSecretStringRemover;
-import org.sopt.makers.crew.main.meetingdemandcomment.v2.dto.request.MeetingDemandCommentV2CreateCommentBodyDto;
 import org.sopt.makers.crew.main.meetingdemandcomment.v2.dto.request.MeetingDemandCommentV2MentionUserInCommentRequestDto;
 import org.springframework.stereotype.Component;
 
@@ -19,33 +15,24 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MeetingDemandCommentNotificationSender {
 
-	private static final String MEETING_DEMAND_COMMENT_TITLE = "나의 모임 수요에 새로운 댓글이 달렸어요";
-	private static final String MEETING_DEMAND_REPLY_TITLE = "나의 모임 수요 댓글에 새로운 답글이 달렸어요";
-	private static final String MEETING_DEMAND_MENTION_TITLE_FORMAT = "%s님이 회원님을 언급했어요";
+	private static final String MEETING_DEMAND_COMMENT_TITLE = "내가 만든 모임 수요에 댓글이 달렸어요";
+	private static final String MEETING_DEMAND_COMMENT_CONTENT = "새로운 댓글이 달렸어요.";
 	private static final String MEETING_DEMAND_WEB_LINK_FORMAT = "%s/meeting-demand?id=%d";
 
 	private final PushNotificationService pushNotificationService;
 	private final PushNotificationProperties pushNotificationProperties;
 
-	public void sendCommentNotification(MeetingDemandCommentV2CreateCommentBodyDto requestBody,
-		MeetingDemand meetingDemand, MeetingDemandComment parentComment, MeetingDemandCommentProfile writerProfile) {
-		boolean isReplyComment = !requestBody.getIsParent();
-		Integer receiverUserId = isReplyComment ? getReplyReceiverUserId(parentComment) : meetingDemand.getUserId();
-		if (receiverUserId == null) {
+	public void sendCommentNotification(MeetingDemand meetingDemand, Integer writerUserId) {
+		if (writerUserId == null || meetingDemand.isWriter(writerUserId)) {
 			return;
 		}
 
-		String title = isReplyComment ? MEETING_DEMAND_REPLY_TITLE : MEETING_DEMAND_COMMENT_TITLE;
-		String commentType = isReplyComment ? "답글" : "댓글";
-		String secretStringRemovedContent = MentionSecretStringRemover.removeSecretString(requestBody.getContents());
-		String pushNotificationContent = String.format("[%s의 %s] : \"%s\"",
-			writerProfile.getAnonymousNickname(), commentType, secretStringRemovedContent);
 		String webLink = createMeetingDemandWebLink(meetingDemand.getId());
 
 		PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(
-			new String[] {String.valueOf(receiverUserId)},
-			title,
-			pushNotificationContent,
+			new String[] {String.valueOf(meetingDemand.getUserId())},
+			MEETING_DEMAND_COMMENT_TITLE,
+			MEETING_DEMAND_COMMENT_CONTENT,
 			PUSH_NOTIFICATION_CATEGORY.getValue(),
 			webLink
 		);
@@ -53,10 +40,7 @@ public class MeetingDemandCommentNotificationSender {
 		pushNotificationService.sendPushNotification(pushRequestDto);
 	}
 
-	public void sendMentionNotification(MeetingDemandCommentV2MentionUserInCommentRequestDto requestBody,
-		MeetingDemandCommentProfile writerProfile) {
-		String title = String.format(MEETING_DEMAND_MENTION_TITLE_FORMAT, writerProfile.getAnonymousNickname());
-		String content = "\"" + MentionSecretStringRemover.removeSecretString(requestBody.getContent()) + "\"";
+	public void sendMentionNotification(MeetingDemandCommentV2MentionUserInCommentRequestDto requestBody) {
 		String webLink = createMeetingDemandWebLink(requestBody.getMeetingDemandId());
 
 		String[] userOrgIds = requestBody.getOrgIds().stream()
@@ -65,21 +49,13 @@ public class MeetingDemandCommentNotificationSender {
 
 		PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(
 			userOrgIds,
-			title,
-			content,
+			MEETING_DEMAND_COMMENT_TITLE,
+			MEETING_DEMAND_COMMENT_CONTENT,
 			PUSH_NOTIFICATION_CATEGORY.getValue(),
 			webLink
 		);
 
 		pushNotificationService.sendPushNotification(pushRequestDto);
-	}
-
-	private Integer getReplyReceiverUserId(MeetingDemandComment parentComment) {
-		if (parentComment == null) {
-			return null;
-		}
-
-		return parentComment.getUserId();
 	}
 
 	private String createMeetingDemandWebLink(Integer meetingDemandId) {

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentV2ServiceImpl.java
@@ -92,16 +92,16 @@ public class MeetingDemandCommentV2ServiceImpl implements MeetingDemandCommentV2
 		MeetingDemandCommentV2CreateCommentBodyDto requestBody, Integer userId) {
 		MeetingDemand meetingDemand = meetingDemandRepository.findByIdOrThrow(meetingDemandId);
 		User writer = userRepository.findByIdOrThrow(userId);
-		MeetingDemandCommentProfile writerProfile = meetingDemandCommentProfileFactory.findOrCreate(meetingDemandId,
-			userId);
+		meetingDemandCommentProfileFactory.findOrCreate(meetingDemandId, userId);
 
 		MeetingDemandCommentFactory.CreatedComment createdComment = meetingDemandCommentFactory.create(meetingDemand,
 			writer, requestBody);
 
 		MeetingDemandComment savedComment = meetingDemandCommentRepository.save(createdComment.comment());
 		meetingDemand.increaseCommentCount();
-		meetingDemandCommentNotificationSender.sendCommentNotification(requestBody, meetingDemand,
-			createdComment.parentComment(), writerProfile);
+		if (!meetingDemand.isWriter(userId)) {
+			meetingDemandCommentNotificationSender.sendCommentNotification(meetingDemand, userId);
+		}
 
 		return MeetingDemandCommentV2CreateCommentResponseDto.of(savedComment.getId());
 	}

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentV2ServiceImpl.java
@@ -92,16 +92,16 @@ public class MeetingDemandCommentV2ServiceImpl implements MeetingDemandCommentV2
 		MeetingDemandCommentV2CreateCommentBodyDto requestBody, Integer userId) {
 		MeetingDemand meetingDemand = meetingDemandRepository.findByIdOrThrow(meetingDemandId);
 		User writer = userRepository.findByIdOrThrow(userId);
-		MeetingDemandCommentProfile writerProfile = meetingDemandCommentProfileFactory.findOrCreate(meetingDemandId,
-			userId);
+		meetingDemandCommentProfileFactory.findOrCreate(meetingDemandId, userId);
 
 		MeetingDemandCommentFactory.CreatedComment createdComment = meetingDemandCommentFactory.create(meetingDemand,
 			writer, requestBody);
 
 		MeetingDemandComment savedComment = meetingDemandCommentRepository.save(createdComment.comment());
 		meetingDemand.increaseCommentCount();
-		meetingDemandCommentNotificationSender.sendCommentNotification(requestBody, meetingDemand,
-			createdComment.parentComment(), writerProfile);
+		if (!meetingDemand.isWriter(userId)) {
+			meetingDemandCommentNotificationSender.sendCommentNotification(meetingDemand, userId);
+		}
 
 		return MeetingDemandCommentV2CreateCommentResponseDto.of(savedComment.getId());
 	}
@@ -172,9 +172,7 @@ public class MeetingDemandCommentV2ServiceImpl implements MeetingDemandCommentV2
 		meetingDemandRepository.findByIdOrThrow(requestBody.getMeetingDemandId());
 		userRepository.findByIdOrThrow(userId);
 
-		MeetingDemandCommentProfile writerProfile = meetingDemandCommentProfileFactory.findOrCreate(
-			requestBody.getMeetingDemandId(), userId);
-		meetingDemandCommentNotificationSender.sendMentionNotification(requestBody, writerProfile);
+		meetingDemandCommentNotificationSender.sendMentionNotification(requestBody);
 	}
 
 	@Override

--- a/main/src/main/resources/schema.sql
+++ b/main/src/main/resources/schema.sql
@@ -9,6 +9,8 @@ drop table if exists "meeting_demand_comment_like" cascade;
 drop table if exists "meeting_demand_comment_profile" cascade;
 drop table if exists "meeting_demand_comment" cascade;
 drop table if exists "mumu_text" cascade;
+drop table if exists "meeting_demand_opened_notification" cascade;
+drop table if exists "meeting_demand_wait_history" cascade;
 drop table if exists "meeting_demand_wait" cascade;
 drop table if exists "meeting_demand" cascade;
 drop table if exists "meeting" cascade;
@@ -80,11 +82,32 @@ create table if not exists meeting_demand_wait
     unique ("meetingDemandId", "userId")
 );
 
+create table if not exists meeting_demand_wait_history
+(
+    id                 serial
+    primary key,
+    "meetingDemandId"  integer              not null
+    constraint fk_meeting_demand_wait_history_demand
+    references meeting_demand
+    on delete cascade,
+    "userId"           integer              not null
+    constraint fk_meeting_demand_wait_history_user
+    references "user"
+    on delete cascade,
+    "createdTimestamp" timestamp default CURRENT_TIMESTAMP,
+    "modifiedTimestamp" timestamp default CURRENT_TIMESTAMP,
+    constraint "UQ_meeting_demand_wait_history_demand_user"
+    unique ("meetingDemandId", "userId")
+);
+
 create index if not exists "meeting_demand_status_created_index"
     on meeting_demand (status, "createdTimestamp" desc, id desc);
 
 create index if not exists "meeting_demand_wait_user_index"
     on meeting_demand_wait ("userId");
+
+create index if not exists "meeting_demand_wait_history_user_index"
+    on meeting_demand_wait_history ("userId");
 
 create table if not exists meeting_demand_comment_profile
 (
@@ -196,6 +219,24 @@ create table if not exists meeting
 
 create index if not exists "meeting_meeting_demand_index"
     on meeting ("meetingDemandId");
+
+create table if not exists meeting_demand_opened_notification
+(
+    id                  serial
+    primary key,
+    "meetingId"         integer              not null
+    constraint fk_meeting_demand_opened_notification_meeting
+    references meeting
+    on delete cascade,
+    "sentAt"            timestamp,
+    "createdTimestamp"  timestamp default CURRENT_TIMESTAMP,
+    "modifiedTimestamp" timestamp default CURRENT_TIMESTAMP,
+    constraint "UQ_meeting_demand_opened_notification_meeting"
+    unique ("meetingId")
+);
+
+create index if not exists "meeting_demand_opened_notification_sent_index"
+    on meeting_demand_opened_notification ("sentAt");
 
 create table if not exists co_leader
 (

--- a/main/src/test/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandNotificationSenderTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandNotificationSenderTest.java
@@ -1,0 +1,143 @@
+package org.sopt.makers.crew.main.meetingdemand.v2.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemand;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandRepository;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandWaitRepository;
+import org.sopt.makers.crew.main.entity.meetingdemandcomment.MeetingDemandCommentRepository;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.UserFixture;
+import org.sopt.makers.crew.main.external.notification.PushNotificationService;
+import org.sopt.makers.crew.main.external.notification.dto.request.PushNotificationRequestDto;
+import org.sopt.makers.crew.main.global.config.PushNotificationProperties;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingDemandNotificationSenderTest {
+
+	private static final int MEETING_DEMAND_ID = 10;
+	private static final int MEETING_ID = 20;
+	private static final int DEMAND_WRITER_ID = 1;
+	private static final int MEETING_LEADER_ID = 2;
+
+	@Mock
+	private MeetingDemandRepository meetingDemandRepository;
+
+	@Mock
+	private MeetingDemandCommentRepository meetingDemandCommentRepository;
+
+	@Mock
+	private MeetingDemandWaitRepository meetingDemandWaitRepository;
+
+	@Mock
+	private PushNotificationService pushNotificationService;
+
+	private MeetingDemandNotificationSender meetingDemandNotificationSender;
+	private MeetingDemand meetingDemand;
+	private Meeting meeting;
+
+	@BeforeEach
+	void setUp() {
+		meetingDemandNotificationSender = new MeetingDemandNotificationSender(
+			meetingDemandRepository,
+			meetingDemandCommentRepository,
+			meetingDemandWaitRepository,
+			pushNotificationService,
+			new PushNotificationProperties("https://crew.test")
+		);
+
+		User demandWriter = UserFixture.createUser(DEMAND_WRITER_ID, "서버", 36);
+		User meetingLeader = UserFixture.createUser(MEETING_LEADER_ID, "기획", 36);
+		meetingDemand = MeetingDemand.builder()
+			.user(demandWriter)
+			.shortIntro("러닝 모임 열어주세요")
+			.expectation("같이 달릴 모임이 있으면 좋겠어요.")
+			.meetingKeywordTypes(List.of())
+			.joinInfo(null)
+			.build();
+		setField(meetingDemand, "id", MEETING_DEMAND_ID);
+
+		meeting = Meeting.builder()
+			.user(meetingLeader)
+			.meetingDemandId(MEETING_DEMAND_ID)
+			.createdGeneration(36)
+			.build();
+		setField(meeting, "id", MEETING_ID);
+	}
+
+	@Test
+	@DisplayName("수요 기반 모임 개설 알림은 중복을 제거하고 모임장을 제외해 발송한다.")
+	void sendOpenedMeetingNotification_deduplicatesReceiversAndExcludesMeetingLeader() {
+		given(meetingDemandRepository.findByIdOrThrow(MEETING_DEMAND_ID)).willReturn(meetingDemand);
+		given(meetingDemandCommentRepository.findDistinctUserIdsByMeetingDemandId(MEETING_DEMAND_ID))
+			.willReturn(List.of(DEMAND_WRITER_ID, MEETING_LEADER_ID, 3, 3));
+		given(meetingDemandWaitRepository.findUserIdsByMeetingDemandId(MEETING_DEMAND_ID))
+			.willReturn(List.of(MEETING_LEADER_ID, 4));
+
+		meetingDemandNotificationSender.sendOpenedMeetingNotification(meeting);
+
+		ArgumentCaptor<PushNotificationRequestDto> captor = ArgumentCaptor.forClass(
+			PushNotificationRequestDto.class);
+		verify(pushNotificationService).sendPushNotification(captor.capture());
+
+		PushNotificationRequestDto request = captor.getValue();
+		assertThat(request.getUserIds()).containsExactly("1", "3", "4");
+		assertThat(request.getTitle()).isEqualTo("기다리던 모임이 열렸어요");
+		assertThat(request.getContent()).isEqualTo("관심을 보였던 수요가 모임으로 개설됐어요.");
+		assertThat(request.getCategory()).isEqualTo("NEWS");
+		assertThat(request.getWebLink()).isEqualTo("https://crew.test/detail?id=20");
+	}
+
+	@Test
+	@DisplayName("수신자가 모임장뿐이면 수요 기반 모임 개설 알림을 보내지 않는다.")
+	void sendOpenedMeetingNotification_skipsWhenOnlyReceiverIsMeetingLeader() {
+		User meetingLeaderDemand = UserFixture.createUser(MEETING_LEADER_ID, "기획", 36);
+		MeetingDemand ownDemand = MeetingDemand.builder()
+			.user(meetingLeaderDemand)
+			.shortIntro("러닝 모임 열어주세요")
+			.expectation("같이 달릴 모임이 있으면 좋겠어요.")
+			.meetingKeywordTypes(List.of())
+			.joinInfo(null)
+			.build();
+		setField(ownDemand, "id", MEETING_DEMAND_ID);
+		given(meetingDemandRepository.findByIdOrThrow(MEETING_DEMAND_ID)).willReturn(ownDemand);
+		given(meetingDemandCommentRepository.findDistinctUserIdsByMeetingDemandId(MEETING_DEMAND_ID))
+			.willReturn(List.of(MEETING_LEADER_ID));
+		given(meetingDemandWaitRepository.findUserIdsByMeetingDemandId(MEETING_DEMAND_ID))
+			.willReturn(List.of(MEETING_LEADER_ID));
+
+		meetingDemandNotificationSender.sendOpenedMeetingNotification(meeting);
+
+		verify(pushNotificationService, never()).sendPushNotification(org.mockito.ArgumentMatchers.any());
+	}
+
+	@Test
+	@DisplayName("기다려요 알림은 수요 작성자에게 수요 상세 링크로 발송한다.")
+	void sendWaitNotification_sendsToMeetingDemandWriter() {
+		meetingDemandNotificationSender.sendWaitNotification(meetingDemand);
+
+		ArgumentCaptor<PushNotificationRequestDto> captor = ArgumentCaptor.forClass(
+			PushNotificationRequestDto.class);
+		verify(pushNotificationService).sendPushNotification(captor.capture());
+
+		PushNotificationRequestDto request = captor.getValue();
+		assertThat(request.getUserIds()).containsExactly("1");
+		assertThat(request.getTitle()).isEqualTo("내가 만든 모임 수요를 기다리는 사람이 생겼어요");
+		assertThat(request.getContent()).isEqualTo("수요에 관심을 보인 멤버가 있어요.");
+		assertThat(request.getWebLink()).isEqualTo("https://crew.test/meeting-demand?id=10");
+	}
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandOpenedNotificationServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandOpenedNotificationServiceTest.java
@@ -1,0 +1,172 @@
+package org.sopt.makers.crew.main.meetingdemand.v2.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.makers.crew.main.entity.meeting.Meeting;
+import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandOpenedNotification;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandOpenedNotificationRepository;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.UserFixture;
+import org.sopt.makers.crew.main.global.util.Time;
+import org.sopt.makers.crew.main.meetingdemand.v2.dto.event.MeetingDemandOpenedNotificationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingDemandOpenedNotificationServiceTest {
+
+	private static final int MEETING_ID = 20;
+	private static final int MEETING_DEMAND_ID = 10;
+	private static final LocalDateTime NOW = LocalDateTime.of(2026, 7, 7, 12, 0);
+
+	@Mock
+	private MeetingDemandOpenedNotificationRepository meetingDemandOpenedNotificationRepository;
+
+	@Mock
+	private MeetingRepository meetingRepository;
+
+	@Mock
+	private MeetingDemandNotificationSender meetingDemandNotificationSender;
+
+	@Mock
+	private ApplicationEventPublisher eventPublisher;
+
+	@Mock
+	private Time time;
+
+	private MeetingDemandOpenedNotificationService meetingDemandOpenedNotificationService;
+	private Meeting meeting;
+
+	@BeforeEach
+	void setUp() {
+		meetingDemandOpenedNotificationService = new MeetingDemandOpenedNotificationService(
+			meetingDemandOpenedNotificationRepository,
+			meetingRepository,
+			meetingDemandNotificationSender,
+			eventPublisher,
+			time
+		);
+
+		User meetingLeader = UserFixture.createUser(2, "기획", 36);
+		meeting = Meeting.builder()
+			.user(meetingLeader)
+			.meetingDemandId(MEETING_DEMAND_ID)
+			.startDate(NOW.minusHours(1))
+			.endDate(NOW.plusHours(1))
+			.createdGeneration(36)
+			.build();
+		setField(meeting, "id", MEETING_ID);
+	}
+
+	@Test
+	@DisplayName("수요 기반 모임이 신청 가능 시간대에 생성되면 알림 이력을 만들고 즉시 발송 이벤트를 예약한다.")
+	void register_applyAbleMeetingPublishesNotificationEvent() {
+		MeetingDemandOpenedNotification notification = MeetingDemandOpenedNotification.builder()
+			.meetingId(MEETING_ID)
+			.build();
+		given(time.now()).willReturn(NOW);
+		given(meetingDemandOpenedNotificationRepository.findByMeetingId(MEETING_ID)).willReturn(Optional.empty());
+		given(meetingDemandOpenedNotificationRepository.save(any(MeetingDemandOpenedNotification.class)))
+			.willReturn(notification);
+
+		meetingDemandOpenedNotificationService.register(meeting);
+
+		verify(meetingDemandOpenedNotificationRepository).save(any(MeetingDemandOpenedNotification.class));
+		ArgumentCaptor<MeetingDemandOpenedNotificationEvent> captor = ArgumentCaptor.forClass(
+			MeetingDemandOpenedNotificationEvent.class);
+		verify(eventPublisher).publishEvent(captor.capture());
+		assertThat(captor.getValue().meetingId()).isEqualTo(MEETING_ID);
+	}
+
+	@Test
+	@DisplayName("모집 시작 전 수요 기반 모임은 이력만 만들고 즉시 발송하지 않는다.")
+	void register_beforeStartMeetingDoesNotPublishNotificationEvent() {
+		Meeting beforeStartMeeting = Meeting.builder()
+			.user(UserFixture.createUser(2, "기획", 36))
+			.meetingDemandId(MEETING_DEMAND_ID)
+			.startDate(NOW.plusHours(1))
+			.endDate(NOW.plusHours(2))
+			.createdGeneration(36)
+			.build();
+		setField(beforeStartMeeting, "id", MEETING_ID);
+		given(time.now()).willReturn(NOW);
+		given(meetingDemandOpenedNotificationRepository.findByMeetingId(MEETING_ID)).willReturn(Optional.empty());
+		given(meetingDemandOpenedNotificationRepository.save(any(MeetingDemandOpenedNotification.class)))
+			.willAnswer(invocation -> invocation.getArgument(0));
+
+		meetingDemandOpenedNotificationService.register(beforeStartMeeting);
+
+		verify(meetingDemandOpenedNotificationRepository).save(any(MeetingDemandOpenedNotification.class));
+		verify(eventPublisher, never()).publishEvent(any());
+	}
+
+	@Test
+	@DisplayName("모집 종료된 수요 기반 모임은 알림 이력을 만들지 않는다.")
+	void register_recruitmentCompleteMeetingSkipsNotification() {
+		Meeting completedMeeting = Meeting.builder()
+			.user(UserFixture.createUser(2, "기획", 36))
+			.meetingDemandId(MEETING_DEMAND_ID)
+			.startDate(NOW.minusHours(2))
+			.endDate(NOW.minusHours(1))
+			.createdGeneration(36)
+			.build();
+		given(time.now()).willReturn(NOW);
+
+		meetingDemandOpenedNotificationService.register(completedMeeting);
+
+		verify(meetingDemandOpenedNotificationRepository, never()).save(any());
+		verify(eventPublisher, never()).publishEvent(any());
+	}
+
+	@Test
+	@DisplayName("발송 가능한 pending 알림은 푸시 발송 후 sentAt을 기록한다.")
+	void sendNotification_sendsPushAndMarksSent() {
+		MeetingDemandOpenedNotification notification = MeetingDemandOpenedNotification.builder()
+			.meetingId(MEETING_ID)
+			.build();
+		given(time.now()).willReturn(NOW);
+		given(meetingDemandOpenedNotificationRepository.findByMeetingId(MEETING_ID))
+			.willReturn(Optional.of(notification));
+		given(meetingRepository.findByIdOrThrow(MEETING_ID)).willReturn(meeting);
+
+		meetingDemandOpenedNotificationService.sendNotification(MEETING_ID);
+
+		verify(meetingDemandNotificationSender).sendOpenedMeetingNotification(meeting);
+		assertThat(notification.getSentAt()).isEqualTo(NOW);
+	}
+
+	@Test
+	@DisplayName("스케줄러용 pending 발송은 신청 가능한 미발송 알림만 처리한다.")
+	void sendPendingNotifications_sendsApplyAblePendingNotifications() {
+		MeetingDemandOpenedNotification notification = MeetingDemandOpenedNotification.builder()
+			.meetingId(MEETING_ID)
+			.build();
+		given(time.now()).willReturn(NOW);
+		given(meetingDemandOpenedNotificationRepository.findAllUnsentApplyAble(NOW))
+			.willReturn(List.of(notification));
+		given(meetingDemandOpenedNotificationRepository.findByMeetingId(MEETING_ID))
+			.willReturn(Optional.of(notification));
+		given(meetingRepository.findByIdOrThrow(MEETING_ID)).willReturn(meeting);
+
+		meetingDemandOpenedNotificationService.sendPendingNotifications();
+
+		verify(meetingDemandNotificationSender).sendOpenedMeetingNotification(meeting);
+		assertThat(notification.getSentAt()).isEqualTo(NOW);
+	}
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandV2ServiceTest.java
@@ -27,6 +27,8 @@ import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
 import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemand;
 import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandRepository;
 import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandWait;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandWaitHistory;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandWaitHistoryRepository;
 import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandWaitRepository;
 import org.sopt.makers.crew.main.entity.meetingdemand.enums.MeetingDemandStatus;
 import org.sopt.makers.crew.main.entity.report.Report;
@@ -61,10 +63,16 @@ class MeetingDemandV2ServiceTest {
 	private MeetingDemandWaitRepository meetingDemandWaitRepository;
 
 	@Mock
+	private MeetingDemandWaitHistoryRepository meetingDemandWaitHistoryRepository;
+
+	@Mock
 	private MeetingRepository meetingRepository;
 
 	@Mock
 	private ReportRepository reportRepository;
+
+	@Mock
+	private MeetingDemandNotificationSender meetingDemandNotificationSender;
 
 	private MeetingDemandV2ServiceImpl meetingDemandV2Service;
 
@@ -77,10 +85,12 @@ class MeetingDemandV2ServiceTest {
 			userRepository,
 			meetingDemandRepository,
 			meetingDemandWaitRepository,
+			meetingDemandWaitHistoryRepository,
 			meetingRepository,
 			reportRepository,
 			new MeetingDemandFactory(),
-			new MeetingDemandPageNormalizer()
+			new MeetingDemandPageNormalizer(),
+			meetingDemandNotificationSender
 		);
 
 		writer = UserFixture.createUser(WRITER_ID, "서버", 36);
@@ -207,6 +217,8 @@ class MeetingDemandV2ServiceTest {
 				.willReturn(meetingDemand);
 			given(meetingDemandWaitRepository.existsByMeetingDemandIdAndUserId(MEETING_DEMAND_ID, REQUEST_USER_ID))
 				.willReturn(false);
+			given(meetingDemandWaitHistoryRepository.existsByMeetingDemandIdAndUserId(MEETING_DEMAND_ID,
+				REQUEST_USER_ID)).willReturn(false);
 			given(meetingDemandWaitRepository.countByMeetingDemandId(MEETING_DEMAND_ID)).willReturn(1L);
 
 			MeetingDemandV2SwitchMeetingDemandWaitResponseDto response = meetingDemandV2Service.switchMeetingDemandWait(
@@ -214,6 +226,8 @@ class MeetingDemandV2ServiceTest {
 
 			ArgumentCaptor<MeetingDemandWait> captor = ArgumentCaptor.forClass(MeetingDemandWait.class);
 			verify(meetingDemandWaitRepository).save(captor.capture());
+			verify(meetingDemandWaitHistoryRepository).save(any(MeetingDemandWaitHistory.class));
+			verify(meetingDemandNotificationSender).sendWaitNotification(meetingDemand);
 			verify(meetingDemandWaitRepository).flush();
 
 			assertThat(captor.getValue().getMeetingDemandId()).isEqualTo(MEETING_DEMAND_ID);
@@ -221,6 +235,27 @@ class MeetingDemandV2ServiceTest {
 			assertThat(response.getIsWaiting()).isTrue();
 			assertThat(response.getWaitCount()).isEqualTo(1);
 			assertThat(meetingDemand.getWaitCount()).isEqualTo(1);
+		}
+
+		@Test
+		@DisplayName("기다려요를 다시 누른 이력이 있는 유저에게는 알림을 반복 발송하지 않는다.")
+		void switchMeetingDemandWait_doesNotSendDuplicatedWaitNotification() {
+			given(meetingDemandRepository.findByIdWithPessimisticWriteLockOrThrow(MEETING_DEMAND_ID))
+				.willReturn(meetingDemand);
+			given(meetingDemandWaitRepository.existsByMeetingDemandIdAndUserId(MEETING_DEMAND_ID, REQUEST_USER_ID))
+				.willReturn(false);
+			given(meetingDemandWaitHistoryRepository.existsByMeetingDemandIdAndUserId(MEETING_DEMAND_ID,
+				REQUEST_USER_ID)).willReturn(true);
+			given(meetingDemandWaitRepository.countByMeetingDemandId(MEETING_DEMAND_ID)).willReturn(1L);
+
+			MeetingDemandV2SwitchMeetingDemandWaitResponseDto response = meetingDemandV2Service.switchMeetingDemandWait(
+				MEETING_DEMAND_ID, REQUEST_USER_ID);
+
+			verify(meetingDemandWaitRepository).save(any(MeetingDemandWait.class));
+			verify(meetingDemandWaitHistoryRepository, never()).save(any());
+			verify(meetingDemandNotificationSender, never()).sendWaitNotification(any());
+			assertThat(response.getIsWaiting()).isTrue();
+			assertThat(response.getWaitCount()).isEqualTo(1);
 		}
 
 		@Test

--- a/main/src/test/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentNotificationSenderTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentNotificationSenderTest.java
@@ -1,0 +1,93 @@
+package org.sopt.makers.crew.main.meetingdemandcomment.v2.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemand;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.UserFixture;
+import org.sopt.makers.crew.main.external.notification.PushNotificationService;
+import org.sopt.makers.crew.main.external.notification.dto.request.PushNotificationRequestDto;
+import org.sopt.makers.crew.main.global.config.PushNotificationProperties;
+import org.sopt.makers.crew.main.meetingdemandcomment.v2.dto.request.MeetingDemandCommentV2MentionUserInCommentRequestDto;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingDemandCommentNotificationSenderTest {
+
+	private static final int MEETING_DEMAND_ID = 10;
+	private static final int DEMAND_WRITER_ID = 1;
+	private static final int COMMENT_WRITER_ID = 2;
+
+	@Mock
+	private PushNotificationService pushNotificationService;
+
+	private MeetingDemandCommentNotificationSender meetingDemandCommentNotificationSender;
+	private MeetingDemand meetingDemand;
+
+	@BeforeEach
+	void setUp() {
+		meetingDemandCommentNotificationSender = new MeetingDemandCommentNotificationSender(
+			pushNotificationService,
+			new PushNotificationProperties("https://crew.test")
+		);
+
+		User demandWriter = UserFixture.createUser(DEMAND_WRITER_ID, "서버", 36);
+		meetingDemand = MeetingDemand.builder()
+			.user(demandWriter)
+			.shortIntro("러닝 모임 열어주세요")
+			.expectation("같이 달릴 모임이 있으면 좋겠어요.")
+			.meetingKeywordTypes(List.of())
+			.joinInfo(null)
+			.build();
+		setField(meetingDemand, "id", MEETING_DEMAND_ID);
+	}
+
+	@Test
+	@DisplayName("댓글 알림은 새 요구사항 문구로 수요 작성자에게 발송한다.")
+	void sendCommentNotification_usesNewMessage() {
+		meetingDemandCommentNotificationSender.sendCommentNotification(meetingDemand, COMMENT_WRITER_ID);
+
+		ArgumentCaptor<PushNotificationRequestDto> captor = ArgumentCaptor.forClass(
+			PushNotificationRequestDto.class);
+		verify(pushNotificationService).sendPushNotification(captor.capture());
+
+		PushNotificationRequestDto request = captor.getValue();
+		assertThat(request.getUserIds()).containsExactly("1");
+		assertThat(request.getTitle()).isEqualTo("내가 만든 모임 수요에 댓글이 달렸어요");
+		assertThat(request.getContent()).isEqualTo("새로운 댓글이 달렸어요.");
+		assertThat(request.getWebLink()).isEqualTo("https://crew.test/meeting-demand?id=10");
+	}
+
+	@Test
+	@DisplayName("멘션 알림도 댓글 알림과 동일한 문구로 발송한다.")
+	void sendMentionNotification_usesSameCommentMessage() {
+		MeetingDemandCommentV2MentionUserInCommentRequestDto requestBody =
+			new MeetingDemandCommentV2MentionUserInCommentRequestDto(
+				MEETING_DEMAND_ID,
+				"@테스트 유저 멘션 댓글",
+				List.of(3L, 4L)
+			);
+
+		meetingDemandCommentNotificationSender.sendMentionNotification(requestBody);
+
+		ArgumentCaptor<PushNotificationRequestDto> captor = ArgumentCaptor.forClass(
+			PushNotificationRequestDto.class);
+		verify(pushNotificationService).sendPushNotification(captor.capture());
+
+		PushNotificationRequestDto request = captor.getValue();
+		assertThat(request.getUserIds()).containsExactly("3", "4");
+		assertThat(request.getTitle()).isEqualTo("내가 만든 모임 수요에 댓글이 달렸어요");
+		assertThat(request.getContent()).isEqualTo("새로운 댓글이 달렸어요.");
+		assertThat(request.getWebLink()).isEqualTo("https://crew.test/meeting-demand?id=10");
+	}
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentV2ServiceTest.java
@@ -41,6 +41,7 @@ import org.sopt.makers.crew.main.global.exception.ForbiddenException;
 import org.sopt.makers.crew.main.global.util.Time;
 import org.sopt.makers.crew.main.meetingdemand.v2.service.MeetingDemandPageNormalizer;
 import org.sopt.makers.crew.main.meetingdemandcomment.v2.dto.request.MeetingDemandCommentV2CreateCommentBodyDto;
+import org.sopt.makers.crew.main.meetingdemandcomment.v2.dto.request.MeetingDemandCommentV2MentionUserInCommentRequestDto;
 import org.sopt.makers.crew.main.meetingdemandcomment.v2.dto.response.MeetingDemandCommentV2CreateCommentResponseDto;
 import org.sopt.makers.crew.main.meetingdemandcomment.v2.dto.response.MeetingDemandCommentV2ReportCommentResponseDto;
 import org.sopt.makers.crew.main.meetingdemandcomment.v2.dto.response.MeetingDemandCommentV2SwitchCommentLikeResponseDto;
@@ -127,10 +128,32 @@ class MeetingDemandCommentV2ServiceTest {
 	}
 
 	@Nested
+	class 모임_수요_댓글_멘션 {
+
+		@Test
+		@DisplayName("모임 수요 댓글에서 멘션한 사용자에게 알림을 요청한다.")
+		void mentionUserInComment_sendsMentionNotification() {
+			MeetingDemandCommentV2MentionUserInCommentRequestDto requestBody =
+				new MeetingDemandCommentV2MentionUserInCommentRequestDto(
+					MEETING_DEMAND_ID,
+					"@테스트 유저 멘션 댓글",
+					List.of(3L, 4L)
+				);
+			given(meetingDemandRepository.findByIdOrThrow(MEETING_DEMAND_ID)).willReturn(meetingDemand);
+			given(userRepository.findByIdOrThrow(REQUEST_USER_ID)).willReturn(requestUser);
+
+			meetingDemandCommentV2Service.mentionUserInComment(requestBody, REQUEST_USER_ID);
+
+			verify(meetingDemandCommentNotificationSender).sendMentionNotification(requestBody);
+			verify(meetingDemandCommentProfileFactory, never()).findOrCreate(any(), any());
+		}
+	}
+
+	@Nested
 	class 모임_수요_댓글_작성 {
 
 		@Test
-		@DisplayName("부모 댓글을 작성하면 댓글 수를 증가시키고 알림을 요청한다.")
+		@DisplayName("작성자가 자신의 수요에 부모 댓글을 작성하면 댓글 수만 증가시키고 알림을 보내지 않는다.")
 		void createComment_createsParentComment() {
 			MeetingDemandCommentV2CreateCommentBodyDto requestBody = new MeetingDemandCommentV2CreateCommentBodyDto(
 				"부모 댓글", true, null);
@@ -149,8 +172,7 @@ class MeetingDemandCommentV2ServiceTest {
 
 			ArgumentCaptor<MeetingDemandComment> captor = ArgumentCaptor.forClass(MeetingDemandComment.class);
 			verify(meetingDemandCommentRepository).save(captor.capture());
-			verify(meetingDemandCommentNotificationSender).sendCommentNotification(requestBody, meetingDemand, null,
-				writerProfile);
+			verify(meetingDemandCommentNotificationSender, never()).sendCommentNotification(any(), any());
 
 			MeetingDemandComment savedComment = captor.getValue();
 			assertThat(response.getCommentId()).isEqualTo(COMMENT_ID);
@@ -187,8 +209,7 @@ class MeetingDemandCommentV2ServiceTest {
 
 			ArgumentCaptor<MeetingDemandComment> captor = ArgumentCaptor.forClass(MeetingDemandComment.class);
 			verify(meetingDemandCommentRepository).save(captor.capture());
-			verify(meetingDemandCommentNotificationSender).sendCommentNotification(requestBody, meetingDemand,
-				parentComment, writerProfile);
+			verify(meetingDemandCommentNotificationSender).sendCommentNotification(meetingDemand, REQUEST_USER_ID);
 
 			MeetingDemandComment savedComment = captor.getValue();
 			assertThat(response.getCommentId()).isEqualTo(REPLY_COMMENT_ID);

--- a/main/src/test/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentV2ServiceTest.java
@@ -130,7 +130,7 @@ class MeetingDemandCommentV2ServiceTest {
 	class 모임_수요_댓글_작성 {
 
 		@Test
-		@DisplayName("부모 댓글을 작성하면 댓글 수를 증가시키고 알림을 요청한다.")
+		@DisplayName("작성자가 자신의 수요에 부모 댓글을 작성하면 댓글 수만 증가시키고 알림을 보내지 않는다.")
 		void createComment_createsParentComment() {
 			MeetingDemandCommentV2CreateCommentBodyDto requestBody = new MeetingDemandCommentV2CreateCommentBodyDto(
 				"부모 댓글", true, null);
@@ -149,8 +149,7 @@ class MeetingDemandCommentV2ServiceTest {
 
 			ArgumentCaptor<MeetingDemandComment> captor = ArgumentCaptor.forClass(MeetingDemandComment.class);
 			verify(meetingDemandCommentRepository).save(captor.capture());
-			verify(meetingDemandCommentNotificationSender).sendCommentNotification(requestBody, meetingDemand, null,
-				writerProfile);
+			verify(meetingDemandCommentNotificationSender, never()).sendCommentNotification(any(), any());
 
 			MeetingDemandComment savedComment = captor.getValue();
 			assertThat(response.getCommentId()).isEqualTo(COMMENT_ID);
@@ -187,8 +186,7 @@ class MeetingDemandCommentV2ServiceTest {
 
 			ArgumentCaptor<MeetingDemandComment> captor = ArgumentCaptor.forClass(MeetingDemandComment.class);
 			verify(meetingDemandCommentRepository).save(captor.capture());
-			verify(meetingDemandCommentNotificationSender).sendCommentNotification(requestBody, meetingDemand,
-				parentComment, writerProfile);
+			verify(meetingDemandCommentNotificationSender).sendCommentNotification(meetingDemand, REQUEST_USER_ID);
 
 			MeetingDemandComment savedComment = captor.getValue();
 			assertThat(response.getCommentId()).isEqualTo(REPLY_COMMENT_ID);


### PR DESCRIPTION
## 👩‍💻 Contents

- [x] 수요 기반 모임 개설 알림 추가
- 모임 생성 시 `meetingDemandId`가 포함된 경우 알림 발송 후보 등록
- 모임이 `APPLY_ABLE` 상태이고 08:00~22:00 시간대이면 즉시 발송
- 모집 시작 전이거나 발송 가능 시간대가 아니면 예약 후 발송
- `meetingId` 기준 발송 이력 저장 및 중복 발송 방지
- 중복 수신자 제거 및 개설된 모임장 제외
- 삭제된 댓글 작성자와 기다려요 취소 사용자는 수신 대상 제외
- 알림 클릭 시 개설된 모임 상세 페이지로 랜딩

- [x] 모임 수요 댓글 작성 알림 추가
- 수요 작성자가 본인 수요에 댓글/대댓글 작성 시 알림 미발송

- [x] 모임 수요 기다려요 알림 추가
- 수요 작성자가 본인 수요에 기다려요 클릭 시 알림 미발송
- `meeting_demand_wait_history` 기반 사용자별 최초 기다려요 액션만 알림 발송

## 📝 Review Note

1. 현재는 `meeting_demand_opened_notification`에 발송 후보를 저장하고, 스케줄러가 주기적으로 미발송 알림을 조회해 발송하는 방식으로 구현해주었는데요, 현재 구현은 1분 단위 확인이지만 스케줄러 실행 주기를 어느 정도로 가져갈지에 대한 의견 주시면 감사하겠습니다

2. “과거에 기다려요를 눌렀지만 현재는 취소한 사용자"에 대해서 모임 개설 시에는 알림 발송을 안해주는게 스펙상 맞는 것인지 기획 크로스 체크 중이에요

3. 이번 요구사항 기준으로 기존과 다르게 댓글, 대댓글, 멘션 알림은 모두 동일한 문구를 사용하도록 맞춰주었어요

- 제목: `내가 만든 모임 수요에 댓글이 달렸어요`
- 내용: `새로운 댓글이 달렸어요.`


## 📣 Related Issue

- closed #905 

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?