### PR TITLE
fix: 모임 수요 대댓글/멘션 알림 제외

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/MeetingDemandCommentV2Api.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/MeetingDemandCommentV2Api.java
@@ -38,7 +38,7 @@ public interface MeetingDemandCommentV2Api {
 		@Valid @ModelAttribute @Parameter(hidden = true) MeetingDemandCommentV2GetCommentsQueryDto queryDto,
 		Principal principal);
 
-	@Operation(summary = "모임 수요 댓글 작성", description = "모임 수요 댓글 또는 대댓글 생성")
+	@Operation(summary = "모임 수요 댓글 작성", description = "모임 수요 댓글 또는 대댓글 생성. 알림은 부모 댓글 생성 시에만 전송")
 	@ApiResponse(responseCode = "200", description = "성공")
 	ResponseEntity<MeetingDemandCommentV2CreateCommentResponseDto> createComment(
 		@PathVariable Integer meetingDemandId,
@@ -61,7 +61,8 @@ public interface MeetingDemandCommentV2Api {
 	ResponseEntity<MeetingDemandCommentV2SwitchCommentLikeResponseDto> switchCommentLike(
 		@PathVariable Integer commentId, Principal principal);
 
-	@Operation(summary = "모임 수요 댓글 멘션 알림", description = "모임 수요 댓글에서 멘션된 사용자에게 푸시 알림 전송")
+	@Deprecated
+	@Operation(summary = "모임 수요 댓글 멘션 알림", description = "사용하지 않습니다. 모임 수요 알림 정책에서 대댓글/멘션 알림은 제외합니다.", deprecated = true)
 	@ApiResponse(responseCode = "200", description = "성공")
 	ResponseEntity<Void> mentionUserInComment(
 		@Valid @RequestBody MeetingDemandCommentV2MentionUserInCommentRequestDto requestBody,

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/MeetingDemandCommentV2Controller.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/MeetingDemandCommentV2Controller.java
@@ -83,6 +83,7 @@ public class MeetingDemandCommentV2Controller implements MeetingDemandCommentV2A
 	}
 
 	@Override
+	@Deprecated
 	@PostMapping("/comments/mention")
 	public ResponseEntity<Void> mentionUserInComment(
 		@Valid @RequestBody MeetingDemandCommentV2MentionUserInCommentRequestDto requestBody,

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/dto/request/MeetingDemandCommentV2CreateCommentBodyDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/dto/request/MeetingDemandCommentV2CreateCommentBodyDto.java
@@ -18,11 +18,11 @@ public class MeetingDemandCommentV2CreateCommentBodyDto {
 	@NotEmpty
 	private String contents;
 
-	@Schema(example = "true", description = "댓글/대댓글 여부, true면 부모 댓글")
+	@Schema(example = "true", description = "댓글/대댓글 여부, true면 부모 댓글. 알림은 부모 댓글 생성 시에만 전송")
 	@NotNull
 	private Boolean isParent;
 
-	@Schema(example = "3", description = "대댓글인 경우 부모 댓글 id")
+	@Schema(example = "3", description = "대댓글인 경우 부모 댓글 id. 대댓글 알림은 전송하지 않음")
 	private Integer parentCommentId;
 
 	@AssertTrue(message = "대댓글 작성 시 부모 댓글 id는 필수입니다.")

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentNotificationSender.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentNotificationSender.java
@@ -6,7 +6,6 @@ import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemand;
 import org.sopt.makers.crew.main.external.notification.PushNotificationService;
 import org.sopt.makers.crew.main.external.notification.dto.request.PushNotificationRequestDto;
 import org.sopt.makers.crew.main.global.config.PushNotificationProperties;
-import org.sopt.makers.crew.main.meetingdemandcomment.v2.dto.request.MeetingDemandCommentV2MentionUserInCommentRequestDto;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -31,24 +30,6 @@ public class MeetingDemandCommentNotificationSender {
 
 		PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(
 			new String[] {String.valueOf(meetingDemand.getUserId())},
-			MEETING_DEMAND_COMMENT_TITLE,
-			MEETING_DEMAND_COMMENT_CONTENT,
-			PUSH_NOTIFICATION_CATEGORY.getValue(),
-			webLink
-		);
-
-		pushNotificationService.sendPushNotification(pushRequestDto);
-	}
-
-	public void sendMentionNotification(MeetingDemandCommentV2MentionUserInCommentRequestDto requestBody) {
-		String webLink = createMeetingDemandWebLink(requestBody.getMeetingDemandId());
-
-		String[] userOrgIds = requestBody.getOrgIds().stream()
-			.map(Object::toString)
-			.toArray(String[]::new);
-
-		PushNotificationRequestDto pushRequestDto = PushNotificationRequestDto.of(
-			userOrgIds,
 			MEETING_DEMAND_COMMENT_TITLE,
 			MEETING_DEMAND_COMMENT_CONTENT,
 			PUSH_NOTIFICATION_CATEGORY.getValue(),

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentV2ServiceImpl.java
@@ -99,7 +99,7 @@ public class MeetingDemandCommentV2ServiceImpl implements MeetingDemandCommentV2
 
 		MeetingDemandComment savedComment = meetingDemandCommentRepository.save(createdComment.comment());
 		meetingDemand.increaseCommentCount();
-		if (!meetingDemand.isWriter(userId)) {
+		if (savedComment.isParentComment() && !meetingDemand.isWriter(userId)) {
 			meetingDemandCommentNotificationSender.sendCommentNotification(meetingDemand, userId);
 		}
 
@@ -171,8 +171,6 @@ public class MeetingDemandCommentV2ServiceImpl implements MeetingDemandCommentV2
 	public void mentionUserInComment(MeetingDemandCommentV2MentionUserInCommentRequestDto requestBody, Integer userId) {
 		meetingDemandRepository.findByIdOrThrow(requestBody.getMeetingDemandId());
 		userRepository.findByIdOrThrow(userId);
-
-		meetingDemandCommentNotificationSender.sendMentionNotification(requestBody);
 	}
 
 	@Override

--- a/main/src/test/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentNotificationSenderTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentNotificationSenderTest.java
@@ -19,7 +19,6 @@ import org.sopt.makers.crew.main.entity.user.UserFixture;
 import org.sopt.makers.crew.main.external.notification.PushNotificationService;
 import org.sopt.makers.crew.main.external.notification.dto.request.PushNotificationRequestDto;
 import org.sopt.makers.crew.main.global.config.PushNotificationProperties;
-import org.sopt.makers.crew.main.meetingdemandcomment.v2.dto.request.MeetingDemandCommentV2MentionUserInCommentRequestDto;
 
 @ExtendWith(MockitoExtension.class)
 class MeetingDemandCommentNotificationSenderTest {
@@ -68,26 +67,4 @@ class MeetingDemandCommentNotificationSenderTest {
 		assertThat(request.getWebLink()).isEqualTo("https://crew.test/meeting-demand?id=10");
 	}
 
-	@Test
-	@DisplayName("멘션 알림도 댓글 알림과 동일한 문구로 발송한다.")
-	void sendMentionNotification_usesSameCommentMessage() {
-		MeetingDemandCommentV2MentionUserInCommentRequestDto requestBody =
-			new MeetingDemandCommentV2MentionUserInCommentRequestDto(
-				MEETING_DEMAND_ID,
-				"@테스트 유저 멘션 댓글",
-				List.of(3L, 4L)
-			);
-
-		meetingDemandCommentNotificationSender.sendMentionNotification(requestBody);
-
-		ArgumentCaptor<PushNotificationRequestDto> captor = ArgumentCaptor.forClass(
-			PushNotificationRequestDto.class);
-		verify(pushNotificationService).sendPushNotification(captor.capture());
-
-		PushNotificationRequestDto request = captor.getValue();
-		assertThat(request.getUserIds()).containsExactly("3", "4");
-		assertThat(request.getTitle()).isEqualTo("내가 만든 모임 수요에 댓글이 달렸어요");
-		assertThat(request.getContent()).isEqualTo("새로운 댓글이 달렸어요.");
-		assertThat(request.getWebLink()).isEqualTo("https://crew.test/meeting-demand?id=10");
-	}
 }

--- a/main/src/test/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentV2ServiceTest.java
@@ -131,8 +131,8 @@ class MeetingDemandCommentV2ServiceTest {
 	class 모임_수요_댓글_멘션 {
 
 		@Test
-		@DisplayName("모임 수요 댓글에서 멘션한 사용자에게 알림을 요청한다.")
-		void mentionUserInComment_sendsMentionNotification() {
+		@DisplayName("모임 수요 댓글 멘션 알림은 정책에서 제외되어 알림을 요청하지 않는다.")
+		void mentionUserInComment_doesNotSendMentionNotification() {
 			MeetingDemandCommentV2MentionUserInCommentRequestDto requestBody =
 				new MeetingDemandCommentV2MentionUserInCommentRequestDto(
 					MEETING_DEMAND_ID,
@@ -144,7 +144,7 @@ class MeetingDemandCommentV2ServiceTest {
 
 			meetingDemandCommentV2Service.mentionUserInComment(requestBody, REQUEST_USER_ID);
 
-			verify(meetingDemandCommentNotificationSender).sendMentionNotification(requestBody);
+			verify(meetingDemandCommentNotificationSender, never()).sendCommentNotification(any(), any());
 			verify(meetingDemandCommentProfileFactory, never()).findOrCreate(any(), any());
 		}
 	}
@@ -184,7 +184,27 @@ class MeetingDemandCommentV2ServiceTest {
 		}
 
 		@Test
-		@DisplayName("대댓글을 작성하면 부모 댓글과 최근 order를 기준으로 다음 order를 계산한다.")
+		@DisplayName("작성자가 아닌 사용자가 부모 댓글을 작성하면 수요 작성자에게 알림을 보낸다.")
+		void createComment_sendsNotificationForParentComment() {
+			MeetingDemandCommentV2CreateCommentBodyDto requestBody = new MeetingDemandCommentV2CreateCommentBodyDto(
+				"부모 댓글", true, null);
+			given(meetingDemandRepository.findByIdOrThrow(MEETING_DEMAND_ID)).willReturn(meetingDemand);
+			given(userRepository.findByIdOrThrow(REQUEST_USER_ID)).willReturn(requestUser);
+			given(meetingDemandCommentProfileFactory.findOrCreate(MEETING_DEMAND_ID, REQUEST_USER_ID))
+				.willReturn(writerProfile);
+			given(meetingDemandCommentRepository.save(any(MeetingDemandComment.class))).willAnswer(invocation -> {
+				MeetingDemandComment savedComment = invocation.getArgument(0);
+				setField(savedComment, "id", COMMENT_ID);
+				return savedComment;
+			});
+
+			meetingDemandCommentV2Service.createComment(MEETING_DEMAND_ID, requestBody, REQUEST_USER_ID);
+
+			verify(meetingDemandCommentNotificationSender).sendCommentNotification(meetingDemand, REQUEST_USER_ID);
+		}
+
+		@Test
+		@DisplayName("대댓글을 작성하면 부모 댓글과 최근 order를 기준으로 다음 order를 계산하고 알림은 보내지 않는다.")
 		void createComment_createsReplyComment() {
 			MeetingDemandComment recentReply = createComment(RECENT_REPLY_ID, "최근 대댓글", 1, 2, requestUser,
 				meetingDemand, COMMENT_ID);
@@ -209,7 +229,7 @@ class MeetingDemandCommentV2ServiceTest {
 
 			ArgumentCaptor<MeetingDemandComment> captor = ArgumentCaptor.forClass(MeetingDemandComment.class);
 			verify(meetingDemandCommentRepository).save(captor.capture());
-			verify(meetingDemandCommentNotificationSender).sendCommentNotification(meetingDemand, REQUEST_USER_ID);
+			verify(meetingDemandCommentNotificationSender, never()).sendCommentNotification(any(), any());
 
 			MeetingDemandComment savedComment = captor.getValue();
 			assertThat(response.getCommentId()).isEqualTo(REPLY_COMMENT_ID);


### PR DESCRIPTION
## 👩‍💻 Contents
모임 수요 대댓글/멘션 알림 제외

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?