### PR TITLE
fix: 모임 수요 익명 프로필 일관성 보장

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemandcomment/MeetingDemandCommentProfile.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/meetingdemandcomment/MeetingDemandCommentProfile.java
@@ -42,11 +42,16 @@ public class MeetingDemandCommentProfile extends BaseTimeEntity {
 	private Integer anonymousImageNumber;
 
 	@Builder
-	public MeetingDemandCommentProfile(Integer meetingDemandId, Integer userId) {
+	public MeetingDemandCommentProfile(Integer meetingDemandId, Integer userId, String anonymousNickname,
+		Integer anonymousImageNumber) {
 		this.meetingDemandId = meetingDemandId;
 		this.userId = userId;
-		this.anonymousNickname = MeetingDemandAnonymousProfile.generateNickname();
-		this.anonymousImageNumber = MeetingDemandAnonymousProfile.generateImageNumber();
+		this.anonymousNickname = anonymousNickname != null
+			? anonymousNickname
+			: MeetingDemandAnonymousProfile.generateNickname();
+		this.anonymousImageNumber = anonymousImageNumber != null
+			? anonymousImageNumber
+			: MeetingDemandAnonymousProfile.generateImageNumber();
 	}
 
 	public String getAnonymousImageUrl() {

--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentProfileFactory.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentProfileFactory.java
@@ -6,6 +6,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemand;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandRepository;
 import org.sopt.makers.crew.main.entity.meetingdemandcomment.MeetingDemandComment;
 import org.sopt.makers.crew.main.entity.meetingdemandcomment.MeetingDemandCommentProfile;
 import org.sopt.makers.crew.main.entity.meetingdemandcomment.MeetingDemandCommentProfileRepository;
@@ -19,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class MeetingDemandCommentProfileFactory {
 
 	private final MeetingDemandCommentProfileRepository meetingDemandCommentProfileRepository;
+	private final MeetingDemandRepository meetingDemandRepository;
 
 	public MeetingDemandCommentProfile findOrCreate(Integer meetingDemandId, Integer userId) {
 		return meetingDemandCommentProfileRepository.findByMeetingDemandIdAndUserId(meetingDemandId, userId)
@@ -27,14 +30,33 @@ public class MeetingDemandCommentProfileFactory {
 
 	private MeetingDemandCommentProfile createProfile(Integer meetingDemandId, Integer userId) {
 		try {
+			MeetingDemand meetingDemand = meetingDemandRepository.findByIdOrThrow(meetingDemandId);
 			return meetingDemandCommentProfileRepository.saveAndFlush(MeetingDemandCommentProfile.builder()
 				.meetingDemandId(meetingDemandId)
 				.userId(userId)
+				.anonymousNickname(getAnonymousNickname(meetingDemand, userId))
+				.anonymousImageNumber(getAnonymousImageNumber(meetingDemand, userId))
 				.build());
 		} catch (DataIntegrityViolationException exception) {
 			return meetingDemandCommentProfileRepository.findByMeetingDemandIdAndUserId(meetingDemandId, userId)
 				.orElseThrow(() -> exception);
 		}
+	}
+
+	private String getAnonymousNickname(MeetingDemand meetingDemand, Integer userId) {
+		if (!meetingDemand.isWriter(userId)) {
+			return null;
+		}
+
+		return meetingDemand.getAnonymousNickname();
+	}
+
+	private Integer getAnonymousImageNumber(MeetingDemand meetingDemand, Integer userId) {
+		if (!meetingDemand.isWriter(userId)) {
+			return null;
+		}
+
+		return meetingDemand.getAnonymousImageNumber();
 	}
 
 	public Map<Integer, MeetingDemandCommentProfile> createProfileMap(Integer meetingDemandId,

--- a/main/src/test/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentProfileFactoryTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentProfileFactoryTest.java
@@ -1,0 +1,89 @@
+package org.sopt.makers.crew.main.meetingdemandcomment.v2.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingFrequency;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingType;
+import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemand;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemandRepository;
+import org.sopt.makers.crew.main.entity.meetingdemandcomment.MeetingDemandCommentProfile;
+import org.sopt.makers.crew.main.entity.meetingdemandcomment.MeetingDemandCommentProfileRepository;
+import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.UserFixture;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingDemandCommentProfileFactoryTest {
+
+	private static final int MEETING_DEMAND_ID = 10;
+	private static final int WRITER_ID = 1;
+	private static final String MEETING_DEMAND_ANONYMOUS_NICKNAME = "성실한 토마토";
+	private static final int MEETING_DEMAND_ANONYMOUS_IMAGE_NUMBER = 4;
+
+	@Mock
+	private MeetingDemandCommentProfileRepository meetingDemandCommentProfileRepository;
+
+	@Mock
+	private MeetingDemandRepository meetingDemandRepository;
+
+	private MeetingDemandCommentProfileFactory meetingDemandCommentProfileFactory;
+
+	private MeetingDemand meetingDemand;
+
+	@BeforeEach
+	void setUp() {
+		meetingDemandCommentProfileFactory = new MeetingDemandCommentProfileFactory(
+			meetingDemandCommentProfileRepository,
+			meetingDemandRepository
+		);
+
+		User writer = UserFixture.createUser(WRITER_ID, "서버", 36);
+		meetingDemand = MeetingDemand.builder()
+			.user(writer)
+			.shortIntro("러닝 모임 열어주세요")
+			.expectation("같이 꾸준히 달릴 수 있는 모임이 있으면 좋겠어요.")
+			.meetingKeywordTypes(List.of(MeetingKeywordType.EXERCISE, MeetingKeywordType.NETWORKING))
+			.joinInfo(new MeetingJoinInfo(MeetingType.ONLINE, MeetingFrequency.STEADY))
+			.build();
+		setField(meetingDemand, "id", MEETING_DEMAND_ID);
+		setField(meetingDemand, "anonymousNickname", MEETING_DEMAND_ANONYMOUS_NICKNAME);
+		setField(meetingDemand, "anonymousImageNumber", MEETING_DEMAND_ANONYMOUS_IMAGE_NUMBER);
+	}
+
+	@Test
+	@DisplayName("게시글 작성자가 댓글 프로필을 처음 만들면 게시글 익명 프로필을 그대로 사용한다.")
+	void findOrCreate_reusesMeetingDemandAnonymousProfileForWriter() {
+		given(meetingDemandCommentProfileRepository.findByMeetingDemandIdAndUserId(MEETING_DEMAND_ID, WRITER_ID))
+			.willReturn(Optional.empty());
+		given(meetingDemandRepository.findByIdOrThrow(MEETING_DEMAND_ID)).willReturn(meetingDemand);
+		given(meetingDemandCommentProfileRepository.saveAndFlush(any(MeetingDemandCommentProfile.class)))
+			.willAnswer(invocation -> invocation.getArgument(0));
+
+		MeetingDemandCommentProfile profile = meetingDemandCommentProfileFactory.findOrCreate(
+			MEETING_DEMAND_ID, WRITER_ID);
+
+		ArgumentCaptor<MeetingDemandCommentProfile> captor =
+			ArgumentCaptor.forClass(MeetingDemandCommentProfile.class);
+		verify(meetingDemandCommentProfileRepository).saveAndFlush(captor.capture());
+		assertThat(profile).isSameAs(captor.getValue());
+		assertThat(profile.getMeetingDemandId()).isEqualTo(MEETING_DEMAND_ID);
+		assertThat(profile.getUserId()).isEqualTo(WRITER_ID);
+		assertThat(profile.getAnonymousNickname()).isEqualTo(MEETING_DEMAND_ANONYMOUS_NICKNAME);
+		assertThat(profile.getAnonymousImageNumber()).isEqualTo(MEETING_DEMAND_ANONYMOUS_IMAGE_NUMBER);
+	}
+}

--- a/main/src/test/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentResponseFactoryTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meetingdemandcomment/v2/service/MeetingDemandCommentResponseFactoryTest.java
@@ -1,0 +1,130 @@
+package org.sopt.makers.crew.main.meetingdemandcomment.v2.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingFrequency;
+import org.sopt.makers.crew.main.entity.meeting.enums.MeetingType;
+import org.sopt.makers.crew.main.entity.meeting.vo.MeetingJoinInfo;
+import org.sopt.makers.crew.main.entity.meetingdemand.MeetingDemand;
+import org.sopt.makers.crew.main.entity.meetingdemand.vo.MeetingDemandAnonymousProfile;
+import org.sopt.makers.crew.main.entity.meetingdemandcomment.MeetingDemandComment;
+import org.sopt.makers.crew.main.entity.meetingdemandcomment.MeetingDemandCommentLikeRepository;
+import org.sopt.makers.crew.main.entity.meetingdemandcomment.MeetingDemandCommentProfile;
+import org.sopt.makers.crew.main.entity.tag.enums.MeetingKeywordType;
+import org.sopt.makers.crew.main.entity.user.User;
+import org.sopt.makers.crew.main.entity.user.UserFixture;
+import org.sopt.makers.crew.main.entity.user.UserRepository;
+import org.sopt.makers.crew.main.external.playground.service.MemberBlockService;
+import org.sopt.makers.crew.main.meetingdemandcomment.v2.dto.response.MeetingDemandCommentDto;
+import org.sopt.makers.crew.main.meetingdemandcomment.v2.dto.response.MeetingDemandReplyDto;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingDemandCommentResponseFactoryTest {
+
+	private static final int MEETING_DEMAND_ID = 10;
+	private static final int COMMENT_ID = 100;
+	private static final int REPLY_COMMENT_ID = 101;
+	private static final int WRITER_ID = 1;
+	private static final int REQUEST_USER_ID = 2;
+	private static final String ANONYMOUS_NICKNAME = "성실한 토마토";
+	private static final int ANONYMOUS_IMAGE_NUMBER = 4;
+
+	@Mock
+	private MeetingDemandCommentLikeRepository meetingDemandCommentLikeRepository;
+
+	@Mock
+	private MeetingDemandCommentProfileFactory meetingDemandCommentProfileFactory;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private MemberBlockService memberBlockService;
+
+	private MeetingDemandCommentResponseFactory meetingDemandCommentResponseFactory;
+
+	private User writer;
+	private User requestUser;
+	private MeetingDemand meetingDemand;
+
+	@BeforeEach
+	void setUp() {
+		meetingDemandCommentResponseFactory = new MeetingDemandCommentResponseFactory(
+			meetingDemandCommentLikeRepository,
+			meetingDemandCommentProfileFactory,
+			userRepository,
+			memberBlockService
+		);
+
+		writer = UserFixture.createUser(WRITER_ID, "서버", 36);
+		requestUser = UserFixture.createUser(REQUEST_USER_ID, "기획", 36);
+		meetingDemand = MeetingDemand.builder()
+			.user(writer)
+			.shortIntro("러닝 모임 열어주세요")
+			.expectation("같이 꾸준히 달릴 수 있는 모임이 있으면 좋겠어요.")
+			.meetingKeywordTypes(List.of(MeetingKeywordType.EXERCISE, MeetingKeywordType.NETWORKING))
+			.joinInfo(new MeetingJoinInfo(MeetingType.ONLINE, MeetingFrequency.STEADY))
+			.build();
+		setField(meetingDemand, "id", MEETING_DEMAND_ID);
+	}
+
+	@Test
+	@DisplayName("같은 작성자의 댓글과 대댓글은 같은 익명 프로필로 조회된다.")
+	void createComments_usesSameAnonymousProfileForCommentAndReplyBySameWriter() {
+		MeetingDemandComment parentComment = createComment(COMMENT_ID, "부모 댓글", 0, 0, writer, COMMENT_ID);
+		MeetingDemandComment replyComment = createComment(REPLY_COMMENT_ID, "대댓글", 1, 1, writer, COMMENT_ID);
+		MeetingDemandCommentProfile profile = MeetingDemandCommentProfile.builder()
+			.meetingDemandId(MEETING_DEMAND_ID)
+			.userId(WRITER_ID)
+			.anonymousNickname(ANONYMOUS_NICKNAME)
+			.anonymousImageNumber(ANONYMOUS_IMAGE_NUMBER)
+			.build();
+		List<MeetingDemandComment> visibleComments = List.of(parentComment, replyComment);
+		given(meetingDemandCommentLikeRepository.findAllByMeetingDemandCommentIdInAndUserId(
+			List.of(COMMENT_ID, REPLY_COMMENT_ID), REQUEST_USER_ID)).willReturn(List.of());
+		given(meetingDemandCommentProfileFactory.createProfileMap(MEETING_DEMAND_ID, visibleComments))
+			.willReturn(Map.of(WRITER_ID, profile));
+		given(userRepository.findByIdOrThrow(REQUEST_USER_ID)).willReturn(requestUser);
+		given(memberBlockService.getBlockedUsers((long)REQUEST_USER_ID, List.of((long)WRITER_ID)))
+			.willReturn(Map.of((long)WRITER_ID, false));
+
+		List<MeetingDemandCommentDto> comments = meetingDemandCommentResponseFactory.createComments(
+			MEETING_DEMAND_ID, List.of(parentComment), List.of(replyComment), REQUEST_USER_ID);
+
+		MeetingDemandCommentDto comment = comments.get(0);
+		MeetingDemandReplyDto reply = comment.getReplies().get(0);
+		assertThat(comment.getWriter().getAnonymousNickname()).isEqualTo(ANONYMOUS_NICKNAME);
+		assertThat(reply.getWriter().getAnonymousNickname()).isEqualTo(comment.getWriter().getAnonymousNickname());
+		assertThat(reply.getWriter().getAnonymousImageUrl()).isEqualTo(comment.getWriter().getAnonymousImageUrl());
+		assertThat(comment.getWriter().getAnonymousImageUrl()).isEqualTo(
+			MeetingDemandAnonymousProfile.getImageUrl(ANONYMOUS_IMAGE_NUMBER));
+	}
+
+	private MeetingDemandComment createComment(Integer id, String contents, int depth, int order, User user,
+		Integer parentId) {
+		MeetingDemandComment comment = MeetingDemandComment.builder()
+			.contents(contents)
+			.depth(depth)
+			.order(order)
+			.user(user)
+			.meetingDemand(meetingDemand)
+			.likeCount(0)
+			.parentId(parentId)
+			.build();
+		setField(comment, "id", id);
+		setField(comment, "userId", user.getId());
+		setField(comment, "meetingDemandId", meetingDemand.getId());
+		return comment;
+	}
+}


### PR DESCRIPTION
## 👩‍💻 Contents

모임 수요를 작성한 사람이 댓글,대댓글 작성시 익명 프로필 일관성을 보장합니다

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?