### PR TITLE
fix: 답장피드 남기기와 답장 피드 카드 보기 액션이 동일한 이슈

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/entity/post/MumuPostWriteHistory.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/post/MumuPostWriteHistory.java
@@ -1,0 +1,44 @@
+package org.sopt.makers.crew.main.entity.post;
+
+import java.time.LocalDate;
+
+import org.sopt.makers.crew.main.entity.common.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "mumu_post_write_history",
+	uniqueConstraints = @UniqueConstraint(
+		name = "UQ_mumu_post_write_history_user_written_date",
+		columnNames = {"userId", "writtenDate"}
+	))
+public class MumuPostWriteHistory extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
+	@Column(nullable = false)
+	private Integer userId;
+
+	@Column(nullable = false)
+	private LocalDate writtenDate;
+
+	@Builder
+	public MumuPostWriteHistory(Integer userId, LocalDate writtenDate) {
+		this.userId = userId;
+		this.writtenDate = writtenDate;
+	}
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/post/MumuPostWriteHistoryRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/post/MumuPostWriteHistoryRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.makers.crew.main.entity.post;
+
+import java.time.LocalDate;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MumuPostWriteHistoryRepository extends JpaRepository<MumuPostWriteHistory, Integer> {
+
+	boolean existsByUserIdAndWrittenDate(Integer userId, LocalDate writtenDate);
+}

--- a/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostRepository.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/entity/post/PostRepository.java
@@ -2,7 +2,6 @@ package org.sopt.makers.crew.main.entity.post;
 
 import static org.sopt.makers.crew.main.global.exception.ErrorStatus.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.sopt.makers.crew.main.global.exception.BadRequestException;
@@ -29,9 +28,4 @@ public interface PostRepository extends JpaRepository<Post, Integer>, PostSearch
 	@Query("DELETE FROM Post p WHERE p.meetingId = :meetingId")
 	void deleteAllByMeetingIdQuery(Integer meetingId);
 
