### PR TITLE
fix: 기다려요 알림 텍스트 변경

### DIFF
--- a/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandNotificationSender.java
+++ b/main/src/main/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandNotificationSender.java
@@ -25,8 +25,8 @@ public class MeetingDemandNotificationSender {
 
 	private static final String MEETING_DEMAND_OPENED_TITLE = "기다리던 모임이 열렸어요";
 	private static final String MEETING_DEMAND_OPENED_CONTENT = "관심을 보였던 수요가 모임으로 개설됐어요.";
-	private static final String MEETING_DEMAND_WAIT_TITLE = "내가 만든 모임 수요를 기다리는 사람이 생겼어요";
-	private static final String MEETING_DEMAND_WAIT_CONTENT = "수요에 관심을 보인 멤버가 있어요.";
+	private static final String MEETING_DEMAND_WAIT_TITLE = "내가 제안한 모임을 기다려요!";
+	private static final String MEETING_DEMAND_WAIT_CONTENT = "내 제안에 관심을 보인 멤버가 있어요.";
 	private static final String MEETING_DETAIL_WEB_LINK_FORMAT = "%s/detail?id=%d";
 	private static final String MEETING_DEMAND_WEB_LINK_FORMAT = "%s/meeting-demand?id=%d";
 

--- a/main/src/test/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandNotificationSenderTest.java
+++ b/main/src/test/java/org/sopt/makers/crew/main/meetingdemand/v2/service/MeetingDemandNotificationSenderTest.java
@@ -136,8 +136,8 @@ class MeetingDemandNotificationSenderTest {
 
 		PushNotificationRequestDto request = captor.getValue();
 		assertThat(request.getUserIds()).containsExactly("1");
-		assertThat(request.getTitle()).isEqualTo("내가 만든 모임 수요를 기다리는 사람이 생겼어요");
-		assertThat(request.getContent()).isEqualTo("수요에 관심을 보인 멤버가 있어요.");
+		assertThat(request.getTitle()).isEqualTo("내가 제안한 모임을 기다려요!");
+		assertThat(request.getContent()).isEqualTo("내 제안에 관심을 보인 멤버가 있어요.");
 		assertThat(request.getWebLink()).isEqualTo("https://crew.test/meeting-demand?id=10");
 	}
 }


### PR DESCRIPTION
## 👩‍💻 Contents

아래와 같이 기다려요 알림 텍스트를 수정합니다

제목 - 내가 제안한 모임을 기다려요! 

본문 - 내 제안에 관심을 보인 멤버가 있어요.

## ✅ 점검사항

- [ ] docker-compose.yml 파일에 마이그레이션 한 API의 포워딩을 변경해줬나요?
- [ ] Spring Secret 값을 수정하거나 추가했다면 Github Secret에서 수정을 해줬나요?
- [ ] Nestjs Secret 값을 수정하거나 추가했다면 Docker-Compose.yml 파일 및 인스턴스 내부의 .env 파일을 수정했나요?