-	boolean existsByUserIdAndCategoryAndCreatedDateGreaterThanEqual(
-		Integer userId,
-		PostCategory category,
-		LocalDateTime createdDate
-	);
 }

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/MumuPostHomeResponseDto.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/dto/response/MumuPostHomeResponseDto.java
@@ -23,6 +23,10 @@ public class MumuPostHomeResponseDto {
 	@NotNull
 	private Boolean hasWrittenTodayMumuPost;
 
+	@Schema(description = "내 모임 피드 카드 노출 여부", example = "true")
+	@NotNull
+	private Boolean hasMumuPostHomeFeed;
+
 	@Schema(description = "오늘의 무무 멘트", example = "true")
 	@NotNull
 	private String mumuText;
@@ -35,6 +39,7 @@ public class MumuPostHomeResponseDto {
 		return MumuPostHomeResponseDto.builder()
 			.isEmptyAppliedMeeting(true)
 			.hasWrittenTodayMumuPost(false)
+			.hasMumuPostHomeFeed(false)
 			.mumuText(mumuText)
 			.mumuPostHomeDtos(List.of())
 			.build();
@@ -46,6 +51,7 @@ public class MumuPostHomeResponseDto {
 			.builder()
 			.isEmptyAppliedMeeting(false)
 			.hasWrittenTodayMumuPost(false)
+			.hasMumuPostHomeFeed(!mumuPostHomeDtos.isEmpty())
 			.mumuText(mumuText)
 			.mumuPostHomeDtos(mumuPostHomeDtos)
 			.build();
@@ -55,6 +61,18 @@ public class MumuPostHomeResponseDto {
 		return MumuPostHomeResponseDto.builder()
 			.isEmptyAppliedMeeting(false)
 			.hasWrittenTodayMumuPost(true)
+			.hasMumuPostHomeFeed(!mumuPostHomeDtos.isEmpty())
+			.mumuText(mumuText)
+			.mumuPostHomeDtos(mumuPostHomeDtos)
+			.build();
+	}
+
+	public static MumuPostHomeResponseDto of(Boolean isEmptyAppliedMeeting, Boolean hasWrittenTodayMumuPost,
+		List<MumuPostHomeDto> mumuPostHomeDtos, String mumuText) {
+		return MumuPostHomeResponseDto.builder()
+			.isEmptyAppliedMeeting(isEmptyAppliedMeeting)
+			.hasWrittenTodayMumuPost(hasWrittenTodayMumuPost)
+			.hasMumuPostHomeFeed(!mumuPostHomeDtos.isEmpty())
 			.mumuText(mumuText)
 			.mumuPostHomeDtos(mumuPostHomeDtos)
 			.build();

--- a/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceImpl.java
@@ -21,6 +21,8 @@ import org.sopt.makers.crew.main.entity.meeting.CoLeaderRepository;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.MeetingRepository;
 import org.sopt.makers.crew.main.entity.post.MumuTextResolver;
+import org.sopt.makers.crew.main.entity.post.MumuPostWriteHistory;
+import org.sopt.makers.crew.main.entity.post.MumuPostWriteHistoryRepository;
 import org.sopt.makers.crew.main.entity.post.Post;
 import org.sopt.makers.crew.main.entity.post.PostCategory;
 import org.sopt.makers.crew.main.entity.post.PostRepository;
@@ -75,6 +77,7 @@ public class PostV2ServiceImpl implements PostV2Service {
 	private final LikeRepository likeRepository;
 	private final ReportRepository reportRepository;
 	private final CoLeaderRepository coLeaderRepository;
+	private final MumuPostWriteHistoryRepository mumuPostWriteHistoryRepository;
 
 	private final PushNotificationService pushNotificationService;
 	private final MemberBlockService memberBlockService;
@@ -109,17 +112,20 @@ public class PostV2ServiceImpl implements PostV2Service {
 			throw new ForbiddenException(FORBIDDEN_EXCEPTION.getErrorCode());
 		}
 
+		PostCategory postCategory = Objects.isNull(requestBody.getPostCategory()) ? PostCategory.NORMAL
+			: requestBody.getPostCategory();
+
 		Post post = Post.builder()
 			.title(requestBody.getTitle())
 			.user(user)
 			.contents(requestBody.getContents())
 			.images(requestBody.getImages())
 			.meeting(meeting)
-			.category(
-				Objects.isNull(requestBody.getPostCategory()) ? PostCategory.NORMAL : requestBody.getPostCategory())
+			.category(postCategory)
 			.build();
 
 		Post savedPost = postRepository.save(post);
+		saveMumuPostWriteHistoryIfNeeded(userId, postCategory);
 
 		List<String> userIdList = applyRepository.findAllByMeetingIdAndStatus(meeting.getId(), EnApplyStatus.APPROVE)
 			.stream()
@@ -338,27 +344,40 @@ public class PostV2ServiceImpl implements PostV2Service {
 
 		String text = extractMumuText();
 
+		boolean hasWrittenTodayMumuPost = mumuPostWriteHistoryRepository.existsByUserIdAndWrittenDate(userId,
+			LocalDate.now());
+
 		List<Integer> relatedMeetingIds = userRelatedMeetingExtractor.extractMeetingIdsByUserId(userId);
 
 		if (relatedMeetingIds.isEmpty()) {
-			return MumuPostHomeResponseDto.emptyAppliedMeeting(text);
+			return MumuPostHomeResponseDto.of(true, hasWrittenTodayMumuPost, List.of(), text);
 		}
-
-		boolean existedTodayMumuPost = postRepository.existsByUserIdAndCategoryAndCreatedDateGreaterThanEqual(userId,
-			PostCategory.MUMU, LocalDate.now().atStartOfDay());
 
 		List<MumuPostHomeDto> findPostsByMeetingIdsExceptSelf = postRepository
 			.findAllByMeetingIdInAndUserIdNotOrderByCreatedDateDesc(relatedMeetingIds, userId);
 
-		if (!existedTodayMumuPost) {
-			return MumuPostHomeResponseDto.notWrittenTodayMumuPost(findPostsByMeetingIdsExceptSelf, text);
-		}
-
-		return MumuPostHomeResponseDto.from(findPostsByMeetingIdsExceptSelf, text);
+		return MumuPostHomeResponseDto.of(false, hasWrittenTodayMumuPost, findPostsByMeetingIdsExceptSelf, text);
 	}
 
 	public String extractMumuText() {
 		return mumuTextResolver.resolveMumuText(LocalDateTime.now()).getText();
+	}
+
+	private void saveMumuPostWriteHistoryIfNeeded(Integer userId, PostCategory postCategory) {
+		if (postCategory != PostCategory.MUMU) {
+			return;
+		}
+
+		LocalDate today = LocalDate.now();
+		if (mumuPostWriteHistoryRepository.existsByUserIdAndWrittenDate(userId, today)) {
+			return;
+		}
+
+		MumuPostWriteHistory history = MumuPostWriteHistory.builder()
+			.userId(userId)
+			.writtenDate(today)
+			.build();
+		mumuPostWriteHistoryRepository.save(history);
 	}
 
 	private PostDetailResponseDto toPostDetailResponseDto(PostDetailResponseDto postDetail,

--- a/main/src/main/resources/schema.sql
+++ b/main/src/main/resources/schema.sql
@@ -4,6 +4,7 @@ drop table if exists "comment" cascade;
 drop table if exists "like" cascade;
 drop table if exists "tag" cascade;
 drop table if exists "flash" cascade;
+drop table if exists "mumu_post_write_history" cascade;
 drop table if exists "post" cascade;
 drop table if exists "meeting_demand_comment_like" cascade;
 drop table if exists "meeting_demand_comment_profile" cascade;
@@ -371,6 +372,24 @@ create table if not exists mumu_text
     "createdTimestamp" timestamp default CURRENT_TIMESTAMP,
     "modifiedTimestamp" timestamp default CURRENT_TIMESTAMP
 );
+
+create table if not exists mumu_post_write_history
+(
+    id                  serial
+    primary key,
+    "userId"            integer not null
+    constraint fk_mumu_post_write_history_user
+    references "user"
+    on delete cascade,
+    "writtenDate"       date    not null,
+    "createdTimestamp"  timestamp default CURRENT_TIMESTAMP,
+    "modifiedTimestamp" timestamp default CURRENT_TIMESTAMP,
+    constraint "UQ_mumu_post_write_history_user_written_date"
+    unique ("userId", "writtenDate")
+);
+
+create index if not exists "mumu_post_write_history_user_written_date_index"
+    on mumu_post_write_history ("userId", "writtenDate");
 
 create table if not exists comment
 (

--- a/main/src/test/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceTest.java
@@ -306,7 +306,7 @@ public class PostV2ServiceTest {
 		}
 
 		@Test
-		@DisplayName("오늘 무무 피드 작성 후 삭제해도 작성 여부는 유지된다")
+		@DisplayName("오늘 무무 피드 작성 후 삭제해도 작성 여부는 유지")
 		void 오늘_무무_피드_작성_후_삭제한_경우() {
 			Integer userId = 1;
 

--- a/main/src/test/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/post/v2/service/PostV2ServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.List;
@@ -24,10 +25,10 @@ import org.sopt.makers.crew.main.entity.like.LikeRepository;
 import org.sopt.makers.crew.main.entity.meeting.Meeting;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingCategory;
 import org.sopt.makers.crew.main.entity.meeting.enums.MeetingJoinablePart;
+import org.sopt.makers.crew.main.entity.post.MumuPostWriteHistoryRepository;
 import org.sopt.makers.crew.main.entity.post.MumuText;
 import org.sopt.makers.crew.main.entity.post.MumuTextResolver;
 import org.sopt.makers.crew.main.entity.post.Post;
-import org.sopt.makers.crew.main.entity.post.PostCategory;
 import org.sopt.makers.crew.main.entity.post.PostRepository;
 import org.sopt.makers.crew.main.entity.report.Report;
 import org.sopt.makers.crew.main.entity.report.ReportRepository;
@@ -57,6 +58,8 @@ public class PostV2ServiceTest {
 	private LikeRepository likeRepository;
 	@Mock
 	private ApplyRepository applyRepository;
+	@Mock
+	private MumuPostWriteHistoryRepository mumuPostWriteHistoryRepository;
 	@Mock
 	private MumuTextResolver mumuTextResolver;
 	@Mock
@@ -225,11 +228,12 @@ public class PostV2ServiceTest {
 			MumuPostHomeResponseDto mumuPostHomeResponseDto = postV2Service.retrieveMumuHomeInfo(userId);
 
 			//then
-			verify(postRepository, never()).existsByUserIdAndCategoryAndCreatedDateGreaterThanEqual(eq(userId), eq(PostCategory.MUMU), any(LocalDateTime.class));
+			verify(postRepository, never()).findAllByMeetingIdInAndUserIdNotOrderByCreatedDateDesc(anyList(), eq(userId));
 			Assertions.assertThat(mumuPostHomeResponseDto).isNotNull();
 			Assertions.assertThat(mumuPostHomeResponseDto.getMumuText()).isEqualTo("무무");
 			Assertions.assertThat(mumuPostHomeResponseDto.getIsEmptyAppliedMeeting()).isTrue();
 			Assertions.assertThat(mumuPostHomeResponseDto.getHasWrittenTodayMumuPost()).isFalse();
+			Assertions.assertThat(mumuPostHomeResponseDto.getHasMumuPostHomeFeed()).isFalse();
 		}
 
 		/**
@@ -247,7 +251,8 @@ public class PostV2ServiceTest {
 			//given
 			when(mumuTextResolver.resolveMumuText(any(LocalDateTime.class))).thenReturn(testMumuTextData("무무"));
 			when(userRelatedMeetingExtractor.extractMeetingIdsByUserId(userId)).thenReturn(List.of(100));
-			when(postRepository.existsByUserIdAndCategoryAndCreatedDateGreaterThanEqual(eq(userId), eq(PostCategory.MUMU), any(LocalDateTime.class))).thenReturn(false);
+			when(mumuPostWriteHistoryRepository.existsByUserIdAndWrittenDate(eq(userId), any(LocalDate.class)))
+				.thenReturn(false);
 			when(postRepository.findAllByMeetingIdInAndUserIdNotOrderByCreatedDateDesc(List.of(100), userId))
 				.thenReturn(List.of(latestPost, oldPost));
 
@@ -260,6 +265,7 @@ public class PostV2ServiceTest {
 			Assertions.assertThat(mumuPostHomeResponseDto.getMumuText()).isEqualTo("무무");
 			Assertions.assertThat(mumuPostHomeResponseDto.getIsEmptyAppliedMeeting()).isFalse();
 			Assertions.assertThat(mumuPostHomeResponseDto.getHasWrittenTodayMumuPost()).isFalse();
+			Assertions.assertThat(mumuPostHomeResponseDto.getHasMumuPostHomeFeed()).isTrue();
 			Assertions.assertThat(mumuPostHomeResponseDto.getMumuPostHomeDtos())
 				.extracting("postId")
 				.containsExactly(2, 1);
@@ -280,7 +286,8 @@ public class PostV2ServiceTest {
 			//given
 			when(mumuTextResolver.resolveMumuText(any(LocalDateTime.class))).thenReturn(testMumuTextData("무무"));
 			when(userRelatedMeetingExtractor.extractMeetingIdsByUserId(userId)).thenReturn(List.of(100));
-			when(postRepository.existsByUserIdAndCategoryAndCreatedDateGreaterThanEqual(eq(userId), eq(PostCategory.MUMU), any(LocalDateTime.class))).thenReturn(true);
+			when(mumuPostWriteHistoryRepository.existsByUserIdAndWrittenDate(eq(userId), any(LocalDate.class)))
+				.thenReturn(true);
 			when(postRepository.findAllByMeetingIdInAndUserIdNotOrderByCreatedDateDesc(List.of(100), userId))
 				.thenReturn(List.of(latestPost, oldPost));
 
@@ -292,9 +299,32 @@ public class PostV2ServiceTest {
 			Assertions.assertThat(mumuPostHomeResponseDto.getMumuText()).isEqualTo("무무");
 			Assertions.assertThat(mumuPostHomeResponseDto.getIsEmptyAppliedMeeting()).isFalse();
 			Assertions.assertThat(mumuPostHomeResponseDto.getHasWrittenTodayMumuPost()).isTrue();
+			Assertions.assertThat(mumuPostHomeResponseDto.getHasMumuPostHomeFeed()).isTrue();
 			Assertions.assertThat(mumuPostHomeResponseDto.getMumuPostHomeDtos())
 				.extracting("postId")
 				.containsExactly(2, 1);
+		}
+
+		@Test
+		@DisplayName("오늘 무무 피드 작성 후 삭제해도 작성 여부는 유지된다")
+		void 오늘_무무_피드_작성_후_삭제한_경우() {
+			Integer userId = 1;
+
+			//given
+			when(mumuTextResolver.resolveMumuText(any(LocalDateTime.class))).thenReturn(testMumuTextData("무무"));
+			when(mumuPostWriteHistoryRepository.existsByUserIdAndWrittenDate(eq(userId), any(LocalDate.class)))
+				.thenReturn(true);
+			when(userRelatedMeetingExtractor.extractMeetingIdsByUserId(userId)).thenReturn(List.of(100));
+			when(postRepository.findAllByMeetingIdInAndUserIdNotOrderByCreatedDateDesc(List.of(100), userId))
+				.thenReturn(List.of());
+
+			//when
+			MumuPostHomeResponseDto mumuPostHomeResponseDto = postV2Service.retrieveMumuHomeInfo(userId);
+
+			//then
+			Assertions.assertThat(mumuPostHomeResponseDto.getHasWrittenTodayMumuPost()).isTrue();
+			Assertions.assertThat(mumuPostHomeResponseDto.getHasMumuPostHomeFeed()).isFalse();
+			Assertions.assertThat(mumuPostHomeResponseDto.getMumuPostHomeDtos()).isEmpty();
 		}
 
 	}


### PR DESCRIPTION
## 👩‍💻 Contents

<img width="670" height="344" alt="image" src="https://github.com/user-attachments/assets/64451dbb-786f-41e9-89fb-bbb997fda58c" />


내 모임 피드 카드 노출 여부를 hasMumuPostHomeFeed로 별도 응답하도록 수정했습니다

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